### PR TITLE
Matrix flexible mode location count restriction

### DIFF
--- a/openrouteservice/WebContent/WEB-INF/app.config.sample
+++ b/openrouteservice/WebContent/WEB-INF/app.config.sample
@@ -50,6 +50,9 @@
 				# Maximum dimension of the result matrix. In other words, the maximum possible length of a row or a column in the matrix.
 				# Default value is 100.
                                 maximum_locations: 100,
+                # Maximum dimension of the result matrix when using custom profiles that do not support Contraction Hierarchies. Usually everything
+                # that is not pure car or hgv profile. Default value is 25.
+                                maximum_locations_flexible: 25,
 				# Maximum allowed distance between the requested coordinate and a point on the nearest road. The value is measured in meters.
                                 maximum_search_radius: 5000,
 				# Maximum allowed number of visited nodes in shortest path computation. This threshold is applied only for Dijkstra algorithm. 

--- a/openrouteservice/src/main/java/heigit/ors/routing/RoutingProfilesCollection.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/RoutingProfilesCollection.java
@@ -134,6 +134,18 @@ public class RoutingProfilesCollection {
 		return rp;
 
 	}
+
+	/**
+	 	 * Check if the CH graph of the specified profile has been built.
+	 	 *
+	 	 * @param routePref				The chosen routing profile
+	 	 */
+
+	public boolean isCHProfileAvailable(int routePref) throws Exception {
+		int routePrefKey = getRoutePreferenceKey(routePref, true);
+		if (!m_routeProfiles.containsKey(routePrefKey)) return false;
+		return true;
+	}
 	
 	public RoutingProfile getRouteProfile(int routePref) throws Exception
 	{

--- a/openrouteservice/src/main/java/heigit/ors/services/mapmatching/requestprocessors/json/JsonMapMatchingRequestProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/mapmatching/requestprocessors/json/JsonMapMatchingRequestProcessor.java
@@ -52,8 +52,8 @@ public class JsonMapMatchingRequestProcessor extends AbstractHttpRequestProcesso
 		
 		if (req == null)
 			throw new StatusCodeException(StatusCode.BAD_REQUEST, MapMatchingErrorCodes.UNKNOWN, "MapMatchingRequest object is null.");
-		
-		if (MapMatchingServiceSettings.getMaximumLocations() > 0 && req.getCoordinates().length > MatrixServiceSettings.getMaximumLocations())
+
+		if (MapMatchingServiceSettings.getMaximumLocations() > 0 && req.getCoordinates().length > MatrixServiceSettings.getMaximumLocations(false))
 			throw new ParameterOutOfRangeException(MapMatchingErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getCoordinates().length), Integer.toString(MapMatchingServiceSettings.getMaximumLocations()));
 
 		

--- a/openrouteservice/src/main/java/heigit/ors/services/matrix/MatrixServiceSettings.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/matrix/MatrixServiceSettings.java
@@ -25,6 +25,7 @@ import heigit.ors.config.AppConfig;
 public class MatrixServiceSettings 
 {
 	private static int maximumLocations = 100;
+	private static int maximumLocationsFlexible = 25;
 	private static int maximumVisitedNodes = 100000;
 	private static double maximumSearchRadius = 2000;
 	private static boolean allowResolveLocations = true;
@@ -39,6 +40,9 @@ public class MatrixServiceSettings
 		value = AppConfig.Global().getServiceParameter("matrix", "maximum_locations");
 		if (value != null)
 			maximumLocations = Math.max(1, Integer.parseInt(value));
+		value = AppConfig.Global().getServiceParameter("matrix", "maximum_locations_flexible");
+		if (value != null)
+			maximumLocationsFlexible = Math.max(1, Integer.parseInt(value));
 		value = AppConfig.Global().getServiceParameter("matrix", "maximum_search_radius");
 		if (value != null)
 			maximumSearchRadius = Math.max(1, Double.parseDouble(value));
@@ -65,8 +69,8 @@ public class MatrixServiceSettings
 		return maximumVisitedNodes;
 	}
 	
-	public static int getMaximumLocations() {
-		return maximumLocations;
+	public static int getMaximumLocations(boolean flexible) {
+		return (flexible? maximumLocationsFlexible : maximumLocations);
 	}
 	
 	public static double getMaximumSearchRadius() {

--- a/openrouteservice/src/main/java/heigit/ors/services/matrix/requestprocessors/json/JsonMatrixRequestProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/matrix/requestprocessors/json/JsonMatrixRequestProcessor.java
@@ -23,6 +23,7 @@ package heigit.ors.services.matrix.requestprocessors.json;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import heigit.ors.routing.RoutingProfilesCollection;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -74,9 +75,9 @@ public class JsonMatrixRequestProcessor extends AbstractHttpRequestProcessor
 
 		if (req == null)
 			throw new StatusCodeException(StatusCode.BAD_REQUEST, MatrixErrorCodes.UNKNOWN, "MatrixRequest object is null.");
-		
-		if (MatrixServiceSettings.getMaximumLocations() > 0 && req.getTotalNumberOfLocations() > MatrixServiceSettings.getMaximumLocations())
-			throw new ParameterOutOfRangeException(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getTotalNumberOfLocations()), Integer.toString(MatrixServiceSettings.getMaximumLocations()));
+		boolean flexibleMode = req.getFlexibleMode() ? true : !RoutingProfileManager.getInstance().getProfiles().isCHProfileAvailable(req.getProfileType());
+		if (MatrixServiceSettings.getMaximumLocations(flexibleMode) > 0 && req.getTotalNumberOfLocations() > MatrixServiceSettings.getMaximumLocations(flexibleMode))
+			throw new ParameterOutOfRangeException(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getTotalNumberOfLocations()), Integer.toString(MatrixServiceSettings.getMaximumLocations(flexibleMode)));
 		
 		MatrixResult mtxResult = RoutingProfileManager.getInstance().computeMatrix(req);
 		


### PR DESCRIPTION
Restricts the matrix requests locations to a diffferent (lower) value if not using profile driving-car or hgv (i.e. if there is no CH profile for the requested profile).
The additional parameter still needs to be added to the app.config in
``` ors -> services -> matrix ```
after the entry ```maximum_locations``` and is called ```maximum_locations_flexible: 25 ``` @TimMcCauley please 😄 
Fallback to value of 25 if the parameter is not set is hardcoded.
Resolves #94 