### PR TITLE
Fix: Properties.load(new FileInputStream(...)) leaks a FileInputStream

### DIFF
--- a/openrouteservice/src/main/java/heigit/ors/logging/LoggingUtility.java
+++ b/openrouteservice/src/main/java/heigit/ors/logging/LoggingUtility.java
@@ -75,7 +75,9 @@ public class LoggingUtility {
 		}
 
 		Properties lprops = new Properties();
-		lprops.load(new FileInputStream(configFile));
+		FileInputStream in = new FileInputStream(configFile);
+		lprops.load(in);
+		in.close();
 		LogManager.resetConfiguration();
 		
 		if (lprops.getProperty("log4j.appender.orslogfile.File") == null)

--- a/openrouteservice/src/main/java/heigit/ors/logging/LoggingUtility.java
+++ b/openrouteservice/src/main/java/heigit/ors/logging/LoggingUtility.java
@@ -75,9 +75,9 @@ public class LoggingUtility {
 		}
 
 		Properties lprops = new Properties();
-		FileInputStream in = new FileInputStream(configFile);
-		lprops.load(in);
-		in.close();
+		try (FileInputStream in = new FileInputStream(configFile)) {;
+		  lprops.load(in);
+		}
 		LogManager.resetConfiguration();
 		
 		if (lprops.getProperty("log4j.appender.orslogfile.File") == null)


### PR DESCRIPTION
According to the Properties' JavaDoc, load does not close the stream
when it is done with reading. Hence, we must close it ourselves.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading
- [ ] 3. I have documented my code using JDocs tags
- [x] 4. I have removed unecessary commented out code, imports and System.out.println statements
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass
- [x] 6. I have created API tests for any new functionality exposed to the API
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below) 
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue)
- [x] 10. For new features involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors)
- [x] 11. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes # .

### Information about the changes
- Key functionality added: none
- Reason for change: fix bug

### Required changes to app.config (if applicable)
- 

