### PR TITLE
Add osmids to wheelchair extra info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed locations code as this will be handled by openpoiservice in the future (Issue #120)
 - Removed Geocoding code as this will be handled by the geocoder service rather than within ORS
 - Added smoothing option for isochrones (Issue #137)
+- Added ExtraInfo storage for osm way id so that this information can be stored (and accessed) agianst the edges (Issue #217)
 
 ### Fixed
 - Fixed problem with avoid polygons excluding ways that should have been accepted (Issue #95)

--- a/openrouteservice-api-tests/conf/app.config.test
+++ b/openrouteservice-api-tests/conf/app.config.test
@@ -269,7 +269,8 @@
                                     KerbsOnCrossings: "true"
                                 },
                                 WaySurfaceType: { },
-                                WayCategory: { }
+                                WayCategory: { },
+                                OsmId: { }
                             }
                         }
                     }

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
@@ -1337,4 +1337,21 @@ public class ResultTest extends ServiceTest {
 				.body("routes[0].summary.duration", is(129.2f))
 				.statusCode(200);
 	}
+
+	@Test
+    public void testOsmIdExtras() {
+        given()
+                .param("coordinates", "8.676730,49.421513|8.678545,49.421117")
+                .param("preference", "shortest")
+                .param("profile", "wheelchair")
+                .param("extra_info", "osmid")
+                .when().log().ifValidationFails()
+                .get(getEndPointName())
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].containsKey('extras')", is(true))
+                .body("routes[0].extras.containsKey('osmid')", is(true))
+                .statusCode(200);
+    }
 }

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
@@ -1351,7 +1351,7 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('extras')", is(true))
-                .body("routes[0].extras.containsKey('osmid')", is(true))
+                .body("routes[0].extras.containsKey('osmId')", is(true))
                 .statusCode(200);
     }
 }

--- a/openrouteservice/WebContent/WEB-INF/app.config.sample
+++ b/openrouteservice/WebContent/WEB-INF/app.config.sample
@@ -349,7 +349,8 @@
                                     # The KerbsOnCrossings option tells the builder whether kerb heights should only be attached to ways
                                     # marked as crossings ("true"), or to any way they fall on ("false")
                                     KerbsOnCrossings: "true"
-                                }
+                                },
+                                OsmId: {}   # Allow the returning of som ids of ways in extra info
                             }
                         }
                     }

--- a/openrouteservice/src/main/java/heigit/ors/routing/RouteExtraInfoFlag.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/RouteExtraInfoFlag.java
@@ -33,6 +33,7 @@ public class RouteExtraInfoFlag {
     public static final int AvgSpeed = 128;
     public static final int Tollways = 256;
     public static final int TrailDifficulty = 512;
+    public static final int OsmId = 1024;
 
     public static boolean isSet(int extraInfo, int value) {
         return (extraInfo & value) == value;
@@ -77,6 +78,9 @@ public class RouteExtraInfoFlag {
                 case "traildifficulty":
                 	res |= TrailDifficulty;
                 	break;
+                case "osmid":
+                    res |= OsmId;
+                    break;
             }
         }
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/RouteSegmentItem.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/RouteSegmentItem.java
@@ -23,10 +23,10 @@ package heigit.ors.routing;
 public class RouteSegmentItem {
 	private int _from;
 	private int _to;
-	private int _value;
+	private long _value;
 	private double _distance;
 
-	public RouteSegmentItem(int from, int to, int value, double distance)
+	public RouteSegmentItem(int from, int to, long value, double distance)
 	{
 		_from = from;
 		_to = to;
@@ -50,7 +50,7 @@ public class RouteSegmentItem {
 		_to = to;
 	}
 
-	public int getValue() {
+	public long getValue() {
 		return _value;
 	}
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
@@ -82,6 +82,11 @@ public class OsmIdGraphStorage implements GraphExtension {
         orsEdges.ensureCapacity(((long) edgeIndex + 1) * edgeEntryBytes);
     }
 
+    /**
+     * Set the osm id of an edge to the spcified value.
+     * @param edgeId    The internal id of the edge in the graph
+     * @param osmId     The osm idto be assigned ot the edge
+     */
     public void setEdgeValue(int edgeId, long osmId) {
         edgesCount++;
         ensureEdgesIndex(edgeId);
@@ -92,6 +97,11 @@ public class OsmIdGraphStorage implements GraphExtension {
         orsEdges.setBytes(edgePointer + EF_OSMID, byteValues, 8);
     }
 
+    /**
+     * Get the OSM id of the edge specified
+     * @param edgeId    The internal graph id of the edge that the OSM way ID is required for
+     * @return          The OSM ID that was stored for the edge (normally the OSM ID of the way the edge was created from)
+     */
     public long getEdgeValue(int edgeId) {
         byte[] buffer = new byte[8];
         long edgePointer = (long) edgeId * edgeEntryBytes;

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
@@ -3,8 +3,6 @@ package heigit.ors.routing.graphhopper.extensions.storages;
 import com.graphhopper.storage.*;
 import heigit.ors.routing.graphhopper.extensions.util.EncodeUtils;
 
-import java.nio.ByteBuffer;
-
 public class OsmIdGraphStorage implements GraphExtension {
     /* pointer for no entry */
     protected final int NO_ENTRY = -1;
@@ -19,9 +17,9 @@ public class OsmIdGraphStorage implements GraphExtension {
 
     public OsmIdGraphStorage() {
         EF_OSMID = 0;
-        edgeEntryBytes = edgeEntryIndex + 8;
+        edgeEntryBytes = edgeEntryIndex + 4;
         edgesCount = 0;
-        byteValues = new byte[8];
+        byteValues = new byte[4];
     }
 
     public void init(Graph graph, Directory dir) {
@@ -47,7 +45,7 @@ public class OsmIdGraphStorage implements GraphExtension {
     }
 
     public GraphExtension create(long initBytes) {
-        orsEdges.create((long) initBytes * edgeEntryBytes);
+        orsEdges.create(initBytes * edgeEntryBytes);
         return this;
     }
 
@@ -93,8 +91,12 @@ public class OsmIdGraphStorage implements GraphExtension {
 
         // add entry
         long edgePointer = (long) edgeId * edgeEntryBytes;
-        byteValues = EncodeUtils.longToByteArray(osmId);
-        orsEdges.setBytes(edgePointer + EF_OSMID, byteValues, 8);
+        byte[] tempBytes = EncodeUtils.longToByteArray(osmId);
+        byteValues[0] = tempBytes[4];
+        byteValues[1] = tempBytes[5];
+        byteValues[2] = tempBytes[6];
+        byteValues[3] = tempBytes[7];
+        orsEdges.setBytes(edgePointer + EF_OSMID, byteValues, 4);
     }
 
     /**
@@ -103,9 +105,9 @@ public class OsmIdGraphStorage implements GraphExtension {
      * @return          The OSM ID that was stored for the edge (normally the OSM ID of the way the edge was created from)
      */
     public long getEdgeValue(int edgeId) {
-        byte[] buffer = new byte[8];
+        byte[] buffer = new byte[4];
         long edgePointer = (long) edgeId * edgeEntryBytes;
-        orsEdges.getBytes(edgePointer + EF_OSMID, buffer, 8);
+        orsEdges.getBytes(edgePointer + EF_OSMID, buffer, 4);
 
         return EncodeUtils.byteArrayToLong(buffer);
     }

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
@@ -1,0 +1,139 @@
+package heigit.ors.routing.graphhopper.extensions.storages;
+
+import com.graphhopper.storage.*;
+import heigit.ors.routing.graphhopper.extensions.util.EncodeUtils;
+
+import java.nio.ByteBuffer;
+
+public class OsmIdGraphStorage implements GraphExtension {
+    /* pointer for no entry */
+    protected final int NO_ENTRY = -1;
+    protected final int EF_OSMID;
+
+    protected DataAccess orsEdges;
+    protected int edgeEntryIndex = 0;
+    protected int edgeEntryBytes;
+    protected int edgesCount; // number of edges with custom values
+
+    private byte[] byteValues;
+
+    public OsmIdGraphStorage() {
+        EF_OSMID = 0;
+        edgeEntryBytes = edgeEntryIndex + 8;
+        edgesCount = 0;
+        byteValues = new byte[8];
+    }
+
+    public void init(Graph graph, Directory dir) {
+        if (edgesCount > 0)
+            throw new AssertionError("The ORS storage must be initialized only once.");
+
+        this.orsEdges = dir.find("ext_osmids");
+    }
+
+    /**
+     * initializes the extended storage to be empty - required for testing purposes as the ext_storage aren't created
+     * at the time tests are run
+     */
+    public void init() {
+        if(edgesCount > 0)
+            throw new AssertionError("The ORS storage must be initialized only once.");
+        Directory d = new RAMDirectory();
+        this.orsEdges = d.find("");
+    }
+
+    public void setSegmentSize(int bytes) {
+        orsEdges.setSegmentSize(bytes);
+    }
+
+    public GraphExtension create(long initBytes) {
+        orsEdges.create((long) initBytes * edgeEntryBytes);
+        return this;
+    }
+
+    public void flush() {
+        orsEdges.setHeader(0, edgeEntryBytes);
+        orsEdges.setHeader(1 * 4, edgesCount);
+        orsEdges.flush();
+    }
+
+    public void close() {
+        orsEdges.close();
+    }
+
+    public long getCapacity() {
+        return orsEdges.getCapacity();
+    }
+
+    public int entries() {
+        return edgesCount;
+    }
+
+    public boolean loadExisting() {
+        if (!orsEdges.loadExisting())
+            throw new IllegalStateException("Unable to load storage 'ext_osmids'. corrupt file or directory? " );
+
+        edgeEntryBytes = orsEdges.getHeader(0);
+        edgesCount = orsEdges.getHeader(4);
+        return true;
+    }
+
+    void ensureEdgesIndex(int edgeIndex) {
+        orsEdges.ensureCapacity(((long) edgeIndex + 1) * edgeEntryBytes);
+    }
+
+    public void setEdgeValue(int edgeId, long osmId) {
+        edgesCount++;
+        ensureEdgesIndex(edgeId);
+
+        // add entry
+        long edgePointer = (long) edgeId * edgeEntryBytes;
+        byteValues = EncodeUtils.longToByteArray(osmId);
+        orsEdges.setBytes(edgePointer + EF_OSMID, byteValues, 8);
+    }
+
+    public long getEdgeValue(int edgeId) {
+        byte[] buffer = new byte[8];
+        long edgePointer = (long) edgeId * edgeEntryBytes;
+        orsEdges.getBytes(edgePointer + EF_OSMID, buffer, 8);
+
+        return EncodeUtils.byteArrayToLong(buffer);
+    }
+
+    public boolean isRequireNodeField() {
+        return false;
+    }
+
+    public boolean isRequireEdgeField() {
+        // we require the additional field in the graph to point to the first
+        // entry in the node table
+        return true;
+    }
+
+    public int getDefaultNodeFieldValue() {
+        return -1; //throw new UnsupportedOperationException("Not supported by this storage");
+    }
+
+    public int getDefaultEdgeFieldValue() {
+        return -1;
+    }
+
+    public GraphExtension copyTo(GraphExtension clonedStorage) {
+        if (!(clonedStorage instanceof OsmIdGraphStorage)) {
+            throw new IllegalStateException("the extended storage to clone must be the same");
+        }
+
+        OsmIdGraphStorage clonedTC = (OsmIdGraphStorage) clonedStorage;
+
+        orsEdges.copyTo(clonedTC.orsEdges);
+        clonedTC.edgesCount = edgesCount;
+
+        return clonedStorage;
+    }
+
+    @Override
+    public boolean isClosed() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+}

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/OsmIdGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/OsmIdGraphStorageBuilder.java
@@ -1,0 +1,32 @@
+package heigit.ors.routing.graphhopper.extensions.storages.builders;
+
+import com.graphhopper.GraphHopper;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.storage.GraphExtension;
+import com.graphhopper.util.EdgeIteratorState;
+import heigit.ors.routing.graphhopper.extensions.storages.OsmIdGraphStorage;
+
+public class OsmIdGraphStorageBuilder extends AbstractGraphStorageBuilder {
+    private OsmIdGraphStorage osmIdGraphStorage;
+
+    public GraphExtension init(GraphHopper graphhopper) throws Exception {
+        if (osmIdGraphStorage != null)
+            throw new Exception("GraphStorageBuilder has been already initialized.");
+
+        osmIdGraphStorage = new OsmIdGraphStorage();
+
+        return osmIdGraphStorage;
+    }
+
+    public void processWay(ReaderWay way) {
+    }
+
+    public void processEdge(ReaderWay way, EdgeIteratorState edge) {
+        osmIdGraphStorage.setEdgeValue(edge.getEdge(), way.getId());
+    }
+
+    @Override
+    public String getName() {
+        return "OsmId";
+    }
+}

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/OsmIdGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/OsmIdGraphStorageBuilder.java
@@ -21,6 +21,12 @@ public class OsmIdGraphStorageBuilder extends AbstractGraphStorageBuilder {
     public void processWay(ReaderWay way) {
     }
 
+    /**
+     * Process the graph edge - In the OSMId graph storage this stores the osm id (the way id) against the edge
+     *
+     * @param way       The full way read from the parser
+     * @param edge      The EdgeIteratorState representing the edge to be processed
+     */
     public void processEdge(ReaderWay way, EdgeIteratorState edge) {
         osmIdGraphStorage.setEdgeValue(edge.getEdge(), way.getId());
     }

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/util/EncodeUtils.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/util/EncodeUtils.java
@@ -20,6 +20,8 @@
  */
 package heigit.ors.routing.graphhopper.extensions.util;
 
+import java.nio.ByteBuffer;
+
 public class EncodeUtils {
 
 	public static double getValue(int restValue, int index) {
@@ -57,6 +59,40 @@ public class EncodeUtils {
 				| (((int) (values[2] * 10) & 0xFF) << 8) | ((int) (values[3] * 10) & 0xFF));
 
 		return value;
+	}
+
+	/**
+	 * Takes a long value and converts it into a byte array of size 8.
+	 *
+	 * @param longValue
+	 * @return			An 8 long byte array representation of the long number
+	 */
+	public static byte[] longToByteArray(long longValue) {
+		ByteBuffer longToByteBuffer = ByteBuffer.allocate(Long.BYTES);
+		longToByteBuffer.putLong(longValue);
+		return longToByteBuffer.array();
+	}
+
+	/**
+	 * Takes a byte array and converts it to a long value representation
+	 *
+	 * @param byteArray
+	 * @return			The long number representation of the bytes
+	 */
+	public static long byteArrayToLong(byte[] byteArray) {
+		ByteBuffer byteToLongBuffer = ByteBuffer.allocate(Long.BYTES);
+		// Need to make up to the needed 8 bytes
+		byte[] storageBytes = {0,0,0,0,0,0,0,0};
+		int differenceInSize = storageBytes.length - byteArray.length;
+
+		for(int i = byteArray.length-1; i >= 0; i--) {
+			if(differenceInSize + i >= 0)
+				storageBytes[differenceInSize + i] = byteArray[i];
+		}
+
+		byteToLongBuffer.put(storageBytes);
+		byteToLongBuffer.flip();
+		return byteToLongBuffer.getLong();
 	}
 
 	public static void main(String[] args) {

--- a/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
@@ -51,6 +51,7 @@ public class ExtraInfoProcessor extends PathProcessor {
 	private TollwaysGraphStorage _extTollways;
 	private TrailDifficultyScaleGraphStorage _extTrailDifficulty;
 	private HillIndexGraphStorage _extHillIndex;
+	private OsmIdGraphStorage _extOsmId;
 	
 	private RouteExtraInfo _surfaceInfo;
 	private RouteExtraInfoBuilder _surfaceInfoBuilder;
@@ -82,6 +83,9 @@ public class ExtraInfoProcessor extends PathProcessor {
 	
 	private RouteExtraInfo _trailDifficultyInfo;
 	private RouteExtraInfoBuilder _trailDifficultyInfoBuilder;
+
+	private RouteExtraInfo _osmIdInfo;
+	private RouteExtraInfoBuilder _osmIdInfoBuilder;
 	
 	private int _profileType = RoutingProfileType.UNKNOWN;
 	private FlagEncoder _encoder;
@@ -185,6 +189,14 @@ public class ExtraInfoProcessor extends PathProcessor {
 			_noiseInfoBuilder = new SimpleRouteExtraInfoBuilder(_noiseInfo);
 		}
 
+		if (RouteExtraInfoFlag.isSet(extraInfo, RouteExtraInfoFlag.OsmId)) {
+			_extOsmId = GraphStorageUtils.getGraphExtension(graphHopper.getGraphHopperStorage(), OsmIdGraphStorage.class);
+
+			if(_extOsmId == null)
+				throw new Exception("OsmId storage is not found");
+			_osmIdInfo = new RouteExtraInfo("osmId");
+			_osmIdInfoBuilder = new SimpleRouteExtraInfoBuilder(_osmIdInfo);
+		}
 		buffer = new byte[4];
 	}
 
@@ -217,6 +229,8 @@ public class ExtraInfoProcessor extends PathProcessor {
 			extras.add(_tollwaysInfo);
 		if (_trailDifficultyInfo != null)
 			extras.add(_trailDifficultyInfo);
+		if (_osmIdInfo != null)
+			extras.add(_osmIdInfo);
 
 		return extras;
 	}
@@ -323,6 +337,13 @@ public class ExtraInfoProcessor extends PathProcessor {
 			
 			int client_noise_level = noise_level + 7;
 			_noiseInfoBuilder.addSegment(noise_level, client_noise_level, geom, dist, lastEdge && _lastSegment);
+		}
+
+		if (_osmIdInfoBuilder != null) {
+
+			long osmId = _extOsmId.getEdgeValue(edge.getOriginalEdge());
+
+			_osmIdInfoBuilder.addSegment((double)osmId, osmId, geom, dist, lastEdge && _lastSegment);
 		}
 	}
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/DummyRouteExtraInfoBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/DummyRouteExtraInfoBuilder.java
@@ -32,7 +32,7 @@ public class DummyRouteExtraInfoBuilder extends RouteExtraInfoBuilder {
 		super(extraInfo);
 	}
 
-	public void addSegment(double value, int valueIndex, PointList geom, double dist, boolean lastEdge)
+	public void addSegment(double value, long valueIndex, PointList geom, double dist, boolean lastEdge)
     {
 		int nPoints = geom.getSize() - 1;
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/RouteExtraInfoBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/RouteExtraInfoBuilder.java
@@ -35,7 +35,7 @@ public abstract class RouteExtraInfoBuilder {
     	_extraInfo = extraInfo;
     }
     
-    public abstract void addSegment(double value, int valueIndex, PointList geom, double dist, boolean lastEdge);
+    public abstract void addSegment(double value, long valueIndex, PointList geom, double dist, boolean lastEdge);
     
     public abstract void finish();
 }

--- a/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/SimpleRouteExtraInfoBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/SimpleRouteExtraInfoBuilder.java
@@ -28,7 +28,7 @@ import heigit.ors.routing.RouteSegmentItem;
 public class SimpleRouteExtraInfoBuilder extends RouteExtraInfoBuilder {
 	private int _prevIndex = 0;
 	private int _segmentLength = 0;
-	private int _prevValueIndex = -1;
+	private long _prevValueIndex = -1;
 	private double _prevValue = Double.MAX_VALUE;
 	private double _segmentDist = 0;
 	
@@ -36,7 +36,7 @@ public class SimpleRouteExtraInfoBuilder extends RouteExtraInfoBuilder {
 		super(extraInfo);
 	}
 
-	public void addSegment(double value, int valueIndex, PointList geom, double dist, boolean lastEdge)
+	public void addSegment(double value, long valueIndex, PointList geom, double dist, boolean lastEdge)
     {
 		int nPoints = geom.getSize() - 1;
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/SteepnessExtraInfoBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/util/extrainfobuilders/SteepnessExtraInfoBuilder.java
@@ -50,7 +50,7 @@ public class SteepnessExtraInfoBuilder extends RouteExtraInfoBuilder
 		_distCalc = Helper.DIST_3D;
 	}
 
-	public void addSegment(double value, int valueIndex, PointList geom, double dist, boolean lastEdge)
+	public void addSegment(double value, long valueIndex, PointList geom, double dist, boolean lastEdge)
     {
 		_lastEdge = lastEdge;
     }

--- a/openrouteservice/src/main/resources/META-INF/services/heigit.ors.routing.graphhopper.extensions.storages.builders.GraphStorageBuilder
+++ b/openrouteservice/src/main/resources/META-INF/services/heigit.ors.routing.graphhopper.extensions.storages.builders.GraphStorageBuilder
@@ -10,3 +10,4 @@ heigit.ors.routing.graphhopper.extensions.storages.builders.AccessRestrictionsGr
 heigit.ors.routing.graphhopper.extensions.storages.builders.TollwaysGraphStorageBuilder
 heigit.ors.routing.graphhopper.extensions.storages.builders.TrailDifficultyScaleGraphStorageBuilder
 heigit.ors.routing.graphhopper.extensions.storages.builders.BordersGraphStorageBuilder
+heigit.ors.routing.graphhopper.extensions.storages.builders.OsmIdGraphStorageBuilder

--- a/openrouteservice/src/test/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorageTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorageTest.java
@@ -17,6 +17,6 @@ public class OsmIdGraphStorageTest {
     public void TestItemCreation() {
         _storage.setEdgeValue(1, 1234L);
 
-        assertEquals(_storage.getEdgeValue(1), 1234);
+        assertEquals(1234, _storage.getEdgeValue(1));
     }
 }

--- a/openrouteservice/src/test/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorageTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorageTest.java
@@ -1,0 +1,22 @@
+package heigit.ors.routing.graphhopper.extensions.storages;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OsmIdGraphStorageTest {
+    private final OsmIdGraphStorage _storage;
+
+    public OsmIdGraphStorageTest() {
+        _storage = new OsmIdGraphStorage();
+        _storage.init();
+        _storage.create(1);
+    }
+
+    @Test
+    public void TestItemCreation() {
+        _storage.setEdgeValue(1, 1234L);
+
+        assertEquals(_storage.getEdgeValue(1), 1234);
+    }
+}

--- a/openrouteservice/src/test/java/heigit/ors/routing/graphhopper/extensions/util/EncodeUtilsTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/routing/graphhopper/extensions/util/EncodeUtilsTest.java
@@ -1,0 +1,38 @@
+package heigit.ors.routing.graphhopper.extensions.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EncodeUtilsTest {
+    @Test
+    public void longToByteArrayTest() {
+        long value = 1234L;
+        byte[] byteValue = EncodeUtils.longToByteArray(value);
+
+        assertEquals(8, byteValue.length);
+        assertEquals(-46, byteValue[7]);
+        assertEquals(4, byteValue[6]);
+    }
+
+    @Test
+    public void byteArrayToLongTest() {
+        // 01001001 10010110 00000010 11010010
+        byte[] byteArr = {0,0,0,0,73,-106,2,-46};
+        long value = EncodeUtils.byteArrayToLong(byteArr);
+
+        assertEquals(1234567890, value);
+
+        // 11101000 01101010 00000100 10011111
+        byte[] byteArr2 = {-24,106,4,-97};
+        long value2 = EncodeUtils.byteArrayToLong(byteArr2);
+
+        assertEquals(3899262111L, value2);
+
+        // 01111100 00000000 00000000 00001100 11010011 01001100 11111000 10100000 00000001
+        byte[] byteArr3 = {124,0,0,12,-45,76,-8,-96,1};
+        long value3 = EncodeUtils.byteArrayToLong(byteArr3);
+
+        assertEquals(14101668995073L, value3);
+    }
+}


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading
- [x] 3. I have documented my code using JDocs tags
- [x] 4. I have removed unecessary commented out code, imports and System.out.println statements
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass
- [x] 6. I have created API tests for any new functionality exposed to the API
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below) 
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue)
- [x] 10. For new features involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors)
- [x] 11. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #217 .

### Information about the changes
- Key functionality added: A new extended storage has been added for the osm id of the way that the edge is attached to.
- Reason for change: This makes it easier (in the case of the wheelchair profile) for users of the route to identify the way in osm that is being travelled along and thus facilitate "inline" osm editing

### Required changes to app.config (if applicable)
- OsmId: {} can be added as an ext_storages to profiles (but is not required)

