### PR TITLE
Fix allow disabling of acceleration calculation

### DIFF
--- a/openrouteservice-api-tests/conf/app.config.test
+++ b/openrouteservice-api-tests/conf/app.config.test
@@ -159,7 +159,7 @@
 						profiles: "driving-car,driving-hgv",
 						parameters: {
 						    encoder_flags_size: 4,
-						    encoder_options : "turn_costs=true|block_fords=false|maximum_grade_level=1,turn_costs=true|block_fords=false",
+						    encoder_options : "turn_costs=true|block_fords=false|maximum_grade_level=1|use_acceleration=true,turn_costs=true|block_fords=false|use_acceleration=true",
                             maximum_distance: 100000,
                             elevation: true, 
 							preparation:

--- a/openrouteservice/WebContent/WEB-INF/app.config.sample
+++ b/openrouteservice/WebContent/WEB-INF/app.config.sample
@@ -226,7 +226,7 @@
 						parameters: {
 							encoder_flags_size: 8,
 							# List of options used by FlagEncoders.
-							encoder_options : "turn_costs=true|block_fords=false,turn_costs=true|block_fords=false,turn_costs=true|block_fords=false",
+							encoder_options : "turn_costs=true|block_fords=false|use_acceleration=false,turn_costs=true|block_fords=false|use_acceleration=false,turn_costs=true|block_fords=false|use_acceleration=false",
                             				maximum_distance: 100000,
                             				elevation: true, 
                                 			preparation: {  

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
@@ -22,11 +22,11 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.util.EncodedDoubleValue;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
-import heigit.ors.config.AppConfig;
-import heigit.ors.services.routing.RoutingServiceSettings;
 import org.apache.log4j.Logger;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Defines bit layout for cars. (speed, access, ferries, ...)

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
@@ -22,6 +22,8 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.util.EncodedDoubleValue;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
+import heigit.ors.config.AppConfig;
+import heigit.ors.services.routing.RoutingServiceSettings;
 import org.apache.log4j.Logger;
 
 import java.util.*;
@@ -49,6 +51,9 @@ public class CarFlagEncoder extends ORSAbstractFlagEncoder {
      */
     protected int maxTrackGradeLevel = 3;
 
+    // Take into account acceleration calculations when determining travel speed
+    protected boolean useAcceleration = false;
+
     public CarFlagEncoder() {
         this(5, 5, 0);
     }
@@ -60,7 +65,9 @@ public class CarFlagEncoder extends ORSAbstractFlagEncoder {
         this.properties = properties;
         this.setBlockFords(properties.getBool("block_fords", true));
         this.setBlockByDefault(properties.getBool("block_barriers", true));
-        
+
+        this.useAcceleration = properties.getBool("use_acceleration", false);
+
         maxTrackGradeLevel = properties.getInt("maximum_grade_level", 3);
     }
 
@@ -368,7 +375,7 @@ public class CarFlagEncoder extends ORSAbstractFlagEncoder {
 
             speed = getSurfaceSpeed(way, speed);
 
-            if(way.hasTag("estimated_distance")) {
+            if(way.hasTag("estimated_distance") && this.useAcceleration) {
                 double estDist = way.getTag("estimated_distance", Double.MAX_VALUE);
                 speed = Math.max(adjustSpeedForAcceleration(estDist, speed), speedFactor);
             }

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -48,6 +48,9 @@ public class HeavyVehicleFlagEncoder extends ORSAbstractFlagEncoder
     protected final HashSet<String> noValues = new HashSet<String>(5);
     protected final HashSet<String> yesValues = new HashSet<String>(5);
     protected final List<String> hgvAccess = new ArrayList<String>(5);
+
+    // Take into account acceleration calculations when determining travel speed
+    protected boolean useAcceleration = false;
     
     protected int maxTrackGradeLevel = 3;
     
@@ -75,6 +78,8 @@ public class HeavyVehicleFlagEncoder extends ORSAbstractFlagEncoder
         setBlockFords(false);
         
         maxTrackGradeLevel = properties.getInt("maximum_grade_level", 1);
+
+        this.useAcceleration = properties.getBool("use_acceleration", false);
     }
 
     public HeavyVehicleFlagEncoder( int speedBits, double speedFactor, int maxTurnCosts )
@@ -481,7 +486,7 @@ public class HeavyVehicleFlagEncoder extends ORSAbstractFlagEncoder
         			speed = surfaceSpeed;
         	}
 
-            if(way.hasTag("estimated_distance")) {
+            if(way.hasTag("estimated_distance") && this.useAcceleration) {
                 double estDist = way.getTag("estimated_distance", Double.MAX_VALUE);
                 speed = Math.max(adjustSpeedForAcceleration(estDist, speed), speedFactor);
             }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [ ] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading
- [ ] 3. I have documented my code using JDocs tags
- [ ] 4. I have removed unecessary commented out code, imports and System.out.println statements
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass
- [ ] 6. I have created API tests for any new functionality exposed to the API
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below) 
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue)
- [ ] 10. For new features involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors)
- [x] 11. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes # .

### Information about the changes
- Key functionality added: Allowed the spcification of whether to use the acceleration calculations when determining speed on an edge. This can be controlled using the parameter `use_acceleration=true/false` in the `encoder_options` of the profile
- Reason for change: Allow more control of the use of the acceleration function as it can dramatically change the routes generated

### Required changes to app.config (if applicable)
- parameter `use_acceleration=true/false` added to the `encoder_options`

