### PR TITLE
Bugfix #262 - enable hgv axleload restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Added area_units for isochrones API as units being misleading (Issue #272)
 - Area calculation for isochrones using metric crs (Issue #130)
 - Decreases maximum peed for bike-regular for more realistic reachability scores (Issue #325)
 - Fixes self intersecting polygons when requesting population for isochrones (Issue #297)
+- Enable HGV axleload restriction (Issue #262)
 ### Changed
 - Changed app.config.sample for docker to consider split profiles (Issue #320)
 - Changed minor information in pom.xml

--- a/openrouteservice/src/main/java/heigit/ors/routing/parameters/VehicleParameters.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/parameters/VehicleParameters.java
@@ -24,10 +24,7 @@ public class VehicleParameters extends ProfileParameters {
 
 	private int _characteristics = VehicleLoadCharacteristicsFlags.NONE;
 
-	public VehicleParameters()
-	{
-
-	}
+	public VehicleParameters() {}
 
 	public double getLength() {
 		return _length;
@@ -57,8 +54,8 @@ public class VehicleParameters extends ProfileParameters {
 		return _weight;
 	}
 
-	public void setWeight(double _weight) {
-		this._weight = _weight;
+	public void setWeight(double weight) {
+		_weight = weight;
 	}
 
 	public double getAxleload() {
@@ -77,8 +74,7 @@ public class VehicleParameters extends ProfileParameters {
 		_characteristics = characteristics;
 	}
 	
-	public boolean hasAttributes()
-	{
-		return _height >0.0 || _length > 0.0 || _width > 0.0 || _weight >0.0 || _characteristics != 0;
+	public boolean hasAttributes() {
+		return _height > 0.0 || _length > 0.0 || _width > 0.0 || _weight > 0.0 || _axleload > 0.0 || _characteristics != 0;
 	}
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #262.

Enables logic to check for hgv axleload restriction.