### PR TITLE
Residential penalty may not reduce speed to lower than 5 (fixes #191 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 ### Fixed
+- If residential penalty reduces speed to <5, set it to 5
 ### Changed
 ### Deprecated
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/ORSAbstractFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/ORSAbstractFlagEncoder.java
@@ -29,7 +29,10 @@ public abstract class ORSAbstractFlagEncoder extends AbstractFlagEncoder {
 	}
 
 	double addResedentialPenalty(double baseSpeed, ReaderWay way) {
+		if (baseSpeed == 0)
+			return 0;
 		double speed = baseSpeed;
+
 		if(way.hasTag("highway","residential")) {
 			double estDist = way.getTag("estimated_distance", Double.MAX_VALUE);
 			// take into account number of nodes to get an average distance between nodes
@@ -38,9 +41,12 @@ public abstract class ORSAbstractFlagEncoder extends AbstractFlagEncoder {
 			if(interimNodes > 0) {
 				interimDistance = estDist/(interimNodes+1);
 			}
-			if(interimDistance < 100) {
+			if(interimDistance < 100 && speed > 10) {
 				speed = speed * 0.5;
 			}
+			//Don't go below 2.5 because it will be stored as 0 later
+			if(speed < 5)
+				speed = 5;
 		}
 
 		return speed;

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/ORSAbstractFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/ORSAbstractFlagEncoder.java
@@ -41,7 +41,7 @@ public abstract class ORSAbstractFlagEncoder extends AbstractFlagEncoder {
 			if(interimNodes > 0) {
 				interimDistance = estDist/(interimNodes+1);
 			}
-			if(interimDistance < 100 && speed > 10) {
+			if(interimDistance < 100) {
 				speed = speed * 0.5;
 			}
 			//Don't go below 2.5 because it will be stored as 0 later


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #191 .

### Information about the changes
- Key functionality added: Speed may not be set to lower than 5 by residential penalty
- Reason for change: Old code resulted in 0 speed for edges with 5 original speed sometimes. Then routing does not work from/to those edges.


