### PR TITLE
Bugfix #291

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 ### Fixed
+- Added a new ParameterValueException if the profile is driving-car and profile_params are set in the operions (Issue #291)
 ### Changed
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 ### Fixed
 - Added a new ParameterValueException if the profile is driving-car and profile_params are set in the operions (Issue #291)
+
 ### Changed
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added Unit Tests for RouteSearchParameters.class() (while fixing Issue #291)
 ### Fixed
-- Added a new ParameterValueException in RouteSearchParameters if the profile is driving-car and profile_params are set in the operions (Issue #291)
+- Added a new ParameterValueException in RouteSearchParameters if the profile is driving-car and profile_params are set in the options (Issue #291)
 - Fixed API Test to consider the new ParameterValueException (while fixing Issue #291)
 ### Changed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added Unit Tests for RouteSearchParameters.class() (while fixing Issue #291)
 ### Fixed
-- Added a new ParameterValueException if the profile is driving-car and profile_params are set in the operions (Issue #291)
-
+- Added a new ParameterValueException in RouteSearchParameters if the profile is driving-car and profile_params are set in the operions (Issue #291)
+- Fixed API Test to consider the new ParameterValueException (while fixing Issue #291)
 ### Changed
 ### Deprecated
 

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
@@ -409,7 +409,7 @@ public class ResultTest extends ServiceTest {
 	}
 
 	@Test
-	public void expectCarToRejectBikeParams() {
+	public void expectCarToRejectProfileParams() {
 
 		// options for cycling profiles
 		JSONObject options = new JSONObject();
@@ -428,7 +428,7 @@ public class ResultTest extends ServiceTest {
 				.get(getEndPointName())
 				.then()
 				.assertThat()
-				.statusCode(200);
+				.statusCode(400);
 	}
 
 	@Test

--- a/openrouteservice/src/main/java/heigit/ors/routing/RouteSearchParameters.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/RouteSearchParameters.java
@@ -20,27 +20,28 @@
  */
 package heigit.ors.routing;
 
-import java.text.ParseException;
-import java.util.Iterator;
-
-import heigit.ors.routing.pathprocessors.BordersExtractor;
-import org.json.JSONArray;
-import org.json.JSONObject;
-
 import com.graphhopper.util.Helper;
-
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Polygon;
-
 import heigit.ors.exceptions.ParameterValueException;
 import heigit.ors.exceptions.UnknownParameterValueException;
 import heigit.ors.geojson.GeometryJSON;
 import heigit.ors.routing.graphhopper.extensions.HeavyVehicleAttributes;
 import heigit.ors.routing.graphhopper.extensions.VehicleLoadCharacteristicsFlags;
 import heigit.ors.routing.graphhopper.extensions.WheelchairTypesEncoder;
-import heigit.ors.routing.parameters.*;
+import heigit.ors.routing.parameters.CyclingParameters;
+import heigit.ors.routing.parameters.ProfileParameters;
+import heigit.ors.routing.parameters.VehicleParameters;
+import heigit.ors.routing.parameters.WalkingParameters;
+import heigit.ors.routing.parameters.WheelchairParameters;
+import heigit.ors.routing.pathprocessors.BordersExtractor;
 import heigit.ors.util.StringUtility;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.text.ParseException;
+import java.util.Iterator;
 
 /**
  * This class is used to store the search/calculation Parameters to calculate the desired Route/Isochrones etc…
@@ -255,28 +256,16 @@ public class RouteSearchParameters {
             }
         }
 
-        if (json.has("profile_params")) {
+        if (json.has("profile_params") && RoutingProfileType.isDriving(_profileType)) {
+            throw new ParameterValueException(RoutingErrorCodes.INVALID_PARAMETER_VALUE, "profile_params");
+        } else if (json.has("profile_params")) {
             JSONObject jProfileParams = json.getJSONObject("profile_params");
             JSONObject jRestrictions = null;
 
             if (jProfileParams.has("restrictions"))
                 jRestrictions = jProfileParams.getJSONObject("restrictions");
-
             if (RoutingProfileType.isCycling(_profileType)) {
                 CyclingParameters cyclingParams = new CyclingParameters();
-
-                // To make the new API compatible with a new one, we create 'weightings' element.
-				/*if (!jProfileParams.has("weightings") && (jProfileParams.has("difficulty_level") || jProfileParams.has("maximum_gradient")))
-				{
-					JSONObject jWeightings = new JSONObject();
-
-					if (jProfileParams.has("difficulty_level"))
-						jWeightings.put("difficulty_level", jProfileParams.get("difficulty_level"));
-					else if	(jProfileParams.has("maximum_gradient"))
-						jWeightings.put("maximum_gradient", jProfileParams.get("maximum_gradient"));
-
-					jProfileParams.put("weightings", jWeightings);
-				}*/
 
                 if (jRestrictions != null) {
                     if (jRestrictions.has("gradient"))
@@ -312,7 +301,7 @@ public class RouteSearchParameters {
                 }
 
                 _profileParams = walkingParams;
-            } else if (RoutingProfileType.isHeavyVehicle(_profileType) == true) {
+            } else if (RoutingProfileType.isHeavyVehicle(_profileType)) {
                 VehicleParameters vehicleParams = new VehicleParameters();
 
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/RouteSearchParameters.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/RouteSearchParameters.java
@@ -256,7 +256,7 @@ public class RouteSearchParameters {
             }
         }
 
-        if (json.has("profile_params") && RoutingProfileType.isDriving(_profileType)) {
+        if (json.has("profile_params") && _profileType == RoutingProfileType.DRIVING_CAR) {
             throw new ParameterValueException(RoutingErrorCodes.INVALID_PARAMETER_VALUE, "profile_params");
         } else if (json.has("profile_params")) {
             JSONObject jProfileParams = json.getJSONObject("profile_params");

--- a/openrouteservice/src/test/java/heigit/ors/routing/RouteSearchParametersTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/routing/RouteSearchParametersTest.java
@@ -1,0 +1,244 @@
+package heigit.ors.routing;
+
+import com.vividsolutions.jts.geom.Polygon;
+import heigit.ors.routing.graphhopper.extensions.HeavyVehicleAttributes;
+import heigit.ors.routing.parameters.VehicleParameters;
+import heigit.ors.routing.pathprocessors.BordersExtractor;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RouteSearchParametersTest {
+
+    @Test
+    public void getProfileType() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertEquals(0, routeSearchParameters.getProfileType());
+    }
+
+    @Test
+    public void setProfileType() throws Exception {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setProfileType(2);
+        Assert.assertEquals(2, routeSearchParameters.getProfileType());
+    }
+
+    @Test
+    public void getMaximumSpeed() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertEquals(-1.0, routeSearchParameters.getMaximumSpeed(), 0.0);
+    }
+
+    @Test
+    public void setMaximumSpeed() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setMaximumSpeed(2.0);
+        Assert.assertEquals(2.0, routeSearchParameters.getMaximumSpeed(), 0.0);
+    }
+
+    @Test
+    public void getWeightingMethod() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertEquals(WeightingMethod.FASTEST, routeSearchParameters.getWeightingMethod(), 0.0);
+    }
+
+    @Test
+    public void setWeightingMethod() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setWeightingMethod(WeightingMethod.RECOMMENDED);
+        Assert.assertEquals(WeightingMethod.RECOMMENDED, routeSearchParameters.getWeightingMethod(), 0.0);
+    }
+
+    @Test
+    public void getConsiderTraffic() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.getConsiderTraffic());
+    }
+
+    @Test
+    public void setConsiderTraffic() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setConsiderTraffic(true);
+        Assert.assertTrue(routeSearchParameters.getConsiderTraffic());
+    }
+
+    @Test
+    public void getAvoidAreas() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertArrayEquals(null, routeSearchParameters.getAvoidAreas());
+    }
+
+    @Test
+    public void setAvoidAreas() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setAvoidAreas(new Polygon[0]);
+        Assert.assertArrayEquals(new Polygon[0], routeSearchParameters.getAvoidAreas());
+    }
+
+    @Test
+    public void hasAvoidAreas() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.hasAvoidAreas());
+        routeSearchParameters.setAvoidAreas(new Polygon[1]);
+        Assert.assertTrue(routeSearchParameters.hasAvoidAreas());
+    }
+
+    @Test
+    public void getAvoidFeatureTypes() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertEquals(0, routeSearchParameters.getAvoidFeatureTypes());
+
+    }
+
+    @Test
+    public void setAvoidFeatureTypes() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setAvoidFeatureTypes(1);
+        Assert.assertEquals(1, routeSearchParameters.getAvoidFeatureTypes());
+    }
+
+    @Test
+    public void hasAvoidFeatures() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.hasAvoidFeatures());
+        routeSearchParameters.setAvoidFeatureTypes(1);
+        Assert.assertTrue(routeSearchParameters.hasAvoidFeatures());
+    }
+
+    @Test
+    public void getAvoidCountries() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertNull(routeSearchParameters.getAvoidCountries());
+    }
+
+    @Test
+    public void setAvoidCountries() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setAvoidCountries(new int[1]);
+        Assert.assertArrayEquals(new int[1], routeSearchParameters.getAvoidCountries());
+    }
+
+    @Test
+    public void hasAvoidCountries() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.hasAvoidCountries());
+        routeSearchParameters.setAvoidCountries(new int[1]);
+        Assert.assertTrue(routeSearchParameters.hasAvoidCountries());
+    }
+
+    @Test
+    public void hasAvoidBorders() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.hasAvoidBorders());
+        routeSearchParameters.setAvoidBorders(BordersExtractor.Avoid.CONTROLLED);
+        Assert.assertTrue(routeSearchParameters.hasAvoidBorders());
+    }
+
+    @Test
+    public void setAvoidBorders() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setAvoidBorders(BordersExtractor.Avoid.CONTROLLED);
+        Assert.assertEquals(BordersExtractor.Avoid.CONTROLLED, routeSearchParameters.getAvoidBorders());
+    }
+
+    @Test
+    public void getAvoidBorders() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertEquals(BordersExtractor.Avoid.NONE, routeSearchParameters.getAvoidBorders());
+    }
+
+    @Test
+    public void getConsiderTurnRestrictions() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.getConsiderTurnRestrictions());
+    }
+
+    @Test
+    public void setConsiderTurnRestrictions() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setConsiderTurnRestrictions(true);
+        Assert.assertTrue(routeSearchParameters.getConsiderTurnRestrictions());
+    }
+
+    @Test
+    public void getVehicleType() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertEquals(HeavyVehicleAttributes.UNKNOWN, routeSearchParameters.getVehicleType());
+    }
+
+    @Test
+    public void setVehicleType() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setVehicleType(HeavyVehicleAttributes.AGRICULTURE);
+        Assert.assertEquals(HeavyVehicleAttributes.AGRICULTURE, routeSearchParameters.getVehicleType());
+
+    }
+
+    @Test
+    public void getOptions() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertNull(routeSearchParameters.getOptions());
+    }
+
+    @Test
+    public void setOptions() throws Exception {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setOptions("{\"maximum_speed\": 10}");
+        Assert.assertEquals("{\"maximum_speed\": 10}", routeSearchParameters.getOptions());
+    }
+
+    @Test
+    public void hasParameters() throws Exception {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.hasParameters(routeSearchParameters.getClass()));
+        routeSearchParameters.setProfileType(2);
+        routeSearchParameters.setOptions("{\"profile_params\":{\"weightings\":{\"green\":{\"factor\":0.8}}}}");
+        Assert.assertTrue(routeSearchParameters.hasParameters(VehicleParameters.class));
+    }
+
+    @Test
+    public void getProfileParameters() throws Exception {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertNull(routeSearchParameters.getProfileParameters());
+    }
+
+    @Test
+    public void getFlexibleMode() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertFalse(routeSearchParameters.getFlexibleMode());
+    }
+
+    @Test
+    public void setFlexibleMode() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setFlexibleMode(true);
+        Assert.assertTrue(routeSearchParameters.getFlexibleMode());
+    }
+
+    @Test
+    public void getMaximumRadiuses() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertNull(routeSearchParameters.getMaximumRadiuses());
+    }
+
+    @Test
+    public void setMaximumRadiuses() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setMaximumRadiuses(new double[0]);
+        Assert.assertNotNull(routeSearchParameters.getMaximumRadiuses());
+        Assert.assertSame(routeSearchParameters.getMaximumRadiuses().getClass(), double[].class);
+        Assert.assertEquals(0, routeSearchParameters.getMaximumRadiuses().length);
+    }
+
+    @Test
+    public void getBearings() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        Assert.assertNull(routeSearchParameters.getBearings());
+    }
+
+    @Test
+    public void setBearings() {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setBearings(new WayPointBearing[]{});
+        Assert.assertArrayEquals(new WayPointBearing[]{}, routeSearchParameters.getBearings());
+    }
+}

--- a/openrouteservice/src/test/java/heigit/ors/routing/RouteSearchParametersTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/routing/RouteSearchParametersTest.java
@@ -1,6 +1,7 @@
 package heigit.ors.routing;
 
 import com.vividsolutions.jts.geom.Polygon;
+import heigit.ors.exceptions.ParameterValueException;
 import heigit.ors.routing.graphhopper.extensions.HeavyVehicleAttributes;
 import heigit.ors.routing.parameters.VehicleParameters;
 import heigit.ors.routing.pathprocessors.BordersExtractor;
@@ -8,6 +9,13 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class RouteSearchParametersTest {
+
+    @Test(expected = ParameterValueException.class)
+    public void expectFailingProfileParamsWithVehicleProfile() throws Exception {
+        RouteSearchParameters routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setProfileType(1);
+        routeSearchParameters.setOptions("{\"profile_params\":{\"weightings\":{\"green\":{\"factor\":0.8}}}}");
+    }
 
     @Test
     public void getProfileType() {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #291  .

### Information about the changes
- Key functionality added: Added a new ParameterValueException in RouteSearchParameters if the profile is driving-car and profile_params are set in the options. Added new Unit Tests for RouteSearchParameters.class() and corrected an API Test for the new error.
- Reason for change: When directions is queried with the profile "driving_car" while using profile_params, the response is just empty without any error.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
- 

### Required changes to app.config (if applicable)
- 
