### PR TITLE
Bugfix  #348 Wrong BBox in GeoJSON with negative coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - If residential penalty reduces speed to <5, set it to 5
 - Added a new ParameterValueException in RouteSearchParameters if the profile is driving-car and profile_params are set in the options (Issue #291)
 - Fixed API Test to consider the new ParameterValueException (while fixing Issue #291)
+- Fixed empty BBox error if the route is located in the southern hemisphere (Issue #348)
 ### Changed
 ### Deprecated
 

--- a/openrouteservice/src/main/java/heigit/ors/services/isochrones/requestprocessors/json/JsonIsochronesRequestProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/isochrones/requestprocessors/json/JsonIsochronesRequestProcessor.java
@@ -191,16 +191,8 @@ public class JsonIsochronesRequestProcessor extends AbstractHttpRequestProcessor
                 jFeatures.put(jFeature);
 
                 Envelope env = shell.getEnvelopeInternal();
-                if (Double.isFinite(env.getMinX()))
-                    bbox.minLon = env.getMinX();
-                if (Double.isFinite(env.getMinY()))
-                    bbox.minLat = env.getMinY();
-                if (Double.isFinite(env.getMaxX()))
-                    bbox.maxLon = env.getMaxX();
-                if (Double.isFinite(env.getMaxY()))
-                    bbox.maxLat = env.getMaxY();
-                if (!bbox.isValid())
-                    bbox = new BBox(0, 0, 0, 0);
+                bbox = constructIsochroneBBox(env);
+
             }
 
             groupIndex++;
@@ -293,5 +285,19 @@ public class JsonIsochronesRequestProcessor extends AbstractHttpRequestProcessor
         jResp.put("info", jInfo);
 
         ServletUtility.write(response, jResp);
+    }
+    public static BBox constructIsochroneBBox(Envelope env){
+        BBox bbox = new BBox(0,0,0,0);
+        if (Double.isFinite(env.getMinX()))
+            bbox.minLon = env.getMinX();
+        if (Double.isFinite(env.getMinY()))
+            bbox.minLat = env.getMinY();
+        if (Double.isFinite(env.getMaxX()))
+            bbox.maxLon = env.getMaxX();
+        if (Double.isFinite(env.getMaxY()))
+            bbox.maxLat = env.getMaxY();
+        if (!bbox.isValid())
+            bbox = new BBox(0, 0, 0, 0);
+        return bbox;
     }
 }

--- a/openrouteservice/src/main/java/heigit/ors/services/isochrones/requestprocessors/json/JsonIsochronesRequestProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/isochrones/requestprocessors/json/JsonIsochronesRequestProcessor.java
@@ -99,7 +99,6 @@ public class JsonIsochronesRequestProcessor extends AbstractHttpRequestProcessor
                 IsochroneMap isochroneMap = RoutingProfileManager.getInstance().buildIsochrone(searchParams, nonDefaultAttrs);
                 isoMaps.add(isochroneMap);
             }
-
             writeResponse(response, req, isoMaps);
         }
     }
@@ -192,17 +191,16 @@ public class JsonIsochronesRequestProcessor extends AbstractHttpRequestProcessor
                 jFeatures.put(jFeature);
 
                 Envelope env = shell.getEnvelopeInternal();
-                if (!Double.isNaN(env.getMinX()) && Double.isFinite(env.getMinX()))
+                if (Double.isFinite(env.getMinX()))
                     bbox.minLon = env.getMinX();
-                if (!Double.isNaN(env.getMinY()) && Double.isFinite(env.getMinY()))
+                if (Double.isFinite(env.getMinY()))
                     bbox.minLat = env.getMinY();
-                if (!Double.isNaN(env.getMaxX()) && Double.isFinite(env.getMaxX()))
+                if (Double.isFinite(env.getMaxX()))
                     bbox.maxLon = env.getMaxX();
-                if (!Double.isNaN(env.getMaxY()) && Double.isFinite(env.getMaxY()))
+                if (Double.isFinite(env.getMaxY()))
                     bbox.maxLat = env.getMaxY();
                 if (!bbox.isValid())
                     bbox = new BBox(0, 0, 0, 0);
-
             }
 
             groupIndex++;

--- a/openrouteservice/src/test/java/heigit/ors/services/isochrones/requestprocessors/json/JsonIsochronesRequestProcessorTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/services/isochrones/requestprocessors/json/JsonIsochronesRequestProcessorTest.java
@@ -1,0 +1,148 @@
+package heigit.ors.services.isochrones.requestprocessors.json;
+
+import com.graphhopper.util.shapes.BBox;
+import com.vividsolutions.jts.geom.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+
+public class JsonIsochronesRequestProcessorTest {
+
+    private Envelope negativeEnv;
+    private Envelope positiveEnv;
+    private Envelope mixedEnv;
+
+    @Before
+    public void setUp() {
+        ArrayList<Double[]> bareNegativeCoordinateList = new ArrayList<>(12);
+        Coordinate[] negativeCoordinates = new Coordinate[12];
+        bareNegativeCoordinateList.add(new Double[]{-77.033874, -12.122793});
+        bareNegativeCoordinateList.add(new Double[]{-77.032343, -12.125334});
+        bareNegativeCoordinateList.add(new Double[]{-77.031219, -12.127203});
+        bareNegativeCoordinateList.add(new Double[]{-77.030908, -12.127332});
+        bareNegativeCoordinateList.add(new Double[]{-77.026632, -12.126794});
+        bareNegativeCoordinateList.add(new Double[]{-77.025097, -12.12488});
+        bareNegativeCoordinateList.add(new Double[]{-77.025082, -12.124412});
+        bareNegativeCoordinateList.add(new Double[]{-77.026141, -12.123228});
+        bareNegativeCoordinateList.add(new Double[]{-77.030908, -12.120505});
+        bareNegativeCoordinateList.add(new Double[]{-77.031669, -12.120756});
+        bareNegativeCoordinateList.add(new Double[]{-77.033806, -12.121682});
+        bareNegativeCoordinateList.add(new Double[]{-77.033874, -12.122793});
+
+        ArrayList<Double[]> barePositiveCoordinateList = new ArrayList<>(12);
+        Coordinate[] positiveCoordinates = new Coordinate[14];
+        barePositiveCoordinateList.add(new Double[]{2.288033, 48.856386});
+        barePositiveCoordinateList.add(new Double[]{2.291753, 48.854886});
+        barePositiveCoordinateList.add(new Double[]{2.300739, 48.85848});
+        barePositiveCoordinateList.add(new Double[]{2.302588, 48.859432});
+        barePositiveCoordinateList.add(new Double[]{2.304801, 48.860647});
+        barePositiveCoordinateList.add(new Double[]{2.304745, 48.864247});
+        barePositiveCoordinateList.add(new Double[]{2.301436, 48.864227});
+        barePositiveCoordinateList.add(new Double[]{2.300037, 48.864114});
+        barePositiveCoordinateList.add(new Double[]{2.299522, 48.864051});
+        barePositiveCoordinateList.add(new Double[]{2.291279, 48.862698});
+        barePositiveCoordinateList.add(new Double[]{2.289955, 48.862126});
+        barePositiveCoordinateList.add(new Double[]{2.289711, 48.861983});
+        barePositiveCoordinateList.add(new Double[]{2.289098, 48.860238});
+        barePositiveCoordinateList.add(new Double[]{2.288033, 48.856386});
+
+        ArrayList<Double[]> bareMixedCoordinateList = new ArrayList<>(12);
+        Coordinate[] mixedCoordinates = new Coordinate[13];
+        bareMixedCoordinateList.add(new Double[]{18.395489, -33.907743});
+        bareMixedCoordinateList.add(new Double[]{18.395657, -33.908133});
+        bareMixedCoordinateList.add(new Double[]{18.39697, -33.90904});
+        bareMixedCoordinateList.add(new Double[]{18.401868, -33.908735});
+        bareMixedCoordinateList.add(new Double[]{18.403667, -33.907228});
+        bareMixedCoordinateList.add(new Double[]{18.409442, -33.90136});
+        bareMixedCoordinateList.add(new Double[]{18.40994, -33.899745});
+        bareMixedCoordinateList.add(new Double[]{18.409858, -33.89932});
+        bareMixedCoordinateList.add(new Double[]{18.409166, -33.897771});
+        bareMixedCoordinateList.add(new Double[]{18.407953, -33.897864});
+        bareMixedCoordinateList.add(new Double[]{18.40041, -33.901431});
+        bareMixedCoordinateList.add(new Double[]{18.395636, -33.905697});
+        bareMixedCoordinateList.add(new Double[]{18.395489, -33.907743});
+
+
+        for (int i = 0; i < bareNegativeCoordinateList.size(); i++) {
+            Coordinate coordinate = new Coordinate();
+            Double[] bareCoordinate = bareNegativeCoordinateList.get(i);
+            coordinate.x = bareCoordinate[0];
+            coordinate.y = bareCoordinate[1];
+            negativeCoordinates[i] = coordinate;
+        }
+
+        for (int i = 0; i < barePositiveCoordinateList.size(); i++) {
+            Coordinate coordinate = new Coordinate();
+            Double[] bareCoordinate = barePositiveCoordinateList.get(i);
+            coordinate.x = bareCoordinate[0];
+            coordinate.y = bareCoordinate[1];
+            positiveCoordinates[i] = coordinate;
+        }
+
+        for (int i = 0; i < bareMixedCoordinateList.size(); i++) {
+            Coordinate coordinate = new Coordinate();
+            Double[] bareCoordinate = bareMixedCoordinateList.get(i);
+            coordinate.x = bareCoordinate[0];
+            coordinate.y = bareCoordinate[1];
+            mixedCoordinates[i] = coordinate;
+        }
+
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Polygon polygonFactory = geometryFactory.createPolygon(negativeCoordinates);
+        LineString negativeShell = polygonFactory.getExteriorRing();
+
+        geometryFactory = new GeometryFactory();
+        polygonFactory = geometryFactory.createPolygon(positiveCoordinates);
+        LineString positiveShell = polygonFactory.getExteriorRing();
+
+        geometryFactory = new GeometryFactory();
+        polygonFactory = geometryFactory.createPolygon(mixedCoordinates);
+        LineString mixedShell = polygonFactory.getExteriorRing();
+
+        negativeEnv = negativeShell.getEnvelopeInternal();
+        positiveEnv = positiveShell.getEnvelopeInternal();
+        mixedEnv = mixedShell.getEnvelopeInternal();
+    }
+
+    @Test
+    public void constructNegativeIsochroneBBoxTest() {
+        BBox bbox = JsonIsochronesRequestProcessor.constructIsochroneBBox(negativeEnv);
+        BBox expectedBBox = new BBox(-77.033874, -77.025082, -12.127332, -12.120505);
+        Assert.assertTrue(bbox.isValid());
+        Assert.assertEquals(expectedBBox.maxLat, bbox.maxLat, 0.0);
+        Assert.assertEquals(expectedBBox.maxLon, bbox.maxLon, 0.0);
+        Assert.assertEquals(expectedBBox.minLat, bbox.minLat, 0.0);
+        Assert.assertEquals(expectedBBox.minLon, bbox.minLon, 0.0);
+        Assert.assertEquals(Double.NaN, bbox.minEle, 0.0);
+        Assert.assertEquals(Double.NaN, bbox.maxEle, 0.0);
+    }
+
+    @Test
+    public void constructPositiveIsochroneBBoxTest() {
+        BBox bbox = JsonIsochronesRequestProcessor.constructIsochroneBBox(positiveEnv);
+        BBox expectedBBox = new BBox(2.288033, 2.304801, 48.854886, 48.864247);
+        Assert.assertTrue(bbox.isValid());
+        Assert.assertEquals(expectedBBox.maxLat, bbox.maxLat, 0.0);
+        Assert.assertEquals(expectedBBox.maxLon, bbox.maxLon, 0.0);
+        Assert.assertEquals(expectedBBox.minLat, bbox.minLat, 0.0);
+        Assert.assertEquals(expectedBBox.minLon, bbox.minLon, 0.0);
+        Assert.assertEquals(Double.NaN, bbox.minEle, 0.0);
+        Assert.assertEquals(Double.NaN, bbox.maxEle, 0.0);
+    }
+
+    @Test
+    public void constructMixedIsochroneBBoxTest() {
+        BBox bbox = JsonIsochronesRequestProcessor.constructIsochroneBBox(mixedEnv);
+        BBox expectedBBox = new BBox(18.395489, 18.409940, -33.909040, -33.897771);
+        Assert.assertTrue(bbox.isValid());
+        Assert.assertEquals(expectedBBox.maxLat, bbox.maxLat, 0.0);
+        Assert.assertEquals(expectedBBox.maxLon, bbox.maxLon, 0.0);
+        Assert.assertEquals(expectedBBox.minLat, bbox.minLat, 0.0);
+        Assert.assertEquals(expectedBBox.minLon, bbox.minLon, 0.0);
+        Assert.assertEquals(Double.NaN, bbox.minEle, 0.0);
+        Assert.assertEquals(Double.NaN, bbox.maxEle, 0.0);
+    }
+}


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #348  .

### Information about the changes
- Key functionality added: The isochrones processor is now correctly processing also negative maxX
and maxY coordinates for the BBox. JUnit tests were added to ensure the new functionality.
- Reason for change: If maxX or maxY of the corresponding Isochrone BBox was negative, it was set to 0.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
- 

### Required changes to app.config (if applicable)
- 
