### PR TITLE
Bugfix #263/increase accuracy of hgv restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - If residential penalty reduces speed to <5, set it to 5
 - Added a new ParameterValueException in RouteSearchParameters if the profile is driving-car and profile_params are set in the options (Issue #291)
 - Fixed API Test to consider the new ParameterValueException (while fixing Issue #291)
+- Improved range and resolution of values encoding dimension/weight road restrictions in order to properly resolve them when corresponding hgv parameters are set (fixes issue #263)
 ### Changed
 ### Deprecated
 

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
@@ -1077,6 +1077,41 @@ http://localhost:8080/ors/routes?
 				.statusCode(200);
 	}
 
+    @Test
+    public void testHGVAxleLoadRestriction() {
+        given()
+                .param("coordinates", "8.686849,49.406093|8.687525,49.405437")
+                .param("instructions", "false")
+                .param("preference", "shortest")
+                .param("profile", "driving-hgv")
+                .param("options", "{\"profile_params\":{\"restrictions\":{\"axleload\":\"12.9\"}},\"vehicle_type\":\"hgv\"}")
+                .param("units", "m")
+                .when().log().ifValidationFails()
+                .get(getEndPointName())
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].summary.distance", is(132.9f))
+                .body("routes[0].summary.duration", is(44.3f))
+                .statusCode(200);
+
+        given()
+                .param("coordinates", "8.686849,49.406093|8.687525,49.405437")
+                .param("instructions", "true")
+                .param("preference", "shortest")
+                .param("profile", "driving-hgv")
+                .param("options", "{\"profile_params\":{\"restrictions\":{\"axleload\":\"13.1\"}},\"vehicle_type\":\"hgv\"}")
+                .param("units", "m")
+                .when().log().ifValidationFails()
+                .get(getEndPointName())
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].summary.distance", is(364.3f))
+                .body("routes[0].summary.duration", is(92.7f))
+                .statusCode(200);
+    }
+
 	@Test
 	public void testCarDistanceAndDuration() {
 		// Generic test to ensure that the distance and duration dont get changed

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/EmergencyVehicleEdgeFilter.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/EmergencyVehicleEdgeFilter.java
@@ -58,7 +58,7 @@ public class EmergencyVehicleEdgeFilter implements EdgeFilter {
 		this.restCount = indexValues == null ? 0 : indexValues.length;
 		this.indexValues = indexValues;
 
-		this.buffer = new byte[10];
+		this.buffer = new byte[2];
 
 		this.gsAttributes = GraphStorageUtils.getGraphExtension(graphStorage, EmergencyVehicleAttributesGraphStorage.class);
 	}
@@ -69,13 +69,13 @@ public class EmergencyVehicleEdgeFilter implements EdgeFilter {
 
 		if (restCount != 0 && gsAttributes != null) {
 			if (restCount == 1) {
-				double value = gsAttributes.getEdgeRestrictionValue(edgeId, indexValues[0], buffer);
+				double value = gsAttributes.getEdgeRestrictionValue(edgeId, indexValues[0]);
 				if (value > 0 && value < restrictionValues[0])
 					return false;
 				else
 					return true;
 			} else {
-				if (gsAttributes.getEdgeRestrictionValues(edgeId, buffer, retValues))
+				if (gsAttributes.getEdgeRestrictionValues(edgeId, retValues))
 				{
 					double value = retValues[0];
 					if (value > 0.0f && value < restrictionValues[0])

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/HeavyVehicleEdgeFilter.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/HeavyVehicleEdgeFilter.java
@@ -104,7 +104,7 @@ public class HeavyVehicleEdgeFilter implements DestinationDependentEdgeFilter {
 		this.indexLocs = indexLocs;
 
 		this.vehicleType = vehicleType;
-		this.buffer = new byte[10];
+		this.buffer = new byte[2];
 
 		this.gsHeavyVehicles = GraphStorageUtils.getGraphExtension(graphStorage, HeavyVehicleAttributesGraphStorage.class);
 	}
@@ -249,13 +249,13 @@ public class HeavyVehicleEdgeFilter implements DestinationDependentEdgeFilter {
 
 		if (restCount != 0) {
 			if (restCount == 1) {
-				double value = gsHeavyVehicles.getEdgeRestrictionValue(edgeId, indexValues[0], buffer);
+				double value = gsHeavyVehicles.getEdgeRestrictionValue(edgeId, indexValues[0]);
 				if (value > 0 && value < restrictionValues[indexLocs[0]])
 					return false;
 				else
 					return true;
 			} else {
-				if (gsHeavyVehicles.getEdgeRestrictionValues(edgeId, buffer, retValues))
+				if (gsHeavyVehicles.getEdgeRestrictionValues(edgeId, retValues))
 				{
 					for(int i=0; i<restCount; i++) {
 						double value = retValues[indexLocs[i]];

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
@@ -185,9 +185,6 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 						if (parsedValue > 0) {
 							_restrictionValues[valueIndex] = parsedValue;
 							_hasRestrictionValues = true;
-							//if (parsedValue > 12.7) System.out.println(way.getId() + " " + key +  " " + parsedValue);
-							if (parsedValue % 0.1 < 0.099 && parsedValue % 0.1 > 0.001) System.out.println(way.getId() + " " + key +  " " + parsedValue);
-
 						}
 					}
 				}

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
@@ -181,8 +181,14 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 						if (parsedValue == -1)
 							parsedValue = parseDouble(value);
 
-						_restrictionValues[valueIndex] = parsedValue;
-						_hasRestrictionValues = true;
+						// it was possible to extract a reasonable value
+						if (parsedValue > 0) {
+							_restrictionValues[valueIndex] = parsedValue;
+							_hasRestrictionValues = true;
+							//if (parsedValue > 12.7) System.out.println(way.getId() + " " + key +  " " + parsedValue);
+							if (parsedValue % 0.1 < 0.099 && parsedValue % 0.1 > 0.001) System.out.println(way.getId() + " " + key +  " " + parsedValue);
+
+						}
 					}
 				}
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #263.

### Information about the changes

In order to address the problem with handling large dimension/weight restriction values such as [`maxaxleload=22.5`](https://taginfo.openstreetmap.org/tags/?key=maxaxleload&value=22.5) I increased the external storage dedicated for each of the `maxheight`, `maxwidth`, `maxlength`, `maxweight` and `maxaxleload` restrictions from one to two bytes. In the new approach the OSM string values  are stored as `short`s after being parsed to doubles and multiplied by 100. This allows to cover a range from 0 to 327.67 with a resolution of 0.01 across the whole range accommodating for values such as [`maxwidth=2.49`](https://taginfo.openstreetmap.org/tags/?key=maxwidth&value=2.49). The increased accuracy will also improve handling of values originally provided in imperial units.

The total amount of space allocated per entry (edge) increased from 8 bytes to 12 bytes so an increase of `ext_hgv` file size by around 50% is expected. 

In addition, I refactored some of the code parsing OSM tag value string to numeric values to avoid any `string`->`double`->`string` conversion present in the original approach.

As a bonus I convert incorrect decimal separator `,` to `.` because this seems to be a quite common number formatting mistake, see https://ask.openrouteservice.org/t/problem-with-maxweight-tag/100/4.

### Examples and reasons for differences between live ORS routes and those generated from this pull request

As an example consider [passing Fridewald](https://maps.openrouteservice.org/directions?n1=50.884423&n2=9.853814&n3=15&a=50.874742,9.834094,50.894128,9.873362&b=4a&c=0&f1=20&k1=en-US&k2=km). The default route leads through the [village road](https://www.openstreetmap.org/way/191736769) with `maxweigh=16`. The weight limit was not picked up by the old implementation (blue route) but is being now (red route).

<img width="720" alt="image" src="https://user-images.githubusercontent.com/6545356/49296297-22cfbe80-f4b8-11e8-9264-92f98962085c.png">

<img width="866" alt="image" src="https://user-images.githubusercontent.com/6545356/49296476-b1dcd680-f4b8-11e8-8f3e-8dd3bcb684f4.png">