### PR TITLE
Bugfix #235/access restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed API Test to consider the new ParameterValueException (while fixing Issue #291)
 - Improved range and resolution of values encoding dimension/weight road restrictions in order to properly resolve them when corresponding hgv parameters are set (fixes issue #263)
 - Fixed empty BBox error if the route is located in the southern hemisphere (Issue #348)
+- Take into account access restrictions specific to hgv subprofiles (fixes issue #235)
 ### Changed
 ### Deprecated
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/HeavyVehicleAttributes.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/HeavyVehicleAttributes.java
@@ -23,6 +23,7 @@ public class HeavyVehicleAttributes {
 	public static final int AGRICULTURE = 8;
 	public static final int FORESTRY = 16;
 	public static final int DELIVERY = 32;
+	public static final int ANY = GOODS | HGV | BUS | AGRICULTURE | FORESTRY | DELIVERY;
 	// Load characteristics
 	public static final int HAZMAT = 128;
 	

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -31,8 +31,6 @@ public class HeavyVehicleFlagEncoder extends ORSAbstractFlagEncoder
 {
     protected final HashSet<String> forwardKeys = new HashSet<String>(5);
     protected final HashSet<String> backwardKeys = new HashSet<String>(5);
-    protected final HashSet<String> noValues = new HashSet<String>(5);
-    protected final HashSet<String> yesValues = new HashSet<String>(5);
     protected final List<String> hgvAccess = new ArrayList<String>(5);
 
     // Take into account acceleration calculations when determining travel speed
@@ -73,15 +71,21 @@ public class HeavyVehicleFlagEncoder extends ORSAbstractFlagEncoder
         super(speedBits, speedFactor, maxTurnCosts);
         restrictions.addAll(Arrays.asList("motorcar", "motor_vehicle", "vehicle", "access"));
         restrictedValues.add("private");
-        restrictedValues.add("agricultural");
-        restrictedValues.add("forestry");
         restrictedValues.add("no");
         restrictedValues.add("restricted");
-        restrictedValues.add("delivery");
+        restrictedValues.add("military");
 
         intendedValues.add("yes");
         intendedValues.add("permissive");
-        
+        intendedValues.add("designated");
+
+        intendedValues.add("agricultural");
+        intendedValues.add("forestry");
+        intendedValues.add("delivery");
+        intendedValues.add("bus");
+        intendedValues.add("hgv");
+        intendedValues.add("goods");
+
         hgvAccess.addAll(Arrays.asList("hgv", "goods", "bus", "agricultural", "forestry", "delivery"));
 
         potentialBarriers.add("gate");
@@ -178,13 +182,7 @@ public class HeavyVehicleFlagEncoder extends ORSAbstractFlagEncoder
         backwardKeys.add("agricultural:backward");
         backwardKeys.add("forestry:backward");
         backwardKeys.add("delivery:backward");
-        
-        noValues.add("no");
-        noValues.add("-1");
-        
-        yesValues.add("yes");
-        yesValues.add("1");
-        
+
         init();
     }
     

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
@@ -51,6 +51,10 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 	private double[] _restrictionValues = new double[VehicleDimensionRestrictions.Count];
 	private List<String> _motorVehicleRestrictions = new ArrayList<String>(5);
 	private Set<String> _motorVehicleRestrictedValues = new HashSet<String>(5);
+	private Set<String> _motorVehicleHgvValues = new HashSet<String>(6);
+
+	private Set<String> _noValues = new HashSet<String>(5);
+	private Set<String> _yesValues = new HashSet<String>(5);
 	private Pattern _patternHeight;
 
 	public HeavyVehicleGraphStorageBuilder()
@@ -61,7 +65,12 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 		_motorVehicleRestrictedValues.add("no");
 		_motorVehicleRestrictedValues.add("restricted");
 		_motorVehicleRestrictedValues.add("military");
-		
+
+		_motorVehicleHgvValues.addAll(Arrays.asList("hgv", "goods", "bus", "agricultural", "forestry", "delivery"));
+
+		_noValues.addAll(Arrays.asList("no", "private"));
+		_yesValues.addAll(Arrays.asList("yes", "designated"));
+
 		_patternHeight = Pattern.compile("(?:\\s*(\\d+)\\s*(?:feet|ft\\.|ft|'))?(?:(\\d+)\\s*(?:inches|in\\.|in|''|\"))?");
 	}
 	
@@ -99,16 +108,23 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 		boolean hasHighway = way.hasTag("highway");
 
 		if (hasHighway) {
-			// restrict all types if there are any generic motor vehicle restrictions
-			if (way.hasTag(_motorVehicleRestrictions, _motorVehicleRestrictedValues)) {
-				_hgvType |= HeavyVehicleAttributes.BUS;
-				_hgvType |= HeavyVehicleAttributes.AGRICULTURE;
-				_hgvType |= HeavyVehicleAttributes.FORESTRY;
-				_hgvType |= HeavyVehicleAttributes.DELIVERY;
-				_hgvType |= HeavyVehicleAttributes.GOODS;
-				_hgvType |= HeavyVehicleAttributes.HGV;
+			// process motor vehicle restrictions before any more specific vehicle type tags which override the former
+
+			// if there are any generic motor vehicle restrictions restrict all types...
+			if (way.hasTag(_motorVehicleRestrictions, _motorVehicleRestrictedValues))
+				_hgvType = HeavyVehicleAttributes.ANY;
+
+			//...or all but the explicitly listed ones
+			if (way.hasTag(_motorVehicleRestrictions, _motorVehicleHgvValues)) {
+				int flag = 0;
+				for (String key : _motorVehicleRestrictions) {
+					String val = way.getTag(key);
+					if (_motorVehicleHgvValues.contains(val))
+						flag |= HeavyVehicleAttributes.getFromString(val);
+				}
+				_hgvType = HeavyVehicleAttributes.ANY & ~flag;
 			}
-			
+
 			Iterator<Entry<String, Object>> it = way.getProperties();
 
 			while (it.hasNext()) {
@@ -176,52 +192,25 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 					}
 				}
 
-				// TODO: the following implementation does not pick up access:destination
-				String hgvTag = getHeavyVehicleValue(key, "hgv", value);
-				String goodsTag = getHeavyVehicleValue(key, "goods", value);
-				String busTag = getHeavyVehicleValue(key, "bus", value);
-				String agriculturalTag = getHeavyVehicleValue(key, "agricultural", value);
-				String forestryTag = getHeavyVehicleValue(key, "forestry", value);
-				String deliveryTag = getHeavyVehicleValue(key, "delivery", value);
+				if (_motorVehicleHgvValues.contains(key)) {
+					// TODO: the following implementation does not pick up access:destination
+					String hgvTag = getHeavyVehicleValue(key, "hgv", value);
+					String goodsTag = getHeavyVehicleValue(key, "goods", value);
+					String busTag = getHeavyVehicleValue(key, "bus", value);
+					String agriculturalTag = getHeavyVehicleValue(key, "agricultural", value);
+					String forestryTag = getHeavyVehicleValue(key, "forestry", value);
+					String deliveryTag = getHeavyVehicleValue(key, "delivery", value);
 
-				String accessTag = key.equals("access") ? value : null;
-
-				if (!Helper.isEmpty(accessTag)) {
-					if ("agricultural".equals(accessTag))
-						agriculturalTag = "yes";
-					else if ("forestry".equals(accessTag))
-						forestryTag = "yes";
-					else if ("bus".equals(accessTag))
-						busTag = "yes";
+					setFlagsFromTag(goodsTag, HeavyVehicleAttributes.GOODS);
+					setFlagsFromTag(hgvTag, HeavyVehicleAttributes.HGV);
+					setFlagsFromTag(busTag, HeavyVehicleAttributes.BUS);
+					setFlagsFromTag(agriculturalTag, HeavyVehicleAttributes.AGRICULTURE);
+					setFlagsFromTag(forestryTag, HeavyVehicleAttributes.FORESTRY);
+					setFlagsFromTag(deliveryTag, HeavyVehicleAttributes.DELIVERY);
 				}
-
-				String motorVehicle = key.equals("motor_vehicle") ? value : null;
-				if (motorVehicle == null)
-					motorVehicle = key.equals("motorcar") ? value : null;
-
-				if (motorVehicle != null) {
-					if ("agricultural".equals(motorVehicle))
-						agriculturalTag = "yes";
-					else if ("forestry".equals(motorVehicle))
-						forestryTag = "yes";
-					else if ("delivery".equals(motorVehicle))
-						deliveryTag = "yes";
-				}
-
-				setFlagsFromTag(goodsTag, HeavyVehicleAttributes.GOODS);
-				setFlagsFromTag(hgvTag, HeavyVehicleAttributes.HGV);
-				setFlagsFromTag(busTag, HeavyVehicleAttributes.BUS);
-				setFlagsFromTag(agriculturalTag, HeavyVehicleAttributes.AGRICULTURE);
-				setFlagsFromTag(forestryTag, HeavyVehicleAttributes.FORESTRY);
-				setFlagsFromTag(deliveryTag, HeavyVehicleAttributes.DELIVERY);
-
-				String hazmatTag = key.equals("hazmat") ? value : null;
-				if ("no".equals(hazmatTag)) {
+				else if (key.equals("hazmat") && "no".equals(value)) {
 					_hgvType |= HeavyVehicleAttributes.HAZMAT;
 				}
-
-				// (access=no) + access:conditional=delivery @
-				// (07:00-11:00); customer @ (07:00-17:00)
 			}
 		}
 	}
@@ -237,15 +226,15 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 	    }
 	}
 
-	private String getHeavyVehicleValue(String key, String hv, String value)
-	{
-		if (value.equals(hv) || (key.equals(hv) && ("yes".equals(value) || "no".equals(value))))
-			return value;
-		else 
-		{
-			if (key.equals(hv+":forward") || key.equals(hv+":backward"))
-				return value;
+	private String getHeavyVehicleValue(String key, String hv, String value) {
+		if (key.equals(hv)) {
+			if (_yesValues.contains(value))
+				return "yes";
+			else if (_noValues.contains(value))
+				return "no";
 		}
+		else if (key.equals(hv+":forward") || key.equals(hv+":backward"))
+			return value;
 		
 		return null;
 	}

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
@@ -227,7 +227,9 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 	}
 
 	private String getHeavyVehicleValue(String key, String hv, String value) {
-		if (key.equals(hv)) {
+		if (value.equals(hv))
+			return value;
+		else if (key.equals(hv)) {
 			if (_yesValues.contains(value))
 				return "yes";
 			else if (_noValues.contains(value))


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #235 .

### Information about the changes
- Key functionality added:

Allow driving on hgv subprofile-specific roads, such as ones tagged with `access=agricultural`.

- Reason for change: 

Roads with restricted traffic were discarded from base graph already by the `HeavyVehicleFlagEncoder` preventing them from being further processed in `HeavyVehicleStorageBuilder` and later considered when evaluating access restrictions in `HeavyVehicleEdgeFilter`.

### Examples and reasons for differences between live ORS routes and those generated from this pull request

Now hgv subtypes may use their profile-specific roads, such as ones tagged with `access=agricultural`. As an example let's focus on `vehicle_type=agricultural`. Compared to previous behaviour (blue route) this may lead to shortcuts (red route) in [micro-scale](https://www.openstreetmap.org/way/35869032) ...

<img width="596" alt="image" src="https://user-images.githubusercontent.com/6545356/49415244-5d667f00-f776-11e8-8890-51af0a565862.png">

[small-scale](https://www.openstreetmap.org/way/33097398) ...

<img width="559" alt="image" src="https://user-images.githubusercontent.com/6545356/49415475-2a70bb00-f777-11e8-9a0a-08839fe0a1fe.png">

or even [large-scale](https://www.openstreetmap.org/way/30478570)

<img width="574" alt="image" src="https://user-images.githubusercontent.com/6545356/49415353-b2a29080-f776-11e8-9542-277e868ecc50.png">

