### PR TITLE
Bugfix #358/tolls hgv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improved range and resolution of values encoding dimension/weight road restrictions in order to properly resolve them when corresponding hgv parameters are set (fixes issue #263)
 - Fixed empty BBox error if the route is located in the southern hemisphere (Issue #348)
 - Take into account access restrictions specific to hgv subprofiles (fixes issue #235)
+- Properly resolve all tolls, especially hgv-specific ones (fixes issue #358)
 ### Changed
 - Allowed access for cars and hgvs on access=destination roads (Issue #342)
 ### Deprecated

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/services/routing/ResultTest.java
@@ -787,10 +787,16 @@ http://localhost:8080/ors/routes?
 				.assertThat()
 				.body("any { it.key == 'routes' }", is(true))
 				.body("routes[0].containsKey('extras')", is(true))
-				.body("routes[0].extras.tollways.values.size()", is(1))
+				.body("routes[0].extras.tollways.values.size()", is(3))
 				.body("routes[0].extras.tollways.values[0][0]", is(0))
-				.body("routes[0].extras.tollways.values[0][1]", is(86))
+				.body("routes[0].extras.tollways.values[0][1]", is(52))
 				.body("routes[0].extras.tollways.values[0][2]", is(0))
+                .body("routes[0].extras.tollways.values[1][0]", is(52))
+                .body("routes[0].extras.tollways.values[1][1]", is(66))
+                .body("routes[0].extras.tollways.values[1][2]", is(1))
+                .body("routes[0].extras.tollways.values[2][0]", is(66))
+                .body("routes[0].extras.tollways.values[2][1]", is(86))
+                .body("routes[0].extras.tollways.values[2][2]", is(0))
 				.statusCode(200);
 
 		checkExtraConsistency(response);

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
@@ -32,6 +32,11 @@ public class TollwayType {
 
 	public static final int General = M | N;
 
+	// OSM classification
+	public static final int Motorcar = M1;
+	public static final int Goods = N1;
+	public static final int Hgv = N2 | N3;
+
     public static boolean isSet(int flag, int value) {
         return (flag & value) == flag;
     }

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
@@ -14,120 +14,37 @@
 package heigit.ors.routing.graphhopper.extensions;
 
 public class TollwayType {
-	//https://en.wikipedia.org/wiki/Vehicle_category
 
 	public static final int None = 0;
+	public static final int General = ~ None;
 
-	public static final int L = 1;
-	public static final int L1 = 2;
-	public static final int L2 = 4;
-	public static final int L3 = 8;
-	public static final int L4 = 16;
-	public static final int L5 = 32;
-	public static final int L6 = 64;
-	public static final int L7 = 128;
-	
-	public  static final int M = 256;
-	public static final int M1 = 512;
-	public static final int M2 = 1024;
-	public static final int M3 = 2048;
-	
-	public  static final int N = 4096;
-	public static final int N1 = 8192;
-	public static final int N2 = 16384;
-	public static final int N3 = 32768;
-	
-	public static final int O = 65536;
-	public static final int O1 = 131072;
-	public static final int O2 = 262144;
-	public static final int O3 = 524288;
-	public static final int O4 = 1048576;
-	
-	public static final int General = M;
-	
-	public static boolean isLType(int flag)
-	{
-		return TollwayType.isSet(flag, TollwayType.L) || TollwayType.isSet(flag, TollwayType.L1) || TollwayType.isSet(flag, TollwayType.L2) ||
-				TollwayType.isSet(flag, TollwayType.L3) || TollwayType.isSet(flag, TollwayType.L4) || TollwayType.isSet(flag, TollwayType.L5) ||
-				TollwayType.isSet(flag, TollwayType.L6) || TollwayType.isSet(flag, TollwayType.L7);
-	}
-	
-	public static boolean isMType(int flag)
-	{
-		return TollwayType.isSet(flag, TollwayType.M) || TollwayType.isSet(flag, TollwayType.M1) || TollwayType.isSet(flag, TollwayType.M2) ||
-				TollwayType.isSet(flag, TollwayType.M3);
-	}
-	
-	public static boolean isNType(int flag)
-	{
-		return TollwayType.isSet(flag, TollwayType.N) || TollwayType.isSet(flag, TollwayType.N1) || TollwayType.isSet(flag, TollwayType.N2) ||
-				TollwayType.isSet(flag, TollwayType.N3);
-	}
-	
-	public static boolean isOType(int flag)
-	{
-		return TollwayType.isSet(flag, TollwayType.O) || TollwayType.isSet(flag, TollwayType.O1) || TollwayType.isSet(flag, TollwayType.O2) ||
-				TollwayType.isSet(flag, TollwayType.O3) || TollwayType.isSet(flag, TollwayType.O4);
-	}
-	
+	// https://en.wikipedia.org/wiki/Vehicle_category
+
+	public static final int M1 = 1;
+	public static final int M2 = 2;
+	public static final int M3 = 4;
+	public static final int M = M1 | M2 | M3;
+
+	public static final int N1 = 8;
+	public static final int N2 = 16;
+	public static final int N3 = 32;
+
+	public static final int N = N1 | N2 | N3;
+
     public static boolean isSet(int flag, int value) {
         return (flag & value) == value;
     }
 
-	public static int getFromString(String value)
-	{
-		if (value == null)
-			return 0;
-
-		switch(value.toLowerCase())
-		{
-		case "l":
-			return L;
-		case "l1":
-			return L1;
-		case "l2":
-			return L2;
-		case "l3":
-			return L3;
-		case "l4":
-			return L4;
-		case "l5":
-			return L5;
-		case "l6":
-			return L6;
-		case "l7":
-			return L7;
-			
-		case "M":
-			return M;
-		case "M1":
-			return M1;
-		case "M2":
-			return M2;
-		case "M3":
-			return M3;
-			
-		case "N":
-			return N;
-		case "N1":
-			return N1;
-		case "N2":
-			return N2;
-		case "N3":
-			return N3;
-			
-		case "O":
-			return O;
-		case "O1":
-			return O1;
-		case "O2":
-			return O2;
-		case "O3":
-			return O3;
-		case "O4":
-			return O4;
-		}
-
-		return None;
+	public static boolean isType(int flag, int value) {
+		return (flag & value) != 0;
 	}
+
+	public static boolean isMType(int value) {
+		return isType(M, value);
+	}
+
+	public static boolean isNType(int value) {
+		return isType(N, value);
+	}
+
 }

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
@@ -16,7 +16,6 @@ package heigit.ors.routing.graphhopper.extensions;
 public class TollwayType {
 
 	public static final int None = 0;
-	public static final int General = ~ None;
 
 	// https://en.wikipedia.org/wiki/Vehicle_category
 
@@ -30,6 +29,8 @@ public class TollwayType {
 	public static final int N3 = 32;
 
 	public static final int N = N1 | N2 | N3;
+
+	public static final int General = M | N;
 
     public static boolean isSet(int flag, int value) {
         return (flag & value) == value;

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/TollwayType.java
@@ -33,7 +33,7 @@ public class TollwayType {
 	public static final int General = M | N;
 
     public static boolean isSet(int flag, int value) {
-        return (flag & value) == value;
+        return (flag & value) == flag;
     }
 
 	public static boolean isType(int flag, int value) {

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/AvoidFeaturesEdgeFilter.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/AvoidFeaturesEdgeFilter.java
@@ -47,7 +47,7 @@ public class AvoidFeaturesEdgeFilter implements EdgeFilter {
 
 		TollwaysGraphStorage extTollways = GraphStorageUtils.getGraphExtension(graphStorage, TollwaysGraphStorage.class);
 		if (extTollways != null)
-			_tollwayExtractor = new TollwayExtractor(extTollways, searchParams.getVehicleType(), searchParams.getProfileParameters());
+			_tollwayExtractor = new TollwayExtractor(extTollways, searchParams.getProfileType(), searchParams.getProfileParameters());
 	}
 
 	@Override

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/TollwaysGraphStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/TollwaysGraphStorage.java
@@ -27,15 +27,15 @@ public class TollwaysGraphStorage implements GraphExtension {
 	protected int edgeEntryIndex = 0;
 	protected int edgeEntryBytes;
 	protected int edgesCount; 
-	private byte[] byteValues;
+	private byte[] byteValue;
 
 	public TollwaysGraphStorage() 
 	{
-		EF_TOLLWAYS = nextBlockEntryIndex (4);
+		EF_TOLLWAYS = nextBlockEntryIndex (1);
 
 		edgeEntryBytes = edgeEntryIndex;
 		edgesCount = 0;
-		byteValues = new byte[4];
+		byteValue = new byte[1];
 	}
 
 	public void init(Graph graph, Directory dir) {
@@ -94,23 +94,16 @@ public class TollwaysGraphStorage implements GraphExtension {
 	public void setEdgeValue(int edgeId, int value) {
 		edgesCount++;
 		ensureEdgesIndex(edgeId);
-
-		long edgePointer = (long) edgeId * edgeEntryBytes;
  
-		byteValues[0] = (byte)(value >> 24);
-		byteValues[1] = (byte)(value >> 16);
-		byteValues[2] = (byte)(value >> 8);
-		byteValues[3] = (byte)(value & 0xff);
-		
-		edges.setBytes(edgePointer + EF_TOLLWAYS, byteValues, 4);
+		byteValue[0] = (byte) value;
+
+		edges.setBytes((long) edgeId * edgeEntryBytes + EF_TOLLWAYS, byteValue, 1);
 	}
 
-	public int getEdgeValue(int edgeId, byte[] buffer) {
-		long edgeBase = (long) edgeId * edgeEntryBytes;
+	public int getEdgeValue(int edgeId) {
+		edges.getBytes((long) edgeId * edgeEntryBytes + EF_TOLLWAYS, byteValue, 1);
 		
-		edges.getBytes(edgeBase + EF_TOLLWAYS, buffer, 4);
-		
-		return buffer[0] << 24 | (buffer[1] & 0xFF) << 16 | (buffer[2] & 0xFF) << 8 | (buffer[3] & 0xFF);
+		return byteValue[0] & 0xFF;
 	}
 
 	public boolean isRequireNodeField() {

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/TollwaysGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/TollwaysGraphStorageBuilder.java
@@ -58,9 +58,9 @@ public class TollwaysGraphStorageBuilder extends AbstractGraphStorageBuilder
 							setFlag(TollwayType.General, value);
 							break;
 						case "toll:hgv":
-							setFlag(TollwayType.N, value);
+							setFlag(TollwayType.Hgv, value);
 							break;
-						case "toll:N1":
+						case "toll:N1": //currently not used in OSM
 							setFlag(TollwayType.N1, value);
 							break;
 						case "toll:N2":
@@ -70,7 +70,7 @@ public class TollwaysGraphStorageBuilder extends AbstractGraphStorageBuilder
 							setFlag(TollwayType.N3, value);
 							break;
 						case "toll:motorcar":
-							setFlag(TollwayType.M1, value);
+							setFlag(TollwayType.Motorcar, value);
 						default:
 							break;
 					}

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/TollwaysGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/TollwaysGraphStorageBuilder.java
@@ -29,11 +29,11 @@ public class TollwaysGraphStorageBuilder extends AbstractGraphStorageBuilder
 {
 	private TollwaysGraphStorage _storage;
 	private int _tollways;
-	private List<String> _tollTags = new ArrayList<String>(7);
+	private List<String> _tollTags = new ArrayList<String>(6);
 	
-	public TollwaysGraphStorageBuilder()
-	{
-		_tollTags.addAll(Arrays.asList("toll", "toll:hgv", "toll:N1", "toll:N2", "toll:N3",  "toll:class", "toll:hgv:class"));
+	public TollwaysGraphStorageBuilder() {
+		// Currently consider only toll tags relevant to cars or hgvs:
+		_tollTags.addAll(Arrays.asList("toll", "toll:hgv", "toll:N1", "toll:N2", "toll:N3",  "toll:motorcar"));
 	}
 
 	public GraphExtension init(GraphHopper graphhopper) throws Exception {
@@ -48,78 +48,50 @@ public class TollwaysGraphStorageBuilder extends AbstractGraphStorageBuilder
 	public void processWay(ReaderWay way) {
 		_tollways = TollwayType.None;
 
-		String tollKey = null;
-		String tollValue = null;
-		
 		for (String key : _tollTags) {
-			if (way.hasTag(key))
-			{
-				tollKey = key;
-				tollValue = way.getTag(key);
-				break;
-			}
-		} 
-		
-		/*
-        toll=yes
-		toll:class= L1, L2, ....M 
-		toll:hgv=yes
-		toll:hgv:class=N1, N2, N3 
-        */
-		if (tollValue != null && !tollValue.equals("no"))
-		{
-			switch(tollKey)
-			{
-			case "toll":
-				_tollways = TollwayType.General;
-				break;
-			case "toll:hgv":
-				_tollways = TollwayType.N;
-				break;
-			case "toll:N1":
-				_tollways = TollwayType.N1;
-				break;
-			case "toll:N2":
-				_tollways = TollwayType.N2;
-				break;
-			case "toll:N3":
-				_tollways = TollwayType.N3;
-				break;
-			case "toll:hgv:class":
-				if (tollValue.equals("yes"))
-					_tollways = TollwayType.N;
-				else
-					_tollways = getTollValues(tollValue);
-				break;
-			case "toll:class":
-				_tollways = getTollValues(tollValue);
-				break;
-			default:
-				_tollways = TollwayType.getFromString(tollValue);
-				break;
+			if (way.hasTag(key)) {
+				String value = way.getTag(key);
+
+				if (value != null) {
+					switch(key) {
+						case "toll":
+							setFlag(TollwayType.General, value);
+							break;
+						case "toll:hgv":
+							setFlag(TollwayType.N, value);
+							break;
+						case "toll:N1":
+							setFlag(TollwayType.N1, value);
+							break;
+						case "toll:N2":
+							setFlag(TollwayType.N2, value);
+							break;
+						case "toll:N3":
+							setFlag(TollwayType.N3, value);
+							break;
+						case "toll:motorcar":
+							setFlag(TollwayType.M1, value);
+						default:
+							break;
+					}
+				}
 			}
 		}
-	}
-	
-	private int getTollValues(String value)
-	{
-		if (value.contains(","))
-		{
-			int res = TollwayType.None;
-			String[] values = value.split(",");
-			for (String v : values)
-			{
-				res |= TollwayType.getFromString(v.trim());
-			}
-			
-			return res;
-		}
-		
-		return TollwayType.getFromString(value);
+
 	}
 
-	public void processEdge(ReaderWay way, EdgeIteratorState edge)
-	{ 
+	private void setFlag(int flag, String value) {
+		switch(value) {
+			case "yes":
+				_tollways |= flag;
+				break;
+			case "no":
+				_tollways &= ~flag;
+				break;
+		}
+	}
+
+	public void processEdge(ReaderWay way, EdgeIteratorState edge) {
 		_storage.setEdgeValue(edge.getEdge(), _tollways);
 	}
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
@@ -150,7 +150,7 @@ public class ExtraInfoProcessor extends PathProcessor {
 			
 			_tollwaysInfo = new RouteExtraInfo("tollways");
 			_tollwaysInfoBuilder = new SimpleRouteExtraInfoBuilder(_tollwaysInfo);
-			_tollwayExtractor = new TollwayExtractor(_extTollways, req.getSearchParameters().getVehicleType(), req.getSearchParameters().getProfileParameters());
+			_tollwayExtractor = new TollwayExtractor(_extTollways, req.getSearchParameters().getProfileType(), req.getSearchParameters().getProfileParameters());
 		}
 
 		if (RouteExtraInfoFlag.isSet(extraInfo, RouteExtraInfoFlag.TrailDifficulty))

--- a/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
@@ -41,10 +41,10 @@ public class TollwayExtractor {
 		int value = _storage.getEdgeValue(edgeId);
 
 		switch (value) {
-			// toll:no
+			// toll=no
 			case TollwayType.None:
 				return 0;
-			// toll: yes
+			// toll=yes
 			case TollwayType.General:
 				return 1;
 			default:

--- a/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
@@ -51,15 +51,15 @@ public class TollwayExtractor {
 				switch(_profileType) {
 					// toll:motorcar
 					case RoutingProfileType.DRIVING_CAR:
-						return TollwayType.isSet(TollwayType.M1, value) ? 1 : 0;
+						return TollwayType.isSet(TollwayType.Motorcar, value) ? 1 : 0;
 
 					case RoutingProfileType.DRIVING_HGV:
 						// toll:hgv
-						if (TollwayType.isSet(TollwayType.N, value))
+						if (TollwayType.isSet(TollwayType.Hgv, value))
 							return 1;
 
 						// check for weight specific toll tags even when weight is unset
-						double weight = _vehicleParams.getWeight();
+						double weight = _vehicleParams==null ? 0 : _vehicleParams.getWeight();
 						if (weight == 0 && TollwayType.isNType(value))
 							return 1;
 							//Check in which weight range the hgv falls and return accordingly

--- a/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
@@ -13,6 +13,7 @@
  */
 package heigit.ors.routing.pathprocessors;
 
+import heigit.ors.routing.RoutingProfileType;
 import heigit.ors.routing.graphhopper.extensions.HeavyVehicleAttributes;
 import heigit.ors.routing.graphhopper.extensions.TollwayType;
 import heigit.ors.routing.graphhopper.extensions.storages.TollwaysGraphStorage;
@@ -21,19 +22,18 @@ import heigit.ors.routing.parameters.VehicleParameters;
 
 public class TollwayExtractor {
 	private VehicleParameters _vehicleParams;
-	private int _vehicleType;
+	private int _profileType;
 	private TollwaysGraphStorage _storage;
 	private byte[] _buffer = new byte[4];
 
-	public TollwayExtractor(TollwaysGraphStorage storage, int vehicleType, ProfileParameters vehicleParams) {
+	public TollwayExtractor(TollwaysGraphStorage storage, int profileType, ProfileParameters vehicleParams) {
 		_storage = storage;
-		_vehicleType = vehicleType;
+		_profileType = profileType;
 		if (vehicleParams instanceof VehicleParameters)
 			_vehicleParams = (VehicleParameters) vehicleParams;
 	}
 	/**
-	 * return if a way is a tollway for the configured vehicle. If _vehicleType != 0, it is a heavy vehicle.
-	 * If it is a heavy vehicle and weight parameter is provided, return the toll attribute based on the weight
+	 * return if a way is a tollway for the configured vehicle.
 	 *
 	 * @param edgeId				The edgeId for which toll should be checked
 	 * @see HeavyVehicleAttributes
@@ -41,35 +41,45 @@ public class TollwayExtractor {
 	public int getValue(int edgeId) {
 		int value = _storage.getEdgeValue(edgeId, _buffer);
 
-		if (value != TollwayType.None) {
-
-			// Check if "toll=yes" is present. If no and you're a car, you're good to go
-			if (TollwayType.isLType(value) || TollwayType.isMType(value))
-				return 1;
-			if (_vehicleType == 0)
+		switch (value) {
+			// toll:no
+			case TollwayType.None:
 				return 0;
-
-			//Check if tag "toll:hgv" is present -> assume toll for any hgv type
-			if (TollwayType.isNType(value) && value == TollwayType.N)
+			// toll: yes
+			case TollwayType.General:
 				return 1;
+			default:
+				switch(_profileType) {
+					// toll:motorcar
+					case RoutingProfileType.DRIVING_CAR:
+						return TollwayType.isSet(TollwayType.M1, value) ? 1 : 0;
 
-			//Check if weight specific toll tags are present even though the weight is unset
-			double weight = _vehicleParams.getWeight();
-			if (weight == 0 && TollwayType.isNType(value))
-					return 1;
-			//Check in which weight range the hgv falls and return accordingly
-			//toll:N1=yes - Für Fahrzeuge bis 3,5 Tonnen eingesetzt, Bsp. Pick-up-Truck. (siehe Europäische Fahrzeugklassifikation N1)
-			//toll:N2=yes - Für Fahrzeuge von 3,5 Tonnen bis zu 12 Tonnen eingesetzt, Bsp. Commercial Truck.
-			//toll:N3=yes Für LKW mit einem zulässigen Gesamtgewicht > 12 t
-			else {
-				if (weight < 3.5 && value == TollwayType.N1)
-					return 1;
-				else if (weight >= 3.5 && weight < 12 && value == TollwayType.N2)
-					return 1;
-				else if (weight >= 12 && value == TollwayType.N3)
-					return 1;
-			}
+					case RoutingProfileType.DRIVING_HGV:
+						// toll:hgv
+						if (TollwayType.isSet(TollwayType.N, value))
+							return 1;
+
+						// check for weight specific toll tags even when weight is unset
+						double weight = _vehicleParams.getWeight();
+						if (weight == 0 && TollwayType.isNType(value))
+							return 1;
+							//Check in which weight range the hgv falls and return accordingly
+							//toll:N1=yes - Für Fahrzeuge bis 3,5 Tonnen eingesetzt, Bsp. Pick-up-Truck. (siehe Europäische Fahrzeugklassifikation N1)
+							//toll:N2=yes - Für Fahrzeuge von 3,5 Tonnen bis zu 12 Tonnen eingesetzt, Bsp. Commercial Truck.
+							//toll:N3=yes Für LKW mit einem zulässigen Gesamtgewicht > 12 t
+						else {
+							if (weight < 3.5 && TollwayType.isSet(TollwayType.N1, value))
+								return 1;
+							else if (weight >= 3.5 && weight < 12 && TollwayType.isSet(TollwayType.N2, value))
+								return 1;
+							else if (weight >= 12 && TollwayType.isSet(TollwayType.N3, value))
+								return 1;
+						}
+					default:
+						return 0;
+				}
 		}
-		return 0;
+
 	}
+
 }

--- a/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/pathprocessors/TollwayExtractor.java
@@ -24,7 +24,6 @@ public class TollwayExtractor {
 	private VehicleParameters _vehicleParams;
 	private int _profileType;
 	private TollwaysGraphStorage _storage;
-	private byte[] _buffer = new byte[4];
 
 	public TollwayExtractor(TollwaysGraphStorage storage, int profileType, ProfileParameters vehicleParams) {
 		_storage = storage;
@@ -39,7 +38,7 @@ public class TollwayExtractor {
 	 * @see HeavyVehicleAttributes
 	 */
 	public int getValue(int edgeId) {
-		int value = _storage.getEdgeValue(edgeId, _buffer);
+		int value = _storage.getEdgeValue(edgeId);
 
 		switch (value) {
 			// toll:no


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #358.

### Information about the changes

- Key functionality added:

Tolls are now determined based on the routing profile so in order for things to work there is no need to specify `vehicle_type` for HGV anymore.

Moreover, the `TollwaysGraphStorageBuilder` picks up any toll-specific tags, not just the first one encountered as it was the case in the previous approach. This allows to correctly deal with situations such as [here](https://www.openstreetmap.org/way/22765611) where next to a general tag `toll=no` a more detailed one `toll:hgv=yes` is present.

Because there are only a handful of toll tags relevant to the driving profiles, it was possible to reduce the total amount of space allocated per entry (edge) from 4 bytes to just one byte so a decrease of `ext_tolls` file size by a factor of 4 is expected.

- Reason for change: 

HGV tolls were resolved based on the presence of `vehicle_type` parameter rather than on the routing profile. This lead to tolls not being picked up unless `vehicle_type` was specified even though it's value was anyway not taken into account when extracting the tolls. On top of this combinations of toll tags were not parsed, just the first encountered tag.

### Examples and reasons for differences between live ORS routes and those generated from this pull request

Results for `driving-car` unlike for `driving-hgv` are in general not expected to change. For the latter around 1/3 off random routes on DACH are affected. This is because the toll data now being taken into account is more complete which is reflected either in additional entries in tolls extra info, or in different routes returned for `avoid_features=tollways`.

As an example consider driving hgv with `avoid_features=tollways` on the following [route](https://maps.openrouteservice.org/directions?n1=51.004353&n2=12.377365&n3=9&a=50.4217,12.638499,51.577923,11.895447&b=4a&c=0&k1=en-US&k2=km). The previous route (blue) changes (red) because now roads tagged with [`toll:N3`](https://overpass-turbo.eu/s/Emu) are being discarded.

![image](https://user-images.githubusercontent.com/6545356/49657006-ef081200-fa3e-11e8-8fee-859cda5ae332.png)

