### PR TITLE
Bugfix #382/innacurate small isochrones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 ### Changed
 - Updated rural speed limit in France to be 80km/h (Issue #355)
+- Modified smoothing and buffer distances for small isochrones, aswell as other fixes for smaller isochrones (Issue #382)
 ### Deprecated
 
 ## [4.7.2] - 2018-12-10

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/services/isochrones/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/services/isochrones/ResultTest.java
@@ -59,7 +59,7 @@ public class ResultTest extends ServiceTest {
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].geometry.coordinates[0].size()", is(33))
+                .body("features[0].geometry.coordinates[0].size()", is(52))
                 //.body("features[0].geometry.coordinates[0].size()", is(30))
                 .body("features[0].properties.center.size()", is(2))
                 //.body("bbox", hasItems(8.662622f, 49.40911f, 8.695994f, 49.440487f))
@@ -111,13 +111,13 @@ public class ResultTest extends ServiceTest {
                 .param("profile", getParameter("profile"))
                 .param("range", "400")
                 .param("attributes", "reachfactor|area")
-                .when()
+                .when().log().all()
                 .get(getEndPointName())
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].properties.area", is(both(greaterThan(6614000f)).and(lessThan(6620000f))))
-                .body("features[0].properties.reachfactor", is(0.1895f))
+                .body("features[0].properties.area", is(both(greaterThan(6110000f)).and(lessThan(6120000f))))
+                .body("features[0].properties.reachfactor", is(0.1752f))
                 .statusCode(200);
     }
 
@@ -135,8 +135,8 @@ public class ResultTest extends ServiceTest {
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].properties.area", is(both(greaterThan(6614000f)).and(lessThan(6620000f))))
-                .body("features[0].properties.reachfactor", is(0.1895f))
+                .body("features[0].properties.area", is(both(greaterThan(6110000f)).and(lessThan(6120000f))))
+                .body("features[0].properties.reachfactor", is(0.1752f))
                 .statusCode(200);
     }
 
@@ -154,8 +154,8 @@ public class ResultTest extends ServiceTest {
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].properties.area", is(both(greaterThan(6.6f)).and(lessThan(6.7f))))
-                .body("features[0].properties.reachfactor", is(0.1895f))
+                .body("features[0].properties.area", is(both(greaterThan(6.11f)).and(lessThan(6.12f))))
+                .body("features[0].properties.reachfactor", is(0.1752f))
                 .statusCode(200);
     }
 
@@ -175,7 +175,7 @@ public class ResultTest extends ServiceTest {
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].properties.area", is(both(greaterThan(6.6f)).and(lessThan(6.7f))))
+                .body("features[0].properties.area", is(both(greaterThan(6.11f)).and(lessThan(6.12f))))
                 .statusCode(200);
     }
 
@@ -193,8 +193,8 @@ public class ResultTest extends ServiceTest {
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].properties.area", is(both(greaterThan(2.5f)).and(lessThan(2.6f))))
-                .body("features[0].properties.reachfactor", is(0.1895f))
+                .body("features[0].properties.area", is(both(greaterThan(2.36f)).and(lessThan(2.37f))))
+                .body("features[0].properties.reachfactor", is(0.1752f))
                 .statusCode(200);
     }
 
@@ -221,11 +221,11 @@ public class ResultTest extends ServiceTest {
                 .body("features[2].type", is("Feature"))
                 .body("features[2].geometry.type", is("Polygon"))
                 //.body("features[2].geometry.coordinates[0].size()", is(26))
-                .body("features[2].geometry.coordinates[0].size()", is(25))
+                .body("features[2].geometry.coordinates[0].size()", is(35))
                 .body("features[2].properties.contours.size()", is(2))
                 .body("features[2].properties.containsKey('area')", is(true))
                 //.body("features[2].properties.area", is(5824280.5f))
-                .body("features[0].properties.area", is(both(greaterThan(6614000f)).and(lessThan(6620000f))))
+                .body("features[0].properties.area", is(both(greaterThan(6110000f)).and(lessThan(6120000f))))
                 .body("features[2].properties.contours[0][0]", is(0))
                 .body("features[2].properties.contours[0][1]", is(0))
                 .body("features[2].properties.contours[1][0]", is(1))
@@ -276,7 +276,7 @@ public class ResultTest extends ServiceTest {
                 .body("features[2].type", is("Feature"))
                 .body("features[2].geometry.type", is("Polygon"))
                 //.body("features[2].geometry.coordinates[0].size", is(25))
-                .body("features[2].geometry.coordinates[0].size", is(20))
+                .body("features[2].geometry.coordinates[0].size", is(29))
                 .body("features[3].type", is("Feature"))
                 .body("features[3].geometry.type", is("Polygon"))
                 //.body("features[3].geometry.coordinates[0].size", is(33))

--- a/openrouteservice/src/main/java/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -384,7 +384,7 @@ public class ConcaveBallsIsochroneMapBuilder extends AbstractIsochroneMapBuilder
 
 			// ignore all edges that have been considered in the previous step. We do not want to do this for small
 			// isochrones as the edge may have more than one range on it in that case
-			if (minCost < prevCost & isochronesDifference > 1000)
+			if (minCost < prevCost && isochronesDifference > 1000)
 				continue;
 
 			searchWidth = defaultSearchWidth; 

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/WheelchairFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/WheelchairFlagEncoder.java
@@ -31,7 +31,7 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 public class WheelchairFlagEncoder extends AbstractFlagEncoder 
 {
 	static final int SLOW_SPEED = 2;
-    static final int MEAN_SPEED = 4;
+    public static final int MEAN_SPEED = 4;
     static final int FERRY_SPEED = 10;
     static final int MAX_SPEED = 15;
     


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have merged the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config.sample file along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #382  .

### Information about the changes
- Key functionality added: Modifications have been made to the isochrones generation to make smaller ranged isochrones (e.g. minute level and walking) more accurate and realistic
- Reason for change: Buffers and other bugs meant that some times isochrones would give innacurate results, for example showing that the traveller could be on the other side of a river when there were no bridges within the isochrone distance.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
- Isochrones now have some differences because of how calculations are made for smaller isochrones. This should not impact performance for generating isochrones, and differences should be minor yet result in more accurate isochrones.