### PR TITLE
Fix empty error when unkown exception occurs

### DIFF
--- a/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RouteRequestHandler.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RouteRequestHandler.java
@@ -50,7 +50,7 @@ public class RouteRequestHandler extends GenericHandler {
         } catch (StatusCodeException e) {
             throw e;
         } catch (Exception e) {
-            throw new StatusCodeException(RoutingErrorCodes.UNKNOWN);
+            throw new StatusCodeException(StatusCode.INTERNAL_SERVER_ERROR, RoutingErrorCodes.UNKNOWN);
         }
     }
 


### PR DESCRIPTION
Hotfix for an empty response when an unknown exception occured.