### PR TITLE
Restrict simplify geometry to single segment routes

### DIFF
--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/routing/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/routing/ParamsTest.java
@@ -1338,4 +1338,26 @@ public class ParamsTest extends ServiceTest {
                 .body("features[0].properties.warnings[0].containsKey('message')", is(true))
                 .statusCode(200);
     }
+
+    @Test
+	public void expectErrorWithMultiSegmentsAndSimplify() {
+		JSONArray coords = (JSONArray) getParameter("coordinatesShort");
+		coords.put(new JSONArray(new double[] {8.680916, 49.410973}));
+
+		JSONObject body = new JSONObject();
+		body.put("coordinates", coords);
+		body.put("geometry_simplify", true);
+
+		given()
+				.header("Accept", "application/json")
+				.header("Content-Type", "application/json")
+				.pathParam("profile", getParameter("carProfile"))
+				.body(body.toString())
+				.when().log().all()
+				.post(getEndPointPath() + "/{profile}/json")
+				.then().log().all()
+				.assertThat()
+				.body("error.code", is(RoutingErrorCodes.INCOMPATIBLE_PARAMETERS))
+				.statusCode(400);
+	}
 }

--- a/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RouteRequest.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RouteRequest.java
@@ -221,10 +221,11 @@ public class RouteRequest {
     private boolean hasSuppressWarnings = false;
 
     @ApiModelProperty(name = PARAM_SIMPLIFY_GEOMETRY, value = "Specifies whether to simplify the geometry. true will automatically be set to false if extra_info parameter is specified. " +
+            "Simplify geometry cannot be applied to routes with more than one segment and when extra_info is required." +
             "CUSTOM_KEYS:{'apiDefault':false}",
             example = "false")
     @JsonProperty(value = PARAM_SIMPLIFY_GEOMETRY)
-    private Boolean simplifyGeometry = false;
+    private Boolean simplifyGeometry;
     @JsonIgnore
     private boolean hasSimplifyGeometry = false;
 

--- a/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RouteRequestHandler.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RouteRequestHandler.java
@@ -97,6 +97,9 @@ public class RouteRequestHandler extends GenericHandler {
             if (request.hasExtraInfo() && request.getSimplifyGeometry()) {
                 throw new IncompatibleParameterException(RoutingErrorCodes.INCOMPATIBLE_PARAMETERS, RouteRequest.PARAM_SIMPLIFY_GEOMETRY, "true", RouteRequest.PARAM_EXTRA_INFO, "*");
             }
+            if (request.getCoordinates().size() > 2 && request.getSimplifyGeometry()) {
+                throw new IncompatibleParameterException(RoutingErrorCodes.INCOMPATIBLE_PARAMETERS, RouteRequest.PARAM_SIMPLIFY_GEOMETRY, "true", RouteRequest.PARAM_COORDINATES, "count > 2");
+            }
         }
 
         if (request.hasSkipSegments()) {


### PR DESCRIPTION
Updated the API so that it is only possible to use simplify geometry when there is one segment. Requesting to simplify on routes with more than one segment will result in an incompatible parameter error.

This has been introduced as there is an issue in how code in GH handles the points generated for lines, and when simplify is used on multiple segments, it is not possible to update the point list like it is when simplify is not used. This should be looked into properly at a later date, but to get a fix in for the release a restriction is added so that just single segment routes can be simplified