### PR TITLE
Added check to v1 API to restrict geometry simplify to single segment…

### DIFF
--- a/openrouteservice/src/main/java/heigit/ors/services/routing/requestprocessors/RoutingRequestParser.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/routing/requestprocessors/RoutingRequestParser.java
@@ -20,6 +20,7 @@ import heigit.ors.common.StatusCode;
 import heigit.ors.exceptions.*;
 import heigit.ors.localization.LocalizationManager;
 import heigit.ors.routing.*;
+import heigit.ors.routing.pathprocessors.ExtraInfoProcessor;
 import heigit.ors.util.ArraysUtility;
 import heigit.ors.util.CoordTools;
 import heigit.ors.util.DistanceUnitUtil;
@@ -180,6 +181,8 @@ public class RoutingRequestParser
 
 		value = request.getParameter("geometry_simplify");
 		if (!Helper.isEmpty(value))
+			if (req.getCoordinates().length > 2 )
+				throw new IncompatibleParameterException(RoutingErrorCodes.INCOMPATIBLE_PARAMETERS, "geometry_simplify", "true", "coordinates", "count > 2");
             req.setGeometrySimplify(Boolean.parseBoolean(value));
 
 		value = request.getParameter("instructions");

--- a/openrouteservice/src/main/java/heigit/ors/services/routing/requestprocessors/RoutingRequestParser.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/routing/requestprocessors/RoutingRequestParser.java
@@ -20,7 +20,6 @@ import heigit.ors.common.StatusCode;
 import heigit.ors.exceptions.*;
 import heigit.ors.localization.LocalizationManager;
 import heigit.ors.routing.*;
-import heigit.ors.routing.pathprocessors.ExtraInfoProcessor;
 import heigit.ors.util.ArraysUtility;
 import heigit.ors.util.CoordTools;
 import heigit.ors.util.DistanceUnitUtil;


### PR DESCRIPTION
Updating v1 API to return error when geometry_simplify is used in conjunction with routes that have more than one segment.

Fixes #457 