### PR TITLE
Replace packages incompatible with Java >8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable > 2 waypoints when geometry_simplify=true (#457)
 ### Changed
 - Updated pom to always build ors.war (Issue #432)
+- Replace usage of packages incompatible with Java >8 (#474)
 ### Deprecated
 -
 

--- a/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RequestProfileParamsWeightings.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/routing/RequestProfileParamsWeightings.java
@@ -15,11 +15,11 @@
 
 package heigit.ors.api.requests.routing;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 
 @ApiModel(value = "Profile Weightings", parent = RequestProfileParams.class, description = "Describe additional weightings to be applied to edges on the routing.")
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -32,21 +32,21 @@ public class RequestProfileParamsWeightings {
             "\n level: 0 = Novice, 1 = Moderate, 2 = Amateur, 3 = Pro. The prefered gradient increases with level. CUSTOM_KEYS:{'validWhen':{'ref':'profile','value':['cycling-*']}}", example = "2")
     @JsonProperty(PARAM_STEEPNESS_DIFFICULTY)
     private Integer steepnessDifficulty;
-    @Ignore
+    @JsonIgnore
     private boolean hasSteepnessDifficulty = false;
 
     @ApiModelProperty(name = PARAM_GREEN_INDEX, value = "Specifies the Green factor for `foot-*` profiles.\n" +
             "\nfactor: Values range from 0 to 1. 0 equals normal routing. 1 will prefer ways through green areas over a shorter route. CUSTOM_KEYS:{'validWhen':{'ref':'profile','value':['foot-*']}}", example = "0.4")
     @JsonProperty(PARAM_GREEN_INDEX)
     private Float greenIndex;
-    @Ignore
+    @JsonIgnore
     private boolean hasGreenIndex = false;
 
     @ApiModelProperty(name = PARAM_QUIETNESS, value = "Specifies the Quiet factor for foot-* profiles.\n" +
             "\nfactor: Values range from 0 to 1. 0 equals normal routing. 1 will prefer quiet ways over a shorter route. CUSTOM_KEYS:{'validWhen':{'ref':'profile','value':['foot-*']}}", example = "0.8")
     @JsonProperty(PARAM_QUIETNESS)
     private Float quietIndex;
-    @Ignore
+    @JsonIgnore
     private boolean hasQuietIndex = false;
 
     public Integer getSteepnessDifficulty() {

--- a/openrouteservice/src/test/java/heigit/ors/globalResponseProcessor/gpx/beans/XMLBuilderTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/globalResponseProcessor/gpx/beans/XMLBuilderTest.java
@@ -25,12 +25,13 @@
 
 package heigit.ors.globalResponseProcessor.gpx.beans;
 
-import com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.math.BigDecimal;
 
@@ -42,9 +43,9 @@ public class XMLBuilderTest {
      * This class initializes the dummy Gpx.class object
      */
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws DatatypeConfigurationException {
         // Time Element
-        XMLGregorianCalendar cal = new XMLGregorianCalendarImpl();
+        XMLGregorianCalendar cal = DatatypeFactory.newInstance().newXMLGregorianCalendar();
         cal.setTime(0, 0, 0, 0);
         // template value
         BigDecimal bigDecimal = BigDecimal.valueOf(0.0);


### PR DESCRIPTION
As Java 8 is officially unsopported since January, we have to upgrade to
a newer version as soon as possible. This commit replaces packages which
are not supported with Java 9/10 by packages that are still compatible
with Java 8.

Fixes #474.

### Pull Request Checklist
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.
