### PR TITLE
Added check to make sure bridleways are accepting foot/wheelchair bef…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Updated documentation to reflect correct isochrone smoothing algorithm (Issue #471)
 - Enable > 2 waypoints when geometry_simplify=true (#457)
+- Made it so that the wheelchair profile only goes over bridleways if they are set to be foot or wheelchair accessible (#415)
 ### Changed
 - Updated pom to always build ors.war (Issue #432)
 - Replace usage of packages incompatible with Java >8 (#474)

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/WheelchairFlagEncoder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/flagencoders/WheelchairFlagEncoder.java
@@ -464,7 +464,10 @@ public class WheelchairFlagEncoder extends AbstractFlagEncoder
                 return 0;
             
             if (restrictedWheelchairHighways.contains(highwayValue) && !bicycleOrHorseOnlyWay) {
-            	// only disallow cycleways/bridleways if they are only designated to either of this mode of traveling
+            	// In some countries bridleways cannot be travelled by anything other than a horse, so we should check if they have been explicitly allowed for foot or pedestrian
+                if (highwayValue.equals("bridleway") && !(intendedValues.contains(way.getTag("foot", "no")) || intendedValues.contains(way.getTag("wheelchair", "no")))) {
+                    return 0;
+                }
            		return acceptBit;
             }
             


### PR DESCRIPTION
…ore including in the graph

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #415  .

### Information about the changes
- Key functionality added: Added an extra check to ensure that bridleways are only used in wheelchair routing if they have an accessible tag for foot or wheelchair
- Reason for change: In some places pedestrians on bridleways are not permitted by default

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
