### PR TITLE
respect isochrone max_locations from app.config, #482

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Makes docker and docker-compose deployment of openrouteservice more customizable (Issue #434)
 - Add the possibility to predefine standard maximum search radii in general and for each used profile in the config file (Issue #418)
 ### Fixed
+- v2 isochrones now respects max_locations in app.config (#482)
 - Updated documentation to reflect correct isochrone smoothing algorithm (Issue #471)
 - Enable > 2 waypoints when geometry_simplify=true (#457)
 - Made it so that the wheelchair profile only goes over bridleways if they are set to be foot or wheelchair accessible (#415)

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/isochrones/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/isochrones/ParamsTest.java
@@ -50,9 +50,9 @@ public class ParamsTest extends ServiceTest {
         secondLocation.put(8.684177);
         secondLocation.put(49.421034);
 
-        //JSONArray thirdLocation = new JSONArray();
-        //thirdLocation.put(8.684177);
-        //thirdLocation.put(49.421034);
+        JSONArray thirdLocation = new JSONArray();
+        thirdLocation.put(8.684177);
+        thirdLocation.put(49.421034);
 
         JSONArray locations_1 = new JSONArray();
         locations_1.put(firstLocation);
@@ -60,7 +60,11 @@ public class ParamsTest extends ServiceTest {
         JSONArray locations_2 = new JSONArray();
         locations_2.put(firstLocation);
         locations_2.put(secondLocation);
-        //locations.put(thirdLocation);
+
+        JSONArray locations_3 = new JSONArray();
+        locations_3.put(firstLocation);
+        locations_3.put(secondLocation);
+        locations_3.put(thirdLocation);
 
         JSONArray ranges_2 = new JSONArray();
         ranges_2.put(1800);
@@ -84,6 +88,7 @@ public class ParamsTest extends ServiceTest {
 
         addParameter("locations_1", locations_1);
         addParameter("locations_2", locations_2);
+        addParameter("locations_3", locations_3);
         addParameter("ranges_2", ranges_2);
         addParameter("ranges_1800", ranges_1800);
         addParameter("interval_100", interval_100);
@@ -227,7 +232,7 @@ public class ParamsTest extends ServiceTest {
     public void testTooManyLocations() {
 
         JSONObject body = new JSONObject();
-        body.put("locations", getParameter("locations_2"));
+        body.put("locations", getParameter("locations_3"));
         body.put("range", getParameter("ranges_1800"));
         body.put("range_type", "time");
         body.put("interval", getParameter("interval_100"));

--- a/openrouteservice/src/main/java/heigit/ors/api/controllers/IsochronesAPI.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/controllers/IsochronesAPI.java
@@ -123,6 +123,8 @@ public class IsochronesAPI {
             return errorHandler.handleStatusCodeException(new ParameterValueException(IsochronesErrorCodes.INVALID_PARAMETER_VALUE, ((InvalidDefinitionException) cause).getPath().get(0).getFieldName()));
         } else if (cause instanceof MismatchedInputException) {
             return errorHandler.handleStatusCodeException(new ParameterValueException(IsochronesErrorCodes.INVALID_PARAMETER_FORMAT, ((MismatchedInputException) cause).getPath().get(0).getFieldName()));
+        } else if (cause instanceof InvalidDefinitionException) {
+            return errorHandler.handleStatusCodeException((new ParameterOutOfRangeException(IsochronesErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, ((InvalidDefinitionException) cause).getPath().get(0).getFieldName())));
         } else {
             // Check if we are missing the body as a whole
             if (e.getLocalizedMessage().startsWith("Required request body is missing")) {

--- a/openrouteservice/src/main/java/heigit/ors/api/requests/isochrones/IsochronesRequest.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/isochrones/IsochronesRequest.java
@@ -163,21 +163,6 @@ public class IsochronesRequest {
     public IsochronesRequest() {
     }
 
-    @JsonCreator
-    public IsochronesRequest(@JsonProperty(value = "locations", required = true) Double[][] locations) throws ParameterValueException {
-        int maximumLocations = IsochronesServiceSettings.getMaximumLocations();
-        if (locations.length > maximumLocations)
-            throw new ParameterValueException(IsochronesErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "locations");
-        if (locations.length < 1)
-            throw new ParameterValueException(IsochronesErrorCodes.INVALID_PARAMETER_FORMAT, "locations");
-        for (Double[] location : locations) {
-            if (location.length != 2)
-                throw new ParameterValueException(IsochronesErrorCodes.INVALID_PARAMETER_FORMAT, "locations");
-        }
-        this.locations = locations;
-    }
-
-
     public String getId() {
         return id;
     }

--- a/openrouteservice/src/main/java/heigit/ors/api/requests/isochrones/IsochronesRequestHandler.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/isochrones/IsochronesRequestHandler.java
@@ -159,10 +159,8 @@ public class IsochronesRequestHandler extends GenericHandler {
     IsochroneRequest convertIsochroneRequest(IsochronesRequest request) throws Exception {
         IsochroneRequest convertedIsochroneRequest = new IsochroneRequest();
         Double[][] locations = request.getLocations();
-        for (int i = 0; i < request.getLocations().length; i++) {
-            if (locations.length > 2)
-                throw new ParameterValueException(IsochronesErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, IsochronesRequest.PARAM_LOCATIONS, Arrays.toString(locations), IsochronesRequest.PARAM_LOCATIONS + " is limited to 2");
 
+        for (int i = 0; i < request.getLocations().length; i++) {
             Double[] location = locations[i];
             TravellerInfo travellerInfo = constructTravellerInfo(location, request);
             travellerInfo.setId(Integer.toString(i));

--- a/openrouteservice/src/main/java/heigit/ors/exceptions/ParameterOutOfRangeException.java
+++ b/openrouteservice/src/main/java/heigit/ors/exceptions/ParameterOutOfRangeException.java
@@ -19,6 +19,11 @@ public class ParameterOutOfRangeException extends StatusCodeException
 {
 	private static final long serialVersionUID = 7728944138955234463L;
 
+	public ParameterOutOfRangeException(int errorCode, String paramName)
+	{
+		super(StatusCode.BAD_REQUEST, errorCode, "Parameter '" + paramName + "' is out of range.");
+	}
+
 	public ParameterOutOfRangeException(int errorCode, String paramName, String value, String maxRangeValue)
 	{
 		super(StatusCode.BAD_REQUEST, errorCode, "Parameter '" + paramName + "="+ value +"' is out of range. Maximum possible value is " + maxRangeValue + ".");

--- a/openrouteservice/src/test/java/heigit/ors/api/requests/isochrones/IsochronesRequestHandlerTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/api/requests/isochrones/IsochronesRequestHandlerTest.java
@@ -10,6 +10,7 @@ import heigit.ors.api.requests.routing.RouteRequestOptions;
 import heigit.ors.common.DistanceUnit;
 import heigit.ors.common.TravelRangeType;
 import heigit.ors.common.TravellerInfo;
+import heigit.ors.exceptions.ParameterOutOfRangeException;
 import heigit.ors.exceptions.ParameterValueException;
 import heigit.ors.isochrones.IsochroneRequest;
 import heigit.ors.routing.*;
@@ -61,7 +62,8 @@ public class IsochronesRequestHandlerTest {
         coords[0] = new Double[]{24.5, 39.2};
         coords[1] = new Double[]{27.4, 38.6};
 
-        request = new IsochronesRequest(coords);
+        request = new IsochronesRequest();
+        request.setLocations(coords);
 
         request.setProfile(APIEnums.Profile.DRIVING_CAR);
         request.setAttributes(new IsochronesRequestEnums.Attributes[]{IsochronesRequestEnums.Attributes.AREA, IsochronesRequestEnums.Attributes.REACH_FACTOR});

--- a/openrouteservice/src/test/java/heigit/ors/api/requests/isochrones/IsochronesRequestTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/api/requests/isochrones/IsochronesRequestTest.java
@@ -240,24 +240,6 @@ public class IsochronesRequestTest {
         Assert.assertEquals(new Double("0.0"), request.getInterval());
     }
 
-    @Test(expected = ParameterValueException.class)
-    public void tooSmallLocationTest() throws ParameterValueException {
-        Double[][] double_array = {{1.0}, {1.0, 3.0}};
-        new IsochronesRequest(double_array);
-    }
-
-    @Test(expected = ParameterValueException.class)
-    public void exceedingLocationMaximumTest() throws ParameterValueException {
-        Double[][] exceedingLocationsMaximumCoords = fakeArrayLocations(IsochronesServiceSettings.getMaximumLocations() + 1, 2);
-        new IsochronesRequest(exceedingLocationsMaximumCoords);
-    }
-
-    @Test(expected = ParameterValueException.class)
-    public void tooLargeLocationTest() throws ParameterValueException {
-        Double[][] exceedingLocationsMaximumCoords = {{1.0, 3.0, 4.0}, {1.0, 3.0}};
-        new IsochronesRequest(exceedingLocationsMaximumCoords);
-    }
-
     @Test
     public void detailedOptionsTest() {
         IsochronesRequest request = new IsochronesRequest();


### PR DESCRIPTION
fixes #482

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes # 482.

### Information about the changes
- Key functionality added: maximum locations were hard-coded in v2 API before. Now it respects the app.config settings

