### PR TITLE
Added missing ProfileParams decleration, quiet/green api_tests, and r…

### DIFF
--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/routing/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/routing/ParamsTest.java
@@ -76,6 +76,7 @@ public class ParamsTest extends ServiceTest {
 		addParameter("preference", "fastest");
 		addParameter("profile", "cycling-regular");
 		addParameter("carProfile", "driving-car");
+		addParameter("footProfile", "foot-walking");
 	}
 
 	@Test
@@ -89,10 +90,10 @@ public class ParamsTest extends ServiceTest {
                 .pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
-                .log().all()
+                .log().ifValidationFails()
 				.post(getEndPointPath()+"/{profile}/json")
 				.then()
-                .log().all()
+                .log().ifValidationFails()
 				.body("any { it.key == 'routes' }", is(true))
 				.statusCode(200);
 	}
@@ -264,7 +265,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath()+"/{profile}/geojson")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("any { it.key == 'features' }", is(true))
 				.body("any { it.key == 'bbox' }", is(true))
@@ -286,7 +287,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath()+"/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
 				.body("any { it.key == 'features' }", is(true))
 				.body("any { it.key == 'bbox' }", is(true))
@@ -311,7 +312,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath()+"/{profile}/geojson")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("any { it.key == 'features' }", is(true))
 				.body("features[0].containsKey('geometry')", is(true))
@@ -420,9 +421,9 @@ public class ParamsTest extends ServiceTest {
 				.param("start", "8.686581")
 				.param("end", "8.688126,49.409074")
 				.pathParam("profile", getParameter("carProfile"))
-				.when().log().all()
+				.when().log().ifValidationFails()
 				.get(getEndPointPath() + "/{profile}")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_FORMAT))
 				.statusCode(400);
@@ -431,9 +432,9 @@ public class ParamsTest extends ServiceTest {
 				.param("start", "8.686581,49.403154")
 				.param("end", "8.688126")
 				.pathParam("profile", getParameter("carProfile"))
-				.when().log().all()
+				.when().log().ifValidationFails()
 				.get(getEndPointPath() + "/{profile}")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_FORMAT))
 				.statusCode(400);
@@ -441,9 +442,9 @@ public class ParamsTest extends ServiceTest {
 		given()
 				.param("start", "8.686581,49.403154")
 				.pathParam("profile", getParameter("carProfile"))
-				.when().log().all()
+				.when().log().ifValidationFails()
 				.get(getEndPointPath() + "/{profile}")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("error.code", is(RoutingErrorCodes.MISSING_PARAMETER))
 				.statusCode(400);
@@ -902,7 +903,7 @@ public class ParamsTest extends ServiceTest {
 				.header("Content-Type", "application/json")
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
-				.when().log().all()
+				.when().log().ifValidationFails()
 				.post(getEndPointPath()+"/{profile}/json")
 				.then()
 				.assertThat()
@@ -1091,9 +1092,9 @@ public class ParamsTest extends ServiceTest {
 				.header("Content-Type", "application/json")
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
-				.when().log().all()
+				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("any { it.key == 'routes' }", is(true))
 				.body("routes[0].containsKey('warnings')", is(true))
@@ -1110,7 +1111,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'features' }", is(true))
                 .body("any { it.key == 'bbox' }", is(true))
@@ -1146,9 +1147,9 @@ public class ParamsTest extends ServiceTest {
 				.header("Content-Type", "application/json")
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
-				.when().log().all()
+				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("any { it.key == 'routes' }", is(true))
 				.body("routes[0].containsKey('warnings')", is(false))
@@ -1169,7 +1170,7 @@ public class ParamsTest extends ServiceTest {
 				.body(body.toString())
 				.when()
 				.post(getEndPointPath() + "/{profile}/geojson")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("error.code", is(RoutingErrorCodes.INCOMPATIBLE_PARAMETERS))
 				.statusCode(400);
@@ -1199,7 +1200,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1210,7 +1211,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/json")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1223,7 +1224,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1234,7 +1235,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/json")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1247,7 +1248,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1258,7 +1259,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/json")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1271,7 +1272,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1282,7 +1283,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/json")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
@@ -1305,7 +1306,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('warnings')", is(true))
@@ -1320,7 +1321,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/geojson")
-				.then().log().all()
+				.then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'features' }", is(true))
                 .body("any { it.key == 'bbox' }", is(true))
@@ -1353,7 +1354,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .statusCode(200);
@@ -1366,7 +1367,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.POINT_NOT_FOUND))
                 .statusCode(404);
@@ -1385,7 +1386,7 @@ public class ParamsTest extends ServiceTest {
 				.body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("error.code", is(RoutingErrorCodes.POINT_NOT_FOUND))
 				.statusCode(404);
@@ -1399,7 +1400,7 @@ public class ParamsTest extends ServiceTest {
 				.body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
 				.assertThat()
 				.body("error.code", is(RoutingErrorCodes.POINT_NOT_FOUND))
 				.statusCode(404);
@@ -1418,7 +1419,7 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .statusCode(200);
@@ -1432,9 +1433,81 @@ public class ParamsTest extends ServiceTest {
                 .body(body.toString())
 				.when().log().ifValidationFails()
 				.post(getEndPointPath() + "/{profile}/json")
-				.then().log().all()
+				.then().log().ifValidationFails()
                 .assertThat()
                 .body("error.code", is(RoutingErrorCodes.POINT_NOT_FOUND))
                 .statusCode(404);
+	}
+
+	@Test
+	public void testGreenWeightingTooHigh() {
+		JSONObject body = new JSONObject();
+
+		JSONArray coordinates = new JSONArray();
+		JSONArray coord1 = new JSONArray();
+		coord1.put(8.676023);
+		coord1.put(49.416809);
+		coordinates.put(coord1);
+		JSONArray coord2 = new JSONArray();
+		coord2.put(8.696837);
+		coord2.put(49.411839);
+		coordinates.put(coord2);
+		body.put("coordinates", coordinates);
+
+		JSONObject weightings = new JSONObject();
+		weightings.put("green", 1.1);
+		JSONObject params = new JSONObject();
+		params.put("weightings", weightings);
+		JSONObject options = new JSONObject();
+		options.put("profile_params", params);
+		body.put("options", options);
+
+		given()
+				.header("Accept", "application/json")
+				.header("Content-Type", "application/json")
+				.pathParam("profile", getParameter("footProfile"))
+				.body(body.toString())
+				.when()
+				.post(getEndPointPath() + "/{profile}/json")
+				.then().log().ifValidationFails()
+				.assertThat()
+				.body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
+				.statusCode(400);
+	}
+
+	@Test
+	public void testQuietWeightingTooHigh() {
+		JSONObject body = new JSONObject();
+
+		JSONArray coordinates = new JSONArray();
+		JSONArray coord1 = new JSONArray();
+		coord1.put(8.676023);
+		coord1.put(49.416809);
+		coordinates.put(coord1);
+		JSONArray coord2 = new JSONArray();
+		coord2.put(8.696837);
+		coord2.put(49.411839);
+		coordinates.put(coord2);
+		body.put("coordinates", coordinates);
+
+		JSONObject weightings = new JSONObject();
+		weightings.put("quiet", 1.1);
+		JSONObject params = new JSONObject();
+		params.put("weightings", weightings);
+		JSONObject options = new JSONObject();
+		options.put("profile_params", params);
+		body.put("options", options);
+
+		given()
+				.header("Accept", "application/json")
+				.header("Content-Type", "application/json")
+				.pathParam("profile", getParameter("footProfile"))
+				.body(body.toString())
+				.when()
+				.post(getEndPointPath() + "/{profile}/json")
+				.then().log().ifValidationFails()
+				.assertThat()
+				.body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
+				.statusCode(400);
 	}
 }

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/routing/ResultTest.java
@@ -81,6 +81,7 @@ public class ResultTest extends ServiceTest {
         addParameter("preference", "fastest");
         addParameter("bikeProfile", "cycling-regular");
         addParameter("carProfile", "driving-car");
+        addParameter("footProfile", "foot-walking");
     }
 
     @Test
@@ -89,9 +90,9 @@ public class ResultTest extends ServiceTest {
                 .param("start", "8.686581,49.403154")
                 .param("end", "8.688126,49.409074")
                 .pathParam("profile", getParameter("carProfile"))
-                .when().log().all()
+                .when().log().ifValidationFails()
                 .get(getEndPointPath() + "/{profile}")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'features' }", is(true))
                 .body("features[0].containsKey('properties')", is(true))
@@ -119,11 +120,11 @@ public class ResultTest extends ServiceTest {
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
-                .log().all()
+                .log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}/gpx");
 
         response.then()
-                .log().all()
+                .log().ifValidationFails()
                 .assertThat()
                 .contentType("application/gpx+xml;charset=UTF-8")
                 .statusCode(200);
@@ -137,7 +138,7 @@ public class ResultTest extends ServiceTest {
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
-                .log().all()
+                .log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}/gpx");
         response_without_instructions.then()
                 .assertThat()
@@ -483,7 +484,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any {it.key == 'metadata'}", is(true))
                 .body("metadata.containsKey('id')", is(true))
@@ -670,7 +671,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 8.714833f, 49.424603f))
@@ -754,7 +755,7 @@ public class ResultTest extends ServiceTest {
                 .header("Content-Type", "application/json")
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
-                .when().log().all()
+                .when().log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}");
 
         Assert.assertEquals(response.getStatusCode(), 200);
@@ -900,10 +901,10 @@ public class ResultTest extends ServiceTest {
                 .header("Content-Type", "application/json")
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
-                .when().log().all()
+                .when().log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}");
 
-        response.then().log().all()
+        response.then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('extras')", is(true))
@@ -1337,7 +1338,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(1147.0f))
@@ -1369,7 +1370,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(3172.3f))
@@ -1435,7 +1436,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].segments[0].detourfactor", is(1.3f))
@@ -1492,7 +1493,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(129.6f))
@@ -1512,7 +1513,7 @@ public class ResultTest extends ServiceTest {
                 .header("Content-Type", "application/json")
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
-                .when().log().all()
+                .when().log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}")
                 .then()
                 .assertThat()
@@ -1778,7 +1779,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('warnings')", is(true))
@@ -1795,7 +1796,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'features' }", is(true))
                 .body("any { it.key == 'bbox' }", is(true))
@@ -1823,7 +1824,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("features[0].geometry.coordinates.size()", is(534))
                 .statusCode(200);
@@ -1837,7 +1838,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("features[0].geometry.coordinates.size()", is(299))
                 .statusCode(200);
@@ -1858,9 +1859,9 @@ public class ResultTest extends ServiceTest {
                 .header("Content-Type", "application/json")
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
-                .when().log().all()
+                .when().log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}/json")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('warnings')", is(true))
@@ -1875,7 +1876,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'features' }", is(true))
                 .body("any { it.key == 'bbox' }", is(true))
@@ -1901,9 +1902,9 @@ public class ResultTest extends ServiceTest {
                 .header("Content-Type", "application/json")
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
-                .when().log().all()
+                .when().log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}/json")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(1744.3f))
@@ -1942,7 +1943,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'features' }", is(true))
                 .body("any { it.key == 'bbox' }", is(true))
@@ -1994,9 +1995,9 @@ public class ResultTest extends ServiceTest {
                 .header("Content-Type", "application/json")
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
-                .when().log().all()
+                .when().log().ifValidationFails()
                 .post(getEndPointPath() + "/{profile}/json")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(10936.3f))
@@ -2042,7 +2043,7 @@ public class ResultTest extends ServiceTest {
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
-                .then().log().all()
+                .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'features' }", is(true))
                 .body("any { it.key == 'bbox' }", is(true))
@@ -2156,6 +2157,114 @@ public class ResultTest extends ServiceTest {
                 .body("routes[0].containsKey('segments')", is(true))
                 .body("routes[0].segments[0].containsKey('avgspeed')", is(true))
                 .body("routes[0].segments[0].avgspeed", is(19.32f))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testPreferGreen() {
+        JSONObject body = new JSONObject();
+
+        JSONArray coordinates = new JSONArray();
+        JSONArray coord1 = new JSONArray();
+        coord1.put(8.676023);
+        coord1.put(49.416809);
+        coordinates.put(coord1);
+        JSONArray coord2 = new JSONArray();
+        coord2.put(8.696837);
+        coord2.put(49.411839);
+        coordinates.put(coord2);
+        body.put("coordinates", coordinates);
+
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].containsKey('summary')", is(true))
+                .body("routes[0].summary.distance", is(2097.2f))
+                .body("routes[0].summary.duration", is(1510.0f))
+                .statusCode(200);
+
+        JSONObject weightings = new JSONObject();
+        weightings.put("green", 1.0);
+        JSONObject params = new JSONObject();
+        params.put("weightings", weightings);
+        JSONObject options = new JSONObject();
+        options.put("profile_params", params);
+        body.put("options", options);
+
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].containsKey('summary')", is(true))
+                .body("routes[0].summary.distance", is(2308.3f))
+                .body("routes[0].summary.duration", is(3323.9f))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testPreferQuiet() {
+        JSONObject body = new JSONObject();
+
+        JSONArray coordinates = new JSONArray();
+        JSONArray coord1 = new JSONArray();
+        coord1.put(8.676023);
+        coord1.put(49.416809);
+        coordinates.put(coord1);
+        JSONArray coord2 = new JSONArray();
+        coord2.put(8.696837);
+        coord2.put(49.411839);
+        coordinates.put(coord2);
+        body.put("coordinates", coordinates);
+
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].containsKey('summary')", is(true))
+                .body("routes[0].summary.distance", is(2097.2f))
+                .body("routes[0].summary.duration", is(1510.0f))
+                .statusCode(200);
+
+        JSONObject weightings = new JSONObject();
+        weightings.put("quiet", 1.0);
+        JSONObject params = new JSONObject();
+        params.put("weightings", weightings);
+        JSONObject options = new JSONObject();
+        options.put("profile_params", params);
+        body.put("options", options);
+
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].containsKey('summary')", is(true))
+                .body("routes[0].summary.distance", is(2878.6f))
+                .body("routes[0].summary.duration", is(4145.2f))
                 .statusCode(200);
     }
 

--- a/openrouteservice/src/main/java/heigit/ors/api/requests/common/GenericHandler.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/common/GenericHandler.java
@@ -19,6 +19,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Polygon;
 
+import heigit.ors.api.errors.GenericErrorCodes;
 import heigit.ors.api.requests.routing.RequestProfileParamsRestrictions;
 import heigit.ors.api.requests.routing.RequestProfileParamsWeightings;
 import heigit.ors.api.requests.routing.RouteRequestOptions;
@@ -307,17 +308,23 @@ public class GenericHandler {
         }
     }
 
-    private ProfileParameters applyWeightings(RequestProfileParamsWeightings weightings, ProfileParameters params) throws ParameterValueException {
+    private ProfileParameters applyWeightings(RequestProfileParamsWeightings weightings, ProfileParameters params) throws ParameterOutOfRangeException, ParameterValueException {
         try {
             if (weightings.hasGreenIndex()) {
                 ProfileWeighting pw = new ProfileWeighting("green");
-                pw.addParameter("factor", String.format("%.2f", weightings.getGreenIndex()));
+                float greenFactor = weightings.getGreenIndex();
+                if (greenFactor > 1)
+                    throw new ParameterOutOfRangeException(GenericErrorCodes.INVALID_PARAMETER_VALUE, String.format("%.2f", greenFactor), "green factor", "1.0");
+                pw.addParameter("factor", String.format("%.2f", greenFactor));
                 params.add(pw);
             }
 
             if (weightings.hasQuietIndex()) {
                 ProfileWeighting pw = new ProfileWeighting("quiet");
-                pw.addParameter("factor", String.format("%.2f", weightings.getQuietIndex()));
+                float quietFactor = weightings.getQuietIndex();
+                if (quietFactor > 1)
+                    throw new ParameterOutOfRangeException(GenericErrorCodes.INVALID_PARAMETER_VALUE, String.format("%.2f", quietFactor), "quiet factor", "1.0");
+                pw.addParameter("factor", String.format("%.2f", quietFactor));
                 params.add(pw);
             }
 

--- a/openrouteservice/src/main/java/heigit/ors/routing/RouteSearchParameters.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/RouteSearchParameters.java
@@ -308,7 +308,8 @@ public class RouteSearchParameters {
                 }
 
                 _profileParams = wheelchairParams;
-            }
+            } else
+                _profileParams = new ProfileParameters();
 
             processWeightings(jProfileParams, _profileParams);
         }


### PR DESCRIPTION
…emoved some api test logging

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

### Information about the changes
- Key functionality added: Added a declaration for ProfileParams object when profile is not a driving, bike or wheelchair profile. Added new API tests for v2 API for quiet and green routing. Added check for green/quiet factors being out of bounds. Updated some logging in api tests.
- Reason for change: Requesting green or quiet routes resulted in an error response.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
