### PR TITLE
[bugfix] isochrone geojson bbox is now compliant, #493

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Makes docker and docker-compose deployment of openrouteservice more customizable (Issue #434)
 - Add the possibility to predefine standard maximum search radii in general and for each used profile in the config file (Issue #418)
 ### Fixed
+- isochrone geojson bbox now format compliant (#493)
 - v2 isochrones now respects max_locations in app.config (#482)
 - Updated documentation to reflect correct isochrone smoothing algorithm (Issue #471)
 - Enable > 2 waypoints when geometry_simplify=true (#457)

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/isochrones/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/isochrones/ResultTest.java
@@ -177,6 +177,29 @@ public class ResultTest extends ServiceTest {
     }
 
     @Test
+    public void testBoundingBox() {
+
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", getParameter("ranges_400"));
+
+        given()
+                .header("Accept", "application/geo+json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("cyclingProfile"))
+                .body(body.toString())
+                .when()
+                .log().all()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .body("bbox[0]", is(8.663811f))
+                .body("bbox[1]", is(49.409103f))
+                .body("bbox[2]", is(8.699429f))
+                .body("bbox[3]", is(49.439289f))
+                .statusCode(200);
+    }
+
+    @Test
     public void testReachfactorAndArea() {
 
         JSONObject body = new JSONObject();

--- a/openrouteservice/src/main/java/heigit/ors/api/responses/isochrones/GeoJSONIsochronesResponseObjects/GeoJSONIsochronesResponse.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/responses/isochrones/GeoJSONIsochronesResponseObjects/GeoJSONIsochronesResponse.java
@@ -68,7 +68,7 @@ public class GeoJSONIsochronesResponse extends IsochronesResponse {
         List<BBox> bboxes = new ArrayList<>();
         for (IsochroneMap isochroneMap : isoMaps.getIsochroneMaps()) {
             Envelope isochroneMapEnvelope = isochroneMap.getEnvelope();
-            BBox isochroneMapBBox = new BBox(isochroneMapEnvelope.getMaxX(), isochroneMapEnvelope.getMaxY(), isochroneMapEnvelope.getMinX(), isochroneMapEnvelope.getMinY());
+            BBox isochroneMapBBox = new BBox(isochroneMapEnvelope.getMinX(), isochroneMapEnvelope.getMaxX(), isochroneMapEnvelope.getMinY(), isochroneMapEnvelope.getMaxY());
             bboxes.add(isochroneMapBBox);
         }
         BBox bounding = GeomUtility.generateBoundingFromMultiple(bboxes.toArray(new BBox[0]));


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [ ] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #493  .

### Information about the changes
- Key functionality added: BBOX object in isochrone GeoJSON response wasn't compliant with the format specs. Now it has the right order of coordinates.
