### PR TITLE
#489 Use Spring to access resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Makes docker and docker-compose deployment of openrouteservice more customizable (Issue #434)
 - Add the possibility to predefine standard maximum search radii in general and for each used profile in the config file (Issue #418)
 ### Fixed
+- fix classpath issues for resources, Windows builds now (#489)
 - isochrone geojson bbox now format compliant (#493)
 - v2 isochrones now respects max_locations in app.config (#482)
 - Updated documentation to reflect correct isochrone smoothing algorithm (Issue #471)

--- a/openrouteservice/src/main/java/heigit/ors/config/AppConfig.java
+++ b/openrouteservice/src/main/java/heigit/ors/config/AppConfig.java
@@ -16,7 +16,6 @@ package heigit.ors.config;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +28,6 @@ import com.typesafe.config.ConfigValue;
 
 import org.apache.log4j.Logger;
 
-import heigit.ors.routing.RoutingProfileManager;
 import heigit.ors.util.StringUtility;
 import heigit.ors.util.FileUtility;
 import org.springframework.core.io.ClassPathResource;
@@ -48,20 +46,19 @@ public class AppConfig {
 	}
 	
 	public AppConfig()	{
-    	URL url = RoutingProfileManager.class.getClassLoader().getResource("../app.config");
+		File file;
+
 		String appConfigName = "app.config";
 		if(System.getenv("ORS_APP_CONFIG") != null)
 			appConfigName = System.getenv("ORS_APP_CONFIG");
     	try {
 
     		ClassPathResource rs = new ClassPathResource(appConfigName);
-    		url = rs.getURL();
+			file = rs.getFile();
+			_config = ConfigFactory.parseFile(file);
 		} catch (IOException ioe) {
     		LOGGER.error(ioe);
 		}
-    	
-    	File file = new File(url.getPath());
-		_config = ConfigFactory.parseFile(file);
 
 		//Modification by H Leuschner: Save md5 hash of map file in static String for access with every request
 		File graphsDir = new File(getServiceParameter("routing.profiles.default_params", "graphs_root_path"));

--- a/openrouteservice/src/main/java/heigit/ors/localization/LocalizationManager.java
+++ b/openrouteservice/src/main/java/heigit/ors/localization/LocalizationManager.java
@@ -14,8 +14,6 @@
 package heigit.ors.localization;
 
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
@@ -30,6 +28,9 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import heigit.ors.util.StringUtility;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 public class LocalizationManager {
 	protected static Logger LOGGER = LoggerFactory.getLogger(LocalizationManager.class);
@@ -59,20 +60,19 @@ public class LocalizationManager {
 
 	private void loadLocalizations() throws Exception
 	{
-		File classFile = new File(getClass().getProtectionDomain().getCodeSource().getLocation().getFile());
-		String classPath = classFile.getAbsolutePath();
-		String classesPath = classPath.substring(0, classPath.indexOf("classes") + "classes".length());
-		Path localesPath = Paths.get(classesPath, "resources", "locales");
+		PathMatchingResourcePatternResolver resource_pattern = new PathMatchingResourcePatternResolver(this.getClass().getClassLoader());
 
 		String filePattern = "ors_(.*?).resources";
+		String resourcePattern = "/resources/**/ors_*.resources";
+
+		Resource[] resources = resource_pattern.getResources(resourcePattern);
 		Pattern pattern = Pattern.compile(filePattern);
 
-		File[] files = new File(localesPath.toString()).listFiles();
-
-		if (files == null)
+		if (resources.length == 0)
 			throw new Exception("Resources can not be found.");
 
-		for (File file : files) {
+		for (Resource res : resources) {
+			File file = res.getFile();
 			try
 			{
 				if (file.isFile()) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #489 .

### Information about the changes
- Key functionality added: Use Spring functions to access resource files, notably for AppConfig and LocalizationManager.
- Reason for change: Windows Server 2016 & 2019 weren't able to build ORS without hard-coding those paths.

Tested on Windows Server 2016 & 2019 and Ubuntu 18.04.
