### PR TITLE
matrix has now maximum number of routes, not locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated pom to always build ors.war (Issue #432)
 - Replace usage of packages incompatible with Java >8 (#474)
+- Updated Matrix to have a maximum number of routes to calculate rather than locations (#518)
 ### Deprecated
 
 

--- a/openrouteservice-api-tests/conf/app.config.test
+++ b/openrouteservice-api-tests/conf/app.config.test
@@ -9,7 +9,7 @@
     services: {
       matrix: {
         enabled: true,
-        maximum_locations: 200,
+        maximum_routes: 200,
         maximum_visited_nodes: 100000,
         allow_resolve_locations: true,
         attribution: "openrouteservice.org, OpenStreetMap contributors"

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/matrix/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/matrix/ParamsTest.java
@@ -60,7 +60,7 @@ public class ParamsTest extends ServiceTest {
         addParameter("locationsFaulty", coordsFaulty);
 
         // Fake array to test maximum exceedings
-        JSONArray maximumLocations = fakeLocations(MatrixServiceSettings.getMaximumLocations(false) + 1);
+        JSONArray maximumLocations = fakeLocations(MatrixServiceSettings.getMaximumRoutes(false) + 1);
         addParameter("maximumLocations", maximumLocations);
         JSONArray minimalLocations = fakeLocations(1);
         addParameter("minimalLocations", minimalLocations);

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/matrix/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/matrix/ResultTest.java
@@ -64,7 +64,7 @@ public class ResultTest extends ServiceTest {
         addParameter("locationsLong", locationsLong);
 
         // Fake array to test maximum exceedings
-        JSONArray maximumLocations = HelperFunctions.fakeJSONLocations(MatrixServiceSettings.getMaximumLocations(false) + 1);
+        JSONArray maximumLocations = HelperFunctions.fakeJSONLocations(MatrixServiceSettings.getMaximumRoutes(false) + 1);
         addParameter("maximumLocations", maximumLocations);
         JSONArray minimalLocations = HelperFunctions.fakeJSONLocations(1);
         addParameter("minimalLocations", minimalLocations);

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/serviceSettings/MatrixServiceSettings.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/serviceSettings/MatrixServiceSettings.java
@@ -16,8 +16,8 @@ package heigit.ors.v2.services.serviceSettings;
 import heigit.ors.v2.services.config.AppConfig;
 
 public class MatrixServiceSettings {
-    private static int maximumLocations = 100;
-    private static int maximumLocationsFlexible = 25;
+    private static int maximumRoutes = 100;
+    private static int maximumRoutesFlexible = 25;
     private static int maximumVisitedNodes = 100000;
     private static double maximumSearchRadius = 2000;
     private static boolean allowResolveLocations = true;
@@ -30,10 +30,10 @@ public class MatrixServiceSettings {
             enabled = Boolean.parseBoolean(value);
         value = AppConfig.Global().getServiceParameter("matrix", "maximum_locations");
         if (value != null)
-            maximumLocations = Math.max(1, Integer.parseInt(value));
+            maximumRoutes = Math.max(1, Integer.parseInt(value));
         value = AppConfig.Global().getServiceParameter("matrix", "maximum_locations_flexible");
         if (value != null)
-            maximumLocationsFlexible = Math.max(1, Integer.parseInt(value));
+            maximumRoutesFlexible = Math.max(1, Integer.parseInt(value));
         value = AppConfig.Global().getServiceParameter("matrix", "maximum_search_radius");
         if (value != null)
             maximumSearchRadius = Math.max(1, Double.parseDouble(value));
@@ -60,8 +60,8 @@ public class MatrixServiceSettings {
         return maximumVisitedNodes;
     }
 
-    public static int getMaximumLocations(boolean flexible) {
-        return (flexible ? maximumLocationsFlexible : maximumLocations);
+    public static int getMaximumRoutes(boolean flexible) {
+        return (flexible ? maximumRoutesFlexible : maximumRoutes);
     }
 
     public static double getMaximumSearchRadius() {

--- a/openrouteservice/src/main/java/heigit/ors/api/requests/matrix/MatrixRequest.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/requests/matrix/MatrixRequest.java
@@ -111,7 +111,7 @@ public class MatrixRequest {
         if (locations.length < 2) {
             throw new ParameterValueException(MatrixErrorCodes.INVALID_PARAMETER_FORMAT, "locations");
         }
-        if (locations.length > MatrixServiceSettings.getMaximumLocations(false))
+        if (locations.length > MatrixServiceSettings.getMaximumRoutes(false))
             throw new ParameterValueException(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "locations");
         this.locations = new ArrayList<>();
         for (Double[] coordPair : locations) {

--- a/openrouteservice/src/main/java/heigit/ors/services/accessibility/AccessibilityServiceSettings.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/accessibility/AccessibilityServiceSettings.java
@@ -112,7 +112,7 @@ public class AccessibilityServiceSettings
 		return responseLimit;
 	}
 	
-	public static int getMaximumLocations() {
+	public static int getMaximumRoutes() {
 		return maximumLocations;
 	}
 	

--- a/openrouteservice/src/main/java/heigit/ors/services/accessibility/requestprocessors/json/JsonAccessibilityRequestProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/accessibility/requestprocessors/json/JsonAccessibilityRequestProcessor.java
@@ -76,8 +76,8 @@ public class JsonAccessibilityRequestProcessor extends AbstractHttpRequestProces
 
         List<TravellerInfo> travellers = req.getTravellers();
 
-        if (travellers.size() > AccessibilityServiceSettings.getMaximumLocations())
-            throw new ParameterOutOfRangeException(AccessibilityErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "locations", Integer.toString(travellers.size()), Integer.toString(AccessibilityServiceSettings.getMaximumLocations()));
+        if (travellers.size() > AccessibilityServiceSettings.getMaximumRoutes())
+            throw new ParameterOutOfRangeException(AccessibilityErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "locations", Integer.toString(travellers.size()), Integer.toString(AccessibilityServiceSettings.getMaximumRoutes()));
 
         for (int i = 0; i < travellers.size(); ++i) {
             TravellerInfo traveller = travellers.get(i);

--- a/openrouteservice/src/main/java/heigit/ors/services/mapmatching/requestprocessors/json/JsonMapMatchingRequestProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/mapmatching/requestprocessors/json/JsonMapMatchingRequestProcessor.java
@@ -46,7 +46,7 @@ public class JsonMapMatchingRequestProcessor extends AbstractHttpRequestProcesso
 		if (req == null)
 			throw new StatusCodeException(StatusCode.BAD_REQUEST, MapMatchingErrorCodes.UNKNOWN, "MapMatchingRequest object is null.");
 
-		if (MapMatchingServiceSettings.getMaximumLocations() > 0 && req.getCoordinates().length > MatrixServiceSettings.getMaximumLocations(false))
+		if (MapMatchingServiceSettings.getMaximumLocations() > 0 && req.getCoordinates().length > MatrixServiceSettings.getMaximumRoutes(false))
 			throw new ParameterOutOfRangeException(MapMatchingErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getCoordinates().length), Integer.toString(MapMatchingServiceSettings.getMaximumLocations()));
 
 		

--- a/openrouteservice/src/main/java/heigit/ors/services/matrix/MatrixServiceSettings.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/matrix/MatrixServiceSettings.java
@@ -17,8 +17,8 @@ import heigit.ors.config.AppConfig;
 
 public class MatrixServiceSettings 
 {
-	private static int maximumLocations = 100;
-	private static int maximumLocationsFlexible = 25;
+	private static int maximumRoutes = 2500;
+	private static int maximumRoutesFlexible = 25;
 	private static int maximumVisitedNodes = 100000;
 	private static double maximumSearchRadius = 2000;
 	private static boolean allowResolveLocations = true;
@@ -30,12 +30,12 @@ public class MatrixServiceSettings
 		String value = AppConfig.Global().getServiceParameter("matrix", "enabled");
 		if (value != null)
 			enabled = Boolean.parseBoolean(value);		
-		value = AppConfig.Global().getServiceParameter("matrix", "maximum_locations");
+		value = AppConfig.Global().getServiceParameter("matrix", "maximum_routes");
 		if (value != null)
-			maximumLocations = Math.max(1, Integer.parseInt(value));
-		value = AppConfig.Global().getServiceParameter("matrix", "maximum_locations_flexible");
+			maximumRoutes = Math.max(1, Integer.parseInt(value));
+		value = AppConfig.Global().getServiceParameter("matrix", "maximum_routes_flexible");
 		if (value != null)
-			maximumLocationsFlexible = Math.max(1, Integer.parseInt(value));
+			maximumRoutesFlexible = Math.max(1, Integer.parseInt(value));
 		value = AppConfig.Global().getServiceParameter("matrix", "maximum_search_radius");
 		if (value != null)
 			maximumSearchRadius = Math.max(1, Double.parseDouble(value));
@@ -62,8 +62,8 @@ public class MatrixServiceSettings
 		return maximumVisitedNodes;
 	}
 	
-	public static int getMaximumLocations(boolean flexible) {
-		return (flexible? maximumLocationsFlexible : maximumLocations);
+	public static int getMaximumRoutes(boolean flexible) {
+		return (flexible? maximumRoutesFlexible : maximumRoutes);
 	}
 	
 	public static double getMaximumSearchRadius() {

--- a/openrouteservice/src/main/java/heigit/ors/services/matrix/requestprocessors/json/JsonMatrixRequestProcessor.java
+++ b/openrouteservice/src/main/java/heigit/ors/services/matrix/requestprocessors/json/JsonMatrixRequestProcessor.java
@@ -16,7 +16,6 @@ package heigit.ors.services.matrix.requestprocessors.json;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import heigit.ors.routing.RoutingProfilesCollection;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -77,8 +76,8 @@ public class JsonMatrixRequestProcessor extends AbstractHttpRequestProcessor
         }
 
         boolean flexibleMode = req.getFlexibleMode() ? true : !RoutingProfileManager.getInstance().getProfiles().isCHProfileAvailable(req.getProfileType());
-        if (MatrixServiceSettings.getMaximumLocations(flexibleMode) > 0 && req.getTotalNumberOfLocations() > MatrixServiceSettings.getMaximumLocations(flexibleMode)) {
-            throw new ParameterOutOfRangeException(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getTotalNumberOfLocations()), Integer.toString(MatrixServiceSettings.getMaximumLocations(flexibleMode)));
+        if (MatrixServiceSettings.getMaximumRoutes(flexibleMode) > 0 && req.getTotalNumberOfLocations() > MatrixServiceSettings.getMaximumRoutes(flexibleMode)) {
+            throw new ParameterOutOfRangeException(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getTotalNumberOfLocations()), Integer.toString(MatrixServiceSettings.getMaximumRoutes(flexibleMode)));
         }
         MatrixResult mtxResult = RoutingProfileManager.getInstance().computeMatrix(req);
 
@@ -107,8 +106,8 @@ public class JsonMatrixRequestProcessor extends AbstractHttpRequestProcessor
 		if (req == null)
 			throw new StatusCodeException(StatusCode.BAD_REQUEST, MatrixErrorCodes.UNKNOWN, "MatrixRequest object is null.");
 		boolean flexibleMode = req.getFlexibleMode() ? true : !RoutingProfileManager.getInstance().getProfiles().isCHProfileAvailable(req.getProfileType());
-		if (MatrixServiceSettings.getMaximumLocations(flexibleMode) > 0 && req.getTotalNumberOfLocations() > MatrixServiceSettings.getMaximumLocations(flexibleMode))
-			throw new ParameterOutOfRangeException(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getTotalNumberOfLocations()), Integer.toString(MatrixServiceSettings.getMaximumLocations(flexibleMode)));
+		if (MatrixServiceSettings.getMaximumRoutes(flexibleMode) > 0 && req.getTotalNumberOfLocations() > MatrixServiceSettings.getMaximumRoutes(flexibleMode))
+			throw new ParameterOutOfRangeException(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM, "sources/destinations", Integer.toString(req.getTotalNumberOfLocations()), Integer.toString(MatrixServiceSettings.getMaximumRoutes(flexibleMode)));
 		
 		MatrixResult mtxResult = RoutingProfileManager.getInstance().computeMatrix(req);
 		

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -9,8 +9,8 @@
     "services": {
       "matrix": {
         "enabled": true,
-        "maximum_locations": 100,
-        "maximum_locations_flexible": 25,
+        "maximum_routes": 100,
+        "maximum_routes_flexible": 25,
         "maximum_search_radius": 5000,
         "maximum_visited_nodes": 100000,
         "allow_resolve_locations": true,

--- a/openrouteservice/src/test/java/heigit/ors/api/requests/matrix/MatrixRequestTest.java
+++ b/openrouteservice/src/test/java/heigit/ors/api/requests/matrix/MatrixRequestTest.java
@@ -48,7 +48,7 @@ public class MatrixRequestTest {
         bareCoordinates[1] = bareCoordinate2;
         bareCoordinates[2] = bareCoordinate3;
 
-        maximumLocationsArray = HelperFunctions.fakeArrayLocations(MatrixServiceSettings.getMaximumLocations(false) + 1, 2);
+        maximumLocationsArray = HelperFunctions.fakeArrayLocations(MatrixServiceSettings.getMaximumRoutes(false) + 1, 2);
         minimalLocationsArray = HelperFunctions.fakeArrayLocations(1, 2);
 
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #518 .

### Information about the changes
- Key functionality added: The Matrix API now has a maximum number of routes it allows to be computed, rather than the previous behavior with a maximum number of locations
- Reason for change: Before a request with 1x61 would fail, while this actually only computes 61 routes, but 60x60 was valid.

### Required changes to app.config (if applicable)
- `ors.services.matrix.maximum_locations` is now `ors.services.matrix.maximum_routes`
- `ors.services.matrix.maximum_locations_flexible` is now `ors.services.matrix.maximum_routes_flexible`