### PR TITLE
Make sure external storages contain entries for all edge IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - isochrone reachfactor gives now more realistic results (#325)
 - Fixed the wrong gpx header for api v2 (#496)
+- Make sure external storages contain entries for all edge IDs (#535)
 ### Changed
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
@@ -113,7 +113,7 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
 			throw new IllegalStateException("EF_RESTRICTION is not supported.");
 
 		for (int i = 0; i < VehicleDimensionRestrictions.Count; i++) {
-			short shortValue = restrictionValues == null ? 0 : (short) (restrictionValues[i] * factor);
+			short shortValue = (short) (restrictionValues[i] * factor);
 			orsEdges.setShort(edgePointer + EF_RESTRICTIONS + i * EF_RESTRICTION_BYTES, shortValue);
 		}
 	}

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/HeavyVehicleGraphStorageBuilder.java
@@ -223,15 +223,8 @@ public class HeavyVehicleGraphStorageBuilder extends AbstractGraphStorageBuilder
 		}
 	}
 
-	public void processEdge(ReaderWay way, EdgeIteratorState edge)
-	{
-		if (_hgvType > HeavyVehicleAttributes.UNKNOWN || _hgvDestination > 0 || _hasRestrictionValues) 
-		{
-			if (_hasRestrictionValues)
-				_storage.setEdgeValue(edge.getEdge(), _hgvType, _hgvDestination, _restrictionValues);
-			else
-				_storage.setEdgeValue(edge.getEdge(), _hgvType, _hgvDestination, null);
-	    }
+	public void processEdge(ReaderWay way, EdgeIteratorState edge) {
+		_storage.setEdgeValue(edge.getEdge(), _hgvType, _hgvDestination, _restrictionValues);
 	}
 
 	private String getHeavyVehicleValue(String key, String hv, String value) {

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
@@ -253,8 +253,7 @@ public class RoadAccessRestrictionsGraphStorageBuilder extends AbstractGraphStor
     }
 
     public void processEdge(ReaderWay way, EdgeIteratorState edge) {
-        if (hasRestrictions)
-            storage.setEdgeValue(edge.getEdge(), restrictions);
+        storage.setEdgeValue(edge.getEdge(), restrictions);
     }
 
     public final int getRestrictions() {

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/WayCategoryGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/storages/builders/WayCategoryGraphStorageBuilder.java
@@ -79,11 +79,9 @@ public class WayCategoryGraphStorageBuilder extends AbstractGraphStorageBuilder
 			}
 		}
 	}
-	
-	public void processEdge(ReaderWay way, EdgeIteratorState edge)
-	{
-		if (_wayType > 0) 
-			_storage.setEdgeValue(edge.getEdge(), _wayType);
+
+	public void processEdge(ReaderWay way, EdgeIteratorState edge) {
+		_storage.setEdgeValue(edge.getEdge(), _wayType);
 	}
 
 	private boolean isFerryRoute(ReaderWay way) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.


Fixes #535 .

### Information about the changes

Data for all processed edges is written into any storage even if the information is missing in order to ensure that the storage contains entries for all edge IDs. These edges might be queried later during routing or in some preprocessing phase, such as the one for CALT.