### PR TITLE
Remove border lmset appconfig resolves #531

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)
 - Reduced distance for neighbourhood point search in isochrones when small isochrones are generated (#494)
-- Removed obsolete storages (#536) 
+- Removed obsolete storages (#536)
+- Removed avoid borders landmark set as default from app.config.sample
 ### Deprecated
 
 ## [5.0.1] - 2019-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - isochrone reachfactor gives now more realistic results (#325)
 - Fixed the wrong gpx header for api v2 (#496)
+- Check if BordersStorage exists before calling it in AvoidBordersCoreEdgeFilter
 ### Changed
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/AvoidBordersEdgeFilter.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/AvoidBordersEdgeFilter.java
@@ -25,6 +25,8 @@ import org.apache.log4j.Logger;
 public class AvoidBordersEdgeFilter implements EdgeFilter {
     private BordersExtractor.Avoid _avoidBorders = BordersExtractor.Avoid.NONE;
     private boolean _avoidCountries = false;
+    private boolean isStorageBuilt;
+
 
     private BordersExtractor _bordersExtractor;
 
@@ -45,7 +47,8 @@ public class AvoidBordersEdgeFilter implements EdgeFilter {
      */
     private void init(RouteSearchParameters searchParams, BordersGraphStorage extBorders) {
         // Init the graph storage
-        if(extBorders != null) {
+        isStorageBuilt = extBorders != null;
+        if(isStorageBuilt) {
             int[] avoidCountries;
             if(searchParams.hasAvoidCountries())
                 avoidCountries = searchParams.getAvoidCountries();
@@ -71,6 +74,9 @@ public class AvoidBordersEdgeFilter implements EdgeFilter {
      */
     @Override
     public final boolean accept(EdgeIteratorState iter) {
+
+        if(!isStorageBuilt)
+            return true;
 
         if (_avoidBorders != BordersExtractor.Avoid.NONE) {
             // We have been told to avoid some form of border

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/core/AvoidBordersCoreEdgeFilter.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/edgefilters/core/AvoidBordersCoreEdgeFilter.java
@@ -24,16 +24,19 @@ public class AvoidBordersCoreEdgeFilter implements EdgeFilter {
     private BordersGraphStorage storage;
     private int[] avoidCountries;
     private boolean isAvoidCountries = false;
+    private boolean isStorageBuilt;
 
     //Used to avoid all borders
     public AvoidBordersCoreEdgeFilter(GraphStorage graphStorage) {
         this.storage = GraphStorageUtils.getGraphExtension(graphStorage, BordersGraphStorage.class);
+        isStorageBuilt = storage != null;
     }
     //Used to specify multiple countries to avoid (For a specific LM set)
     public AvoidBordersCoreEdgeFilter(GraphStorage graphStorage, int[] avoidCountries) {
         this.storage = GraphStorageUtils.getGraphExtension(graphStorage, BordersGraphStorage.class);
         this.avoidCountries = avoidCountries;
         if(avoidCountries.length > 0) isAvoidCountries = true;
+        isStorageBuilt = storage != null;
     }
 
     public int[] getAvoidCountries(){
@@ -46,17 +49,19 @@ public class AvoidBordersCoreEdgeFilter implements EdgeFilter {
      */
     @Override
     public final boolean accept(EdgeIteratorState iter) {
+        //If there is no borders storage, we accept everything
+        if(!isStorageBuilt) return true;
+
         //If a specific country was given, just check if its one of the country borders
         if(iter instanceof CHEdgeIterator)
             if(((CHEdgeIterator)iter).isShortcut()) return true;
+
         if(isAvoidCountries)
             return !restrictedCountry(iter.getEdge());
+
         //else check if there is ANY border
-        if (storage == null) {
-            return true;
-        } else {
-            return storage.getEdgeValue(iter.getEdge(), BordersGraphStorage.Property.TYPE) == BordersGraphStorage.NO_BORDER;
-        }
+        return storage.getEdgeValue(iter.getEdge(), BordersGraphStorage.Property.TYPE) == BordersGraphStorage.NO_BORDER;
+
 
     }
 

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -113,7 +113,7 @@
                       "threads": 1,
                       "weightings": "fastest|shortest",
                       "landmarks": 64,
-                      "lmsets": "highways,tollways;highways;tollways;country_193;allow_all"
+                      "lmsets": "highways;allow_all"
                   }
                 }
               },
@@ -170,7 +170,7 @@
                     "threads": 1,
                     "weightings": "fastest|shortest",
                     "landmarks": 64,
-                    "lmsets": "highways,tollways;highways;tollways;country_193;allow_all"
+                    "lmsets": "highways;allow_all"
                   }
                 }
               },


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #531 and #547   .

### Information about the changes
- Key functionality added:
 Check whether the borders storage exists before calling it in AvoidBordersCoreEdgeFilter
Removed most lmsets from app.config.sample
- Reason for change:
Not useful to have country_193 (CH) as default lmset. Also crashes if you dont have the AvoidBordersStorage built.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
- removed most sets
