### PR TITLE
Consider edge direction when expanding shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed the wrong gpx header for api v2 (#496)
 - Make sure external storages contain entries for all edge IDs (#535)
 - Check if BordersStorage exists before calling it in AvoidBordersCoreEdgeFilter
+- Take into account shortcut direction in LM selection weighting (#550)
 ### Changed
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -118,7 +118,7 @@ public class CoreLandmarkStorage implements Storable<LandmarkStorage>{
                     if (res >= Double.MAX_VALUE)
                         return Double.POSITIVE_INFINITY;
 
-                    expandEdge(tmp, false);
+                    expandEdge(tmp, reverse);
 
                     return count;
                 }
@@ -161,22 +161,25 @@ public class CoreLandmarkStorage implements Storable<LandmarkStorage>{
         int skippedEdge2 = mainEdgeState.getSkippedEdge2();
         int from = mainEdgeState.getBaseNode(), to = mainEdgeState.getAdjNode();
 
+        if (reverse) {
+            int tmp = from;
+            from = to;
+            to = tmp;
+        }
 
+        CHEdgeIteratorState iter = core.getEdgeIteratorState(skippedEdge1, from);
+        boolean empty = iter == null;
+        if (empty)
+            iter =  core.getEdgeIteratorState(skippedEdge2, from);
 
-            CHEdgeIteratorState iter = core.getEdgeIteratorState(skippedEdge1, from);
-            boolean empty = iter == null;
-            if (empty)
-                iter =  core.getEdgeIteratorState(skippedEdge2, from);
+        expandEdge(iter, true);
 
-            expandEdge(iter, true);
+        if (empty)
+            iter =  core.getEdgeIteratorState(skippedEdge1, to);
+        else
+            iter =  core.getEdgeIteratorState(skippedEdge2, to);
 
-            if (empty)
-                iter =  core.getEdgeIteratorState(skippedEdge1, to);
-            else
-                iter =  core.getEdgeIteratorState(skippedEdge2, to);
-
-            expandEdge(iter, false);
-
+        expandEdge(iter, false);
     }
 
     /**


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.


Fixes #550 (hopefully for good).

### Information about the changes

The original approach didn't take into account edge directions when expanding shortcuts in LM preparation phase which was not quite right.