### PR TITLE
Fixed problem where destinations was being used as sources in v2 matr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make sure external storages contain entries for all edge IDs (#535)
 - Check if BordersStorage exists before calling it in AvoidBordersCoreEdgeFilter
 - Take into account shortcut direction in LM selection weighting (#550)
+- Updated Matrix api v2 response to correctly display sources (#560)
 ### Changed
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)

--- a/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/matrix/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/heigit/ors/v2/services/matrix/ResultTest.java
@@ -63,6 +63,30 @@ public class ResultTest extends ServiceTest {
         locationsLong.put(coord3);
         addParameter("locationsLong", locationsLong);
 
+        JSONArray locations5 = new JSONArray();
+        coord1 = new JSONArray();
+        coord1.put(8.684682);
+        coord1.put(49.401961);
+        locations5.put(coord1);
+        coord2 = new JSONArray();
+        coord2.put(8.690518);
+        coord2.put(49.405326);
+        locations5.put(coord2);
+        coord3 = new JSONArray();
+        coord3.put(8.690915);
+        coord3.put(49.430117);
+        locations5.put(coord3);
+        coord4 = new JSONArray();
+        coord4.put(8.68834);
+        coord4.put(49.427758);
+        locations5.put(coord4);
+        JSONArray coord5 = new JSONArray();
+        coord5.put(8.687525);
+        coord5.put(49.405437);
+        locations5.put(coord5);
+
+        addParameter("locations5", locations5);
+
         // Fake array to test maximum exceedings
         JSONArray maximumLocations = HelperFunctions.fakeJSONLocations(MatrixServiceSettings.getMaximumRoutes(false) + 1);
         addParameter("maximumLocations", maximumLocations);
@@ -792,6 +816,36 @@ public class ResultTest extends ServiceTest {
                 .body("durations[1][1]", is(102.53f))
                 .body("durations[2][0]", is(90.42f))
                 .body("durations[2][1]", is(0.0f))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testDefinedSourcesAndDestinations() {
+
+        JSONObject body = new JSONObject();
+
+        body.put("locations", getParameter("locations5"));
+        body.put("sources", new JSONArray(new int[] {0,1}));
+        body.put("destinations", new JSONArray(new int[] {2,3,4}));
+
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when().log().ifValidationFails()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'destinations' }", is(true))
+                .body("any { it.key == 'sources' }", is(true))
+                .body("destinations.size()", is(3))
+                .body("sources.size()", is(2))
+                .body("destinations[0].snapped_distance", is(4.18f))
+                .body("destinations[1].snapped_distance", is(2.42f))
+                .body("destinations[2].snapped_distance", is(7.11f))
+                .body("sources[0].snapped_distance", is(8.98f))
+                .body("sources[1].snapped_distance", is(7.87f))
                 .statusCode(200);
     }
 }

--- a/openrouteservice/src/main/java/heigit/ors/api/responses/matrix/JSONMatrixResponseObjects/JSONBasedIndividualMatrixResponse.java
+++ b/openrouteservice/src/main/java/heigit/ors/api/responses/matrix/JSONMatrixResponseObjects/JSONBasedIndividualMatrixResponse.java
@@ -44,7 +44,7 @@ class JSONBasedIndividualMatrixResponse {
 
     List<JSON2DSources> constructSources(MatrixResult matrixResult) {
         List<JSON2DSources> sources = new ArrayList<>();
-        for (ResolvedLocation location : matrixResult.getDestinations()) {
+        for (ResolvedLocation location : matrixResult.getSources()) {
             if (location != null)
                 sources.add(new JSON2DSources(location, includeResolveLocations));
             else


### PR DESCRIPTION
…ix api response

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #560  .

### Information about the changes
- Key functionality added: Fixed incorrect method call in constructing matrix response
- Reason for change: The response wa using the destinations coordinates as the source coordinates in the response

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
