### PR TITLE
Check for null pointers in shortcut expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Check if BordersStorage exists before calling it in AvoidBordersCoreEdgeFilter
 - Take into account shortcut direction in LM selection weighting (#550)
 - Updated Matrix api v2 response to correctly display sources (#560)
+- Check for null pointer in LM selection weighting (#550)
 ### Changed
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -161,6 +161,8 @@ public class CoreLandmarkStorage implements Storable<LandmarkStorage>{
         int skippedEdge2 = mainEdgeState.getSkippedEdge2();
         int from = mainEdgeState.getBaseNode(), to = mainEdgeState.getAdjNode();
 
+        //TODO: This is an adaptation of the Path4CH expansion algo. The original algo does not properly apply to our core
+        // and therefore produces NPEs sometimes. For now this is fixed by a brute force algo that just tries to expand all edges and checks for null every time
         CHEdgeIteratorState iter = core.getEdgeIteratorState(skippedEdge1, from);
         if (iter != null) {
             expandEdge(iter);

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -151,7 +151,7 @@ public class CoreLandmarkStorage implements Storable<LandmarkStorage>{
         this.subnetworkStorage = new SubnetworkStorage(dir, "landmarks_core_" + name);
     }
 
-    private void expandEdge(CHEdgeIteratorState mainEdgeState, boolean reverse) {
+    private void expandEdge(CHEdgeIteratorState mainEdgeState) {
         if (!mainEdgeState.isShortcut()) {
             count += 1;
             return;
@@ -161,25 +161,21 @@ public class CoreLandmarkStorage implements Storable<LandmarkStorage>{
         int skippedEdge2 = mainEdgeState.getSkippedEdge2();
         int from = mainEdgeState.getBaseNode(), to = mainEdgeState.getAdjNode();
 
-        if (reverse) {
-            int tmp = from;
-            from = to;
-            to = tmp;
-        }
-
         CHEdgeIteratorState iter = core.getEdgeIteratorState(skippedEdge1, from);
-        boolean empty = iter == null;
-        if (empty)
-            iter =  core.getEdgeIteratorState(skippedEdge2, from);
-
-        expandEdge(iter, true);
-
-        if (empty)
-            iter =  core.getEdgeIteratorState(skippedEdge1, to);
-        else
-            iter =  core.getEdgeIteratorState(skippedEdge2, to);
-
-        expandEdge(iter, false);
+        if (iter != null) {
+            expandEdge(iter);
+            iter = core.getEdgeIteratorState(skippedEdge2, to);
+            if(iter != null)
+                expandEdge(iter);
+        }
+        else {
+            iter = core.getEdgeIteratorState(skippedEdge1, to);
+            if (iter != null)
+                expandEdge(iter);
+            iter = core.getEdgeIteratorState(skippedEdge2, from);
+            if (iter != null)
+                expandEdge(iter);
+        }
     }
 
     /**

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -118,7 +118,7 @@ public class CoreLandmarkStorage implements Storable<LandmarkStorage>{
                     if (res >= Double.MAX_VALUE)
                         return Double.POSITIVE_INFINITY;
 
-                    expandEdge(tmp, reverse);
+                    expandEdge(tmp);
 
                     return count;
                 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #550 .

### Information about the changes
- Key functionality added: Check for null pointer before any edge expansion
- Reason for change: Obviously NPEs

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
