### PR TITLE
Replace pipes with commas in method weighting options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Take into account shortcut direction in LM selection weighting (#550)
 - Updated Matrix api v2 response to correctly display sources (#560)
 - Check for null pointer in LM selection weighting (#550)
+- Use commas rather than pipes for weighting options in app.config.sample (#564)
 ### Changed
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -70,7 +70,7 @@
                 "lm": {
                   "enabled": true,
                   "threads": 1,
-                  "weightings": "fastest|shortest",
+                  "weightings": "fastest,shortest",
                   "landmarks": 16
                 }
               }
@@ -105,13 +105,13 @@
                   "lm": {
                     "enabled": false,
                     "threads": 1,
-                    "weightings": "fastest|shortest",
+                    "weightings": "fastest,shortest",
                     "landmarks": 16
                   },
                   "core": {
                       "enabled": true,
                       "threads": 1,
-                      "weightings": "fastest|shortest",
+                      "weightings": "fastest,shortest",
                       "landmarks": 64,
                       "lmsets": "highways;allow_all"
                   }
@@ -162,13 +162,13 @@
                   "lm": {
                     "enabled": true,
                     "threads": 1,
-                    "weightings": "fastest|shortest",
+                    "weightings": "fastest,shortest",
                     "landmarks": 16
                   },
                   "core": {
                     "enabled": true,
                     "threads": 1,
-                    "weightings": "fastest|shortest",
+                    "weightings": "fastest,shortest",
                     "landmarks": 64,
                     "lmsets": "highways;allow_all"
                   }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #564 .

### Information about the changes
- Key functionality added: Replaced pipes with commas in the app.config.sample weightings options
- Reason for change: It seems that when passing these values across to GH, using pipes resulted in only the first weighting method being built. Replacing with a comma make sit so that both are built

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
- app.config should use commas rather than pipes: `"weightings": "shortest,fastest",` rather than `"weightings": "shortest|fastest",`
