### PR TITLE
Bugfix-#571 fix concurrency with routing with extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Check for null pointer in LM selection weighting (#550)
 - Use commas rather than pipes for weighting options in app.config.sample (#564)
 - Update point references when point is not found for routing (#567)
+- Fix concurrency issues when requesting extra info in routing (#571)
 ### Changed
 - Moved walking and hiking flag encoders to the ORS core system (#440)
 - Remove route optimization code (#499)

--- a/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/openrouteservice/src/main/java/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -336,6 +336,7 @@ public class ORSGraphHopper extends GraphHopper {
 				if (request.getEdgeFilter() != null)
 					algoOpts.setEdgeFilter(request.getEdgeFilter());
 				if(tr instanceof TranslationMap.ORSTranslationHashMapWithExtendedInfo){
+					tr = new TranslationMap.ORSTranslationHashMapWithExtendedInfo(tr.getLocale());
 					((TranslationMap.ORSTranslationHashMapWithExtendedInfo) tr).init(encoder, weighting, request.getPathProcessor());
 				}
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #571 .

### Information about the changes
- Key functionality added: None
- Reason for change: Fixes issue #571 , which caused (a) incorrect extra information to be included in concurrently generated responses, or (b) exceptions to be thrown whilst calculating extra information, leading to an empty 'extras' node in the response.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
- Not applicable.

### Required changes to app.config (if applicable)
- Not applicable.
