### PR TITLE
Feature/config also allowed outside war

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Indonesian Translation Language
+- Allow specifying a config file with -Dors_app_config=<file> anywhere on the filesystem
 ### Fixed
 ### Changed
 ### Deprecated

--- a/openrouteservice/src/main/java/heigit/ors/config/AppConfig.java
+++ b/openrouteservice/src/main/java/heigit/ors/config/AppConfig.java
@@ -31,6 +31,7 @@ import org.apache.log4j.Logger;
 import heigit.ors.util.StringUtility;
 import heigit.ors.util.FileUtility;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 
 public class AppConfig {
 
@@ -48,16 +49,20 @@ public class AppConfig {
 	public AppConfig()	{
 		File file;
 
-		String appConfigName = "app.config";
-		if(System.getenv("ORS_APP_CONFIG") != null)
-			appConfigName = System.getenv("ORS_APP_CONFIG");
-    	try {
-
-    		ClassPathResource rs = new ClassPathResource(appConfigName);
-			file = rs.getFile();
+		if(System.getProperty("ors_app_config") != null) {
+			file = new FileSystemResource(System.getProperty("ors_app_config")).getFile();
 			_config = ConfigFactory.parseFile(file);
-		} catch (IOException ioe) {
-    		LOGGER.error(ioe);
+		}else {
+			String appConfigName = "app.config";
+			if(System.getenv("ORS_APP_CONFIG") != null)
+				appConfigName = System.getenv("ORS_APP_CONFIG");
+			try {
+				ClassPathResource rs = new ClassPathResource(appConfigName);
+				file = rs.getFile();
+				_config = ConfigFactory.parseFile(file);
+			} catch (IOException ioe) {
+				LOGGER.error(ioe);
+			}
 		}
 
 		//Modification by H Leuschner: Save md5 hash of map file in static String for access with every request


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [-] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [-] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [-] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes # .

### Information about the changes
- Key functionality added:
Allow a config file to be stored outside of the war, and specify it as startup parameter.
- Reason for change:
Currently the config is part of the packaged war, which makes it hard to distribute over different servers with different config.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
