### PR TITLE
Revert "Integrate SonarQube"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,6 @@ branches:
   - master
   - development
   - integrate-travis
-  - development-v6
-
-addons:
-  sonarcloud:
-    organization: "giscience"
-
-git:
-    depth: false
 
 stages:
   - compile_test
@@ -31,7 +23,7 @@ jobs:
     - stage: compile_test
       script:
         - cp ${TRAVIS_BUILD_DIR}/openrouteservice-api-tests/conf/app.config.test ${TRAVIS_BUILD_DIR}/openrouteservice/src/main/resources/app.config
-        - mvn -f ${TRAVIS_BUILD_DIR}/openrouteservice/pom.xml org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -B
+        - mvn -f ${TRAVIS_BUILD_DIR}/openrouteservice/pom.xml install -B
         - mvn -f ${TRAVIS_BUILD_DIR}/openrouteservice/pom.xml tomcat7:run -B &
         - travis_wait 15 sleep 15m
         - curl http://127.0.0.1:8082/openrouteservice-5.0/health

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Openrouteservice
 
-| | [master](https://github.com/GIScience/openrouteservice) | [development](https://github.com/GIScience/openrouteservice/tree/development) |
-| --- | --- | --- |
-| build status | [![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=master)](https://travis-ci.org/GIScience/openrouteservice) | [![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=development)](https://travis-ci.org/GIScience/openrouteservice) |
-| quality gate | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=heigit.ors%3Aopenrouteservice&metric=alert_status&branch=master)](https://sonarcloud.io/dashboard?id=heigit.ors%3Aopenrouteservice) | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=heigit.ors%3Aopenrouteservice&metric=alert_status&branch=development)](https://sonarcloud.io/dashboard?id=heigit.ors%3Aopenrouteservice) |
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[master](https://github.com/GIScience/openrouteservice)&nbsp;&nbsp;&nbsp;&nbsp; [development](https://github.com/GIScience/openrouteservice/tree/development)
+
+[![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=master)](https://travis-ci.org/GIScience/openrouteservice) [![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=development)](https://travis-ci.org/GIScience/openrouteservice)
 
 The **openrouteservice API** provides global spatial services by consuming user-generated and collaboratively collected free geographic data directly from [OpenStreetMap](http://www.openstreetmap.org). It is highly customizable, performant and written in Java.
 


### PR DESCRIPTION
Reverts GIScience/openrouteservice#583

This PR is breaking travis checks for all builds coming from forked branches