### PR TITLE
Prevent SonarQube from analysing external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@ branches:
   - master
   - development
   - integrate-travis
+  - fix/#613-SonarQube-fails-on-external-PRs
+
+addons:
+  sonarcloud:
+    organization: "giscience"
+
+git:
+    depth: false
 
 stages:
   - compile_test
@@ -23,7 +31,13 @@ jobs:
     - stage: compile_test
       script:
         - cp ${TRAVIS_BUILD_DIR}/openrouteservice-api-tests/conf/app.config.test ${TRAVIS_BUILD_DIR}/openrouteservice/src/main/resources/app.config
-        - mvn -f ${TRAVIS_BUILD_DIR}/openrouteservice/pom.xml install -B
+        - if [[ "$TRAVIS_PULL_REQUEST" == "false" || \
+               "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]];
+          then
+              mvn -f ${TRAVIS_BUILD_DIR}/openrouteservice/pom.xml org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -B;
+          else
+              mvn -f ${TRAVIS_BUILD_DIR}/openrouteservice/pom.xml install -B;
+          fi
         - mvn -f ${TRAVIS_BUILD_DIR}/openrouteservice/pom.xml tomcat7:run -B &
         - travis_wait 15 sleep 15m
         - curl http://127.0.0.1:8082/openrouteservice-5.0/health

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Openrouteservice
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[master](https://github.com/GIScience/openrouteservice)&nbsp;&nbsp;&nbsp;&nbsp; [development](https://github.com/GIScience/openrouteservice/tree/development)
-
-[![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=master)](https://travis-ci.org/GIScience/openrouteservice) [![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=development)](https://travis-ci.org/GIScience/openrouteservice)
+| | [master](https://github.com/GIScience/openrouteservice) | [development](https://github.com/GIScience/openrouteservice/tree/development) |
+| --- | --- | --- |
+| build status | [![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=master)](https://travis-ci.org/GIScience/openrouteservice) | [![Build Status](https://travis-ci.org/GIScience/openrouteservice.svg?branch=development)](https://travis-ci.org/GIScience/openrouteservice) |
+| quality gate | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=heigit.ors%3Aopenrouteservice&metric=alert_status&branch=master)](https://sonarcloud.io/dashboard?id=heigit.ors%3Aopenrouteservice) | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=heigit.ors%3Aopenrouteservice&metric=alert_status&branch=development)](https://sonarcloud.io/dashboard?id=heigit.ors%3Aopenrouteservice) |
 
 The **openrouteservice API** provides global spatial services by consuming user-generated and collaboratively collected free geographic data directly from [OpenStreetMap](http://www.openstreetmap.org). It is highly customizable, performant and written in Java.
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #613 .

### Information about the changes
- Exclude external PR from being scanned by SonarQube
- This PR avoids build failures in Travis resulting from SonarQube not scanning external PRs due to security concerns

