### PR TITLE
fix algo selection for alternative routes with CORE and no LM

### DIFF
--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/services/routing/ResultTest.java
@@ -1606,6 +1606,24 @@ public class ResultTest extends ServiceTest {
                 .body("routes[1].summary.distance", is(10670.9f))
                 .body("routes[1].summary.duration", is(1414))
                 .statusCode(200);
+
+        given()
+                .param("coordinates", getParameter("coordinatesAR"))
+                .param("instructions", "true")
+                .param("preference", getParameter("preference"))
+                .param("profile", getParameter("carProfile"))
+                .param("options", "{\"avoid_features\":\"ferries\",\"alternative_routes_count\": 2}")
+                .when().log().ifValidationFails()
+                .get(getEndPointName())
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes.size()", is(2))
+                .body("routes[0].summary.distance", is(8178.2f))
+                .body("routes[0].summary.duration", is(1087.4f))
+                .body("routes[1].summary.distance", is(10670.9f))
+                .body("routes[1].summary.duration", is(1414))
+                .statusCode(200);
     }
 }
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -919,6 +919,8 @@ public class RoutingProfile {
             if (searchParams.requiresDynamicWeights() || flexibleMode) {
                 if (mGraphHopper.isCHEnabled())
                     req.getHints().put(KEY_CH_DISABLE, true);
+                if (mGraphHopper.isCoreEnabled())
+                   req.getHints().put(KEY_CORE_DISABLE, true);
                 if (mGraphHopper.getLMFactoryDecorator().isEnabled()) {
                     req.setAlgorithm(KEY_ASTARBI);
                     req.getHints().put(KEY_LM_DISABLE, false);
@@ -973,8 +975,9 @@ public class RoutingProfile {
                 req.getHints().put("alternative_route.max_paths", searchParams.getAlternativeRoutesCount());
                 req.getHints().put("alternative_route.max_weight_factor", searchParams.getAlternativeRoutesWeightFactor());
                 req.getHints().put("alternative_route.max_share_factor", searchParams.getAlternativeRoutesShareFactor());
-//              TAKB: contraction hierarchies have to be disabled for alternative routes until GH pulls https://github.com/graphhopper/graphhopper/pull/1524 and we update our fork.
+//              TAKB: CH and CORE have to be disabled for alternative routes
                 req.getHints().put(KEY_CH_DISABLE, true);
+                req.getHints().put(KEY_CORE_DISABLE, true);
             }
 
             if (directedSegment) {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -977,6 +977,7 @@ public class RoutingProfile {
                 req.getHints().put("alternative_route.max_share_factor", searchParams.getAlternativeRoutesShareFactor());
 //              TAKB: CH and CORE have to be disabled for alternative routes
                 req.getHints().put(KEY_CH_DISABLE, true);
+                req.getHints().put(KEY_LM_DISABLE, false);
                 req.getHints().put(KEY_CORE_DISABLE, true);
             }
 


### PR DESCRIPTION
Fixes issues with AlternativeRoutes in case the profile setup has Core enabled and no LM. Also adds a test for AR requests with restriction params.
