### PR TITLE
Fix wrong elevation JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 ### Fixed
+- Fixed invalid JSON and GeoJSON when including elevation ([#640](https://github.com/GIScience/openrouteservice/issues/640))
 ### Changed
 - Make Docker setup more flexible wrt customizations (#627)
 ### Deprecated

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -830,7 +830,7 @@ public class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 8.714833f, 49.424603f))
+                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 107.81765f, 8.714833f, 49.424603f, 404.725f))
                 .statusCode(200);
     }
 
@@ -853,7 +853,7 @@ public class ResultTest extends ServiceTest {
                 .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 8.714833f, 49.424603f))
+                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 107.81765f, 8.714833f, 49.424603f, 404.725f))
                 .body("routes[0].segments[0].steps[0].maneuver.bearing_before", is(0))
                 //.body("routes[0].segments[0].steps[0].maneuver.bearing_after", is(260))
                 .body("routes[0].segments[0].steps[0].maneuver.bearing_after", is(175))

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -830,7 +830,7 @@ public class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 107.81765f, 8.714833f, 49.424603f, 404.725f))
+                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 107.82f, 8.714833f, 49.424603f, 404.73f))
                 .statusCode(200);
     }
 
@@ -853,7 +853,7 @@ public class ResultTest extends ServiceTest {
                 .then().log().ifValidationFails()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 107.81765f, 8.714833f, 49.424603f, 404.725f))
+                .body("routes[0].bbox", hasItems(8.678615f, 49.393272f, 107.82f, 8.714833f, 49.424603f, 404.73f))
                 .body("routes[0].segments[0].steps[0].maneuver.bearing_before", is(0))
                 //.body("routes[0].segments[0].steps[0].maneuver.bearing_after", is(260))
                 .body("routes[0].segments[0].steps[0].maneuver.bearing_after", is(175))

--- a/openrouteservice/src/main/java/org/heigit/ors/api/responses/common/boundingbox/BoundingBox3DBase.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/responses/common/boundingbox/BoundingBox3DBase.java
@@ -19,6 +19,7 @@ import com.graphhopper.util.shapes.BBox;
 import org.heigit.ors.util.FormatUtility;
 
 public class BoundingBox3DBase extends BoundingBoxBase {
+    private static final int ELEVATION_DECIMAL_PLACES = 2;
     protected double minEle;
     protected double maxEle;
 
@@ -41,10 +42,10 @@ public class BoundingBox3DBase extends BoundingBoxBase {
         return new double[] {
                 FormatUtility.roundToDecimals(minLon, COORDINATE_DECIMAL_PLACES),
                 FormatUtility.roundToDecimals(minLat, COORDINATE_DECIMAL_PLACES),
-                FormatUtility.roundToDecimals(minEle, COORDINATE_DECIMAL_PLACES),
+                FormatUtility.roundToDecimals(minEle, ELEVATION_DECIMAL_PLACES),
                 FormatUtility.roundToDecimals(maxLon, COORDINATE_DECIMAL_PLACES),
                 FormatUtility.roundToDecimals(maxLat, COORDINATE_DECIMAL_PLACES),
-                FormatUtility.roundToDecimals(maxEle, COORDINATE_DECIMAL_PLACES),
+                FormatUtility.roundToDecimals(maxEle, ELEVATION_DECIMAL_PLACES),
         };
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/api/responses/common/boundingbox/BoundingBox3DBase.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/responses/common/boundingbox/BoundingBox3DBase.java
@@ -16,6 +16,7 @@
 package org.heigit.ors.api.responses.common.boundingbox;
 
 import com.graphhopper.util.shapes.BBox;
+import org.heigit.ors.util.FormatUtility;
 
 public class BoundingBox3DBase extends BoundingBoxBase {
     protected double minEle;
@@ -33,5 +34,17 @@ public class BoundingBox3DBase extends BoundingBoxBase {
 
     public double getMaxEle() {
         return maxEle;
+    }
+
+    @Override
+    public double[] getAsArray() {
+        return new double[] {
+                FormatUtility.roundToDecimals(minLon, COORDINATE_DECIMAL_PLACES),
+                FormatUtility.roundToDecimals(minLat, COORDINATE_DECIMAL_PLACES),
+                FormatUtility.roundToDecimals(minEle, COORDINATE_DECIMAL_PLACES),
+                FormatUtility.roundToDecimals(maxLon, COORDINATE_DECIMAL_PLACES),
+                FormatUtility.roundToDecimals(maxLat, COORDINATE_DECIMAL_PLACES),
+                FormatUtility.roundToDecimals(maxEle, COORDINATE_DECIMAL_PLACES),
+        };
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResult.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResult.java
@@ -127,7 +127,7 @@ public class RouteResult
 
 	public void addPointlist(PointList pointlistToAdd) {
 		if (pointlist == null) {
-			pointlist = new PointList();
+			pointlist = new PointList(pointlistToAdd.getSize(), pointlistToAdd.is3D());
 		}
 		pointlist.add(pointlistToAdd);
 	}


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the development branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #640   .

### Information about the changes
- Key functionality added: Fixes wrong bbox JSON parsing for JSON and GeoJSON responses.
- Reason for change: When elevation was requested no elevation was actually returned for JSON dependent bbox outputs.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
