### PR TITLE
Added green and noise to the api parameters for extra info (fixes #688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Fixed
+- Allowed the usage of green and noise in extra info parameter ([#688](https://github.com/GIScience/openrouteservice/issues/688))
 ### Changed
 ### Deprecated
 

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -1123,6 +1123,82 @@ public class ResultTest extends ServiceTest {
     }
 
     @Test
+    public void testGreenExtraInfo() {
+        JSONObject body = new JSONObject();
+
+        JSONArray coordinates = new JSONArray();
+        JSONArray coord1 = new JSONArray();
+        coord1.put(8.676023);
+        coord1.put(49.416809);
+        coordinates.put(coord1);
+        JSONArray coord2 = new JSONArray();
+        coord2.put(8.696837);
+        coord2.put(49.411839);
+        coordinates.put(coord2);
+        body.put("coordinates", coordinates);
+
+        body.put("extra_info", constructExtras("green"));
+
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].containsKey('extras')", is(true))
+                .body("routes[0].extras.green.values[0][0]", is(0))
+                .body("routes[0].extras.green.values[0][1]", is(8))
+                .body("routes[0].extras.green.values[0][2]", is(9))
+                .body("routes[0].extras.green.values[3][0]", is(15))
+                .body("routes[0].extras.green.values[3][1]", is(34))
+                .body("routes[0].extras.green.values[3][2]", is(10))
+
+                .statusCode(200);
+    }
+
+    @Test
+    public void testNoiseExtraInfo() {
+        JSONObject body = new JSONObject();
+
+        JSONArray coordinates = new JSONArray();
+        JSONArray coord1 = new JSONArray();
+        coord1.put(8.676023);
+        coord1.put(49.416809);
+        coordinates.put(coord1);
+        JSONArray coord2 = new JSONArray();
+        coord2.put(8.696837);
+        coord2.put(49.411839);
+        coordinates.put(coord2);
+        body.put("coordinates", coordinates);
+
+        body.put("extra_info", constructExtras("noise"));
+
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].containsKey('extras')", is(true))
+                .body("routes[0].extras.noise.values[0][0]", is(0))
+                .body("routes[0].extras.noise.values[0][1]", is(10))
+                .body("routes[0].extras.noise.values[0][2]", is(10))
+                .body("routes[0].extras.noise.values[4][0]", is(27))
+                .body("routes[0].extras.noise.values[4][1]", is(34))
+                .body("routes[0].extras.noise.values[4][2]", is(9))
+
+                .statusCode(200);
+    }
+
+    @Test
     public void testOptimizedAndTurnRestrictions() {
         JSONObject body = new JSONObject();
         body.put("coordinates", constructCoords("8.684081,49.398155|8.684703,49.397359"));

--- a/openrouteservice/src/main/java/org/heigit/ors/api/requests/common/APIEnums.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/requests/common/APIEnums.java
@@ -64,7 +64,9 @@ public class APIEnums {
         TRAIL_DIFFICULTY("traildifficulty"),
         OSM_ID("osmid"),
         ROAD_ACCESS_RESTRICTIONS("roadaccessrestrictions"),
-        COUNTRY_INFO("countryinfo");
+        COUNTRY_INFO("countryinfo"),
+        GREEN("green"),
+        NOISE("noise");
 
         private final String value;
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #688 .

### Information about the changes
- Key functionality added: Added the green and noise values to the APIEnums class for extra_info
- Reason for change: These values were missing and so the information couldnt be requested (API threw a invalid parameter value exception)

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
