### PR TITLE
Pedestrian core alt only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Querying shortest weighting can now use CH shortest preparation if available
 ### Changed
 - Refactor the algorithm selection process
+- Use ALT/A* Beeline for roundtrips. Enable Core-ALT-only for pedestrian profile.
 ### Deprecated
 
 ## [6.1.0] - 2020-03-06

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -2861,8 +2861,9 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes.size()", is(1))
-                .body("routes[0].summary.distance", is(1866.2f))
-                .body("routes[0].summary.duration", is(1343.6f))
+                //A* Beeline and ALT values, respectively
+                .body("routes[0].summary.distance", anyOf(is(1866.2f), is(1792.8f)))
+                .body("routes[0].summary.duration", anyOf(is(1343.6f), is(1290.8f)))
                 .statusCode(200);
 
         JSONObject avoidGeom = new JSONObject("{\"type\":\"Polygon\",\"coordinates\":[[[8.670658,49.446519], [8.671023,49.446331], [8.670723,49.446212], [8.670658,49.446519]]]}}");
@@ -2879,8 +2880,8 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes.size()", is(1))
-                .body("routes[0].summary.distance", is(1784.2f))
-                .body("routes[0].summary.duration", is(1284.6f))
+                .body("routes[0].summary.distance", anyOf(is(1784.2f), is(1792.8f)))
+                .body("routes[0].summary.duration", anyOf(is(1284.6f), is(1290.8f)))
                 .statusCode(200);
 
         options.remove("avoid_polygons");
@@ -2897,8 +2898,8 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes.size()", is(1))
-                .body("routes[0].summary.distance", is( 1559.3f))
-                .body("routes[0].summary.duration", is(1122.7f))
+                .body("routes[0].summary.distance", anyOf(is(1559.3f), is(1559.3f)))
+                .body("routes[0].summary.duration", anyOf(is(1122.7f), is(1122.7f)))
                 .statusCode(200);
 
         body.put("bearings", constructBearings("25,30"));
@@ -2913,8 +2914,8 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes.size()", is(1))
-                .body("routes[0].summary.distance", is(2519.8f))
-                .body("routes[0].summary.duration", is(1814.2f))
+                .body("routes[0].summary.distance", anyOf(is(2519.8f), is(2496.8f)))
+                .body("routes[0].summary.duration", anyOf(is(1814.2f), is(1797.6f)))
                 .statusCode(200);
     }
     

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -2861,8 +2861,8 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes.size()", is(1))
-                .body("routes[0].summary.distance", is(1792.8f))
-                .body("routes[0].summary.duration", is(1290.8f))
+                .body("routes[0].summary.distance", is(1866.2f))
+                .body("routes[0].summary.duration", is(1343.6f))
                 .statusCode(200);
 
         JSONObject avoidGeom = new JSONObject("{\"type\":\"Polygon\",\"coordinates\":[[[8.670658,49.446519], [8.671023,49.446331], [8.670723,49.446212], [8.670658,49.446519]]]}}");
@@ -2879,8 +2879,8 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes.size()", is(1))
-                .body("routes[0].summary.distance", is( 1792.8f))
-                .body("routes[0].summary.duration", is(1290.8f))
+                .body("routes[0].summary.distance", is(1784.2f))
+                .body("routes[0].summary.duration", is(1284.6f))
                 .statusCode(200);
 
         options.remove("avoid_polygons");
@@ -2913,8 +2913,8 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes.size()", is(1))
-                .body("routes[0].summary.distance", is( 2496.8f))
-                .body("routes[0].summary.duration", is(1797.6f))
+                .body("routes[0].summary.distance", is(2519.8f))
+                .body("routes[0].summary.duration", is(1814.2f))
                 .statusCode(200);
     }
     


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.


### Information about the changes
- Key functionality added: Use only A* Beeline or ALT for roundtrips. Support for pedestrian profile using only Core-ALT.
- Reason for change: CH/CALT do not work properly with roundtrip. At the same time, the goal is to use solely Core-ALT as speedup. This PR enables using foot profile when building only Core-ALT. All routing cases are then covered by either Core-ALT or A* Beeline. Roundtrip produces different results for A* Beeline and ALT and Core-ALT and CH, respectively. That is because the usage is not proper for CALT/CH, and because the usage of the distance approximator for A* and ALT is wrong (in GH), leading to suboptimal and therefore ambiguous routes. That is why two test cases have to be covered, one if ALT is enabled for foot, one if it is only A* Beeline.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
ALT
![ALT route](https://user-images.githubusercontent.com/13396640/78562053-087ac300-7819-11ea-9688-635cf0e2cb08.png)
A* Beeline
![A* Beeline route](https://user-images.githubusercontent.com/13396640/78562386-8b9c1900-7819-11ea-8ef6-282a6b3b5908.png)
Core-ALT
![Core-ALT route](https://user-images.githubusercontent.com/13396640/78562412-95be1780-7819-11ea-87c7-a55f37380e64.png)

All three should be the same. But Core-ALT does not work with the current implementation and ALT/A* produce two different results because of the non-admissible heuristic used in GH implementation.




### Required changes to app.config (if applicable)
-
