### PR TITLE
Enable destination_speed in hgv flag encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Allowed the usage of green and noise in extra info parameter ([#688](https://github.com/GIScience/openrouteservice/issues/688))
 - Fixed way surface/type encoding issue ([#677](https://github.com/GIScience/openrouteservice/issues/677))
 - Querying shortest weighting can now use CH shortest preparation if available
+- Roads tagged with destination access are penalized the same way for hgv as for car ([#525](https://github.com/GIScience/openrouteservice/issues/525))
 ### Changed
 - Refactor the algorithm selection process
 - Use ALT/A* Beeline for roundtrips. Enable Core-ALT-only for pedestrian profile.

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/services/routing/ResultTest.java
@@ -896,7 +896,7 @@ public class ResultTest extends ServiceTest {
                 .body("routes[0].extras.tollways.values[1][1]", is(66))
                 .body("routes[0].extras.tollways.values[1][2]", is(1))
                 .body("routes[0].extras.tollways.values[2][0]", is(66))
-                .body("routes[0].extras.tollways.values[2][1]", is(86))
+                .body("routes[0].extras.tollways.values[2][1]", is(101))
                 .body("routes[0].extras.tollways.values[2][2]", is(0))
 				.statusCode(200);
 
@@ -925,7 +925,7 @@ public class ResultTest extends ServiceTest {
 				.body("routes[0].extras.tollways.values[1][1]", is(66))
 				.body("routes[0].extras.tollways.values[1][2]", is(1))
 				.body("routes[0].extras.tollways.values[2][0]", is(66))
-				.body("routes[0].extras.tollways.values[2][1]", is(86))
+				.body("routes[0].extras.tollways.values[2][1]", is(101))
 				.body("routes[0].extras.tollways.values[2][2]", is(0))
 				.statusCode(200);
 
@@ -1145,7 +1145,7 @@ public class ResultTest extends ServiceTest {
 				.assertThat()
 				.body("any { it.key == 'routes' }", is(true))
 				.body("routes[0].summary.distance", is(379.5f))
-				.body("routes[0].summary.duration", is(136))
+				.body("routes[0].summary.duration", is(270))
 				.statusCode(200);
 	}
 
@@ -1164,7 +1164,7 @@ public class ResultTest extends ServiceTest {
 				.assertThat()
 				.body("any { it.key == 'routes' }", is(true))
 				.body("routes[0].summary.distance", is(549))
-				.body("routes[0].summary.duration", is(163.2f))
+				.body("routes[0].summary.duration", is(185.4f))
 				.statusCode(200);
 
 		given()
@@ -1180,7 +1180,7 @@ public class ResultTest extends ServiceTest {
 				.assertThat()
 				.body("any { it.key == 'routes' }", is(true))
 				.body("routes[0].summary.distance", is(376.5f))
-				.body("routes[0].summary.duration", is(130))
+				.body("routes[0].summary.duration", is(184.2f))
 				.statusCode(200);
 	}
 

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -1077,7 +1077,7 @@ public class ResultTest extends ServiceTest {
                 .body("routes[0].extras.tollways.values[1][1]", is(66))
                 .body("routes[0].extras.tollways.values[1][2]", is(1))
                 .body("routes[0].extras.tollways.values[2][0]", is(66))
-                .body("routes[0].extras.tollways.values[2][1]", is(86))
+                .body("routes[0].extras.tollways.values[2][1]", is(101))
                 .body("routes[0].extras.tollways.values[2][2]", is(0))
                 .statusCode(200);
 
@@ -1115,7 +1115,7 @@ public class ResultTest extends ServiceTest {
                 .body("routes[0].extras.tollways.values[1][1]", is(66))
                 .body("routes[0].extras.tollways.values[1][2]", is(1))
                 .body("routes[0].extras.tollways.values[2][0]", is(66))
-                .body("routes[0].extras.tollways.values[2][1]", is(86))
+                .body("routes[0].extras.tollways.values[2][1]", is(101))
                 .body("routes[0].extras.tollways.values[2][2]", is(0))
                 .statusCode(200);
 
@@ -1465,7 +1465,7 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(379.5f))
-                .body("routes[0].summary.duration", is(136.0f))
+                .body("routes[0].summary.duration", is(270.0f))
                 .statusCode(200);
     }
 
@@ -1497,7 +1497,7 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(549.0f))
-                .body("routes[0].summary.duration", is(163.2f))
+                .body("routes[0].summary.duration", is(185.4f))
                 .statusCode(200);
 
         restrictions = new JSONObject();
@@ -1520,7 +1520,7 @@ public class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(376.5f))
-                .body("routes[0].summary.duration", is(130.0f))
+                .body("routes[0].summary.duration", is(184.2f))
                 .statusCode(200);
     }
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -117,9 +117,6 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
         backwardKeys.add("forestry:backward");
         backwardKeys.add("delivery:backward");
 
-        // Disable reduction of speed on roads with destination only tag - this was only enabled in the car and emergency vehicle profiles
-        destinationSpeed = -1;
-
         init();
     }
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #525 (partially, see comments therein).

### Information about the changes
- Key functionality added: Set `destinationSpeed` on ways tagged with `access:destination`.
- Reason for change: Use common mechanism across profiles to discourage routing over ways tagged with `access:destination`.
