### PR TITLE
read ele tag data for nodes if app.config flag set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Configuration option to read elevation tags from pbf data
 ### Fixed
 - Allowed the usage of green and noise in extra info parameter ([#688](https://github.com/GIScience/openrouteservice/issues/688))
 - Fixed way surface/type encoding issue ([#677](https://github.com/GIScience/openrouteservice/issues/677))

--- a/openrouteservice-api-tests/conf/app.config.test
+++ b/openrouteservice-api-tests/conf/app.config.test
@@ -39,6 +39,7 @@
         attribution: "openrouteservice.org, OpenStreetMap contributors, tmc - BASt",
         distance_approximation: true,
         routing_name: "ORSRouting",
+        "elevation_preprocessed": false,
         profiles: {
           active: ["vehicles-car", "vehicles-hgv", "bike", "bike-mtb", "bike-road", "bike-e", "pedestrian-walk", "pedestrian-hike", "wheelchair"],
           default_params: {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
@@ -23,6 +23,7 @@ import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.shapes.GHPoint;
 import com.vividsolutions.jts.geom.Coordinate;
 import org.apache.log4j.Logger;
+import org.heigit.ors.config.AppConfig;
 import org.heigit.ors.routing.graphhopper.extensions.reader.osmfeatureprocessors.OSMFeatureFilter;
 import org.heigit.ors.routing.graphhopper.extensions.reader.osmfeatureprocessors.WheelchairWayFilter;
 import org.heigit.ors.routing.graphhopper.extensions.storages.builders.BordersGraphStorageBuilder;
@@ -47,6 +48,8 @@ public class ORSOSMReader extends OSMReader {
 	private boolean processGeom = false;
 	private boolean processSimpleGeom = false;
 	private boolean detachSidewalksFromRoad = false;
+
+	private boolean processElevationFromPreprocessedData = "true".equalsIgnoreCase(AppConfig.getGlobal().getParameter("services.routing", "elevation_preprocessed"));
 
 	private List<OSMFeatureFilter> filtersToApply = new ArrayList<>();
 
@@ -412,5 +415,15 @@ public class ORSOSMReader extends OSMReader {
 		procCntx.finish();
 	}
 
-
+	@Override
+	protected double getElevation(ReaderNode node) {
+		if (processElevationFromPreprocessedData) {
+			double ele = node.getEle();
+			if (Double.isNaN(ele)) { // this should npt happen if preprocessing worked correctly
+				ele = 0;
+			}
+			return ele;
+		}
+		return super.getElevation(node);
+	}
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
@@ -49,7 +49,8 @@ public class ORSOSMReader extends OSMReader {
 	private boolean processSimpleGeom = false;
 	private boolean detachSidewalksFromRoad = false;
 
-	private boolean processElevationFromPreprocessedData = "true".equalsIgnoreCase(AppConfig.getGlobal().getParameter("services.routing", "elevation_preprocessed"));
+	private boolean getElevationFromPreprocessedData = "true".equalsIgnoreCase(AppConfig.getGlobal().getParameter("services.routing", "elevation_preprocessed"));
+	private boolean getElevationFromPreprocessedDataErrorLogged = false;
 
 	private List<OSMFeatureFilter> filtersToApply = new ArrayList<>();
 
@@ -417,9 +418,13 @@ public class ORSOSMReader extends OSMReader {
 
 	@Override
 	protected double getElevation(ReaderNode node) {
-		if (processElevationFromPreprocessedData) {
+		if (getElevationFromPreprocessedData) {
 			double ele = node.getEle();
-			if (Double.isNaN(ele)) { // this should npt happen if preprocessing worked correctly
+			if (Double.isNaN(ele)) {
+				if (!getElevationFromPreprocessedDataErrorLogged) {
+					LOGGER.error("elevation_preprocessed set to true in app.config, still found a Node with invalid ele tag! Set this flag only if you use a preprocessed pbf file! Node ID: " + node.getId());
+					getElevationFromPreprocessedDataErrorLogged = true;
+				}
 				ele = 0;
 			}
 			return ele;

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -38,6 +38,7 @@
         "sources": ["openrouteservice/src/main/files/heidelberg.osm.gz"],
         "init_threads": 2,
         "attribution": "openrouteservice.org, OpenStreetMap contributors",
+        "elevation_preprocessed": false,
         "profiles": {
           "active": [
             "car",


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

### Information about the changes
- Key functionality added:
Option in app.config ors.services.routing.elevation_preprocessed (true/false) added, if enabled ORSOSMReader reads elevation values from the 'ele' tags on nodes in the OSM file instead of using GHs elevation lookup. 
This is intended to be used in combination with the ors-preprocessor to reduce memory consumption during graph building. 

Also reduces processing time for the initial graph building, as a reference build times with germany, single profile build (car) with no graph preparations, elevation data for GH cached, local machine:
- original OSM file 589.679s
- preprocessed file without ele reading 378.853s
- preprocessed file with ele reading 339.448s.