### PR TITLE
Add location index parameters to configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Configuration option to read elevation tags from pbf data
+- Configuration parameters to set location index resolution and the maximum number of iterations in coordinates lookup ([#712](https://github.com/GIScience/openrouteservice/issues/712))
 ### Fixed
 - Allowed the usage of green and noise in extra info parameter ([#688](https://github.com/GIScience/openrouteservice/issues/688))
 - Fixed way surface/type encoding issue ([#677](https://github.com/GIScience/openrouteservice/issues/677))

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -363,7 +363,8 @@ public class RoutingProfile {
 
         args.put("graph.flag_encoders", flagEncoders.toString().toLowerCase());
 
-        args.put("index.high_resolution", 500);
+        args.put("index.high_resolution", config.getLocationIndexResolution());
+        args.put("index.max_region_search", config.getLocationIndexSearchIterations());
 
         return args;
     }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
@@ -53,6 +53,9 @@ public class RouteProfileConfiguration {
 	private Envelope extent;
 	private boolean hasMaximumSnappingRadius = false;
 
+	private int locationIndexResolution = 500;
+	private int locationIndexSearchIterations = 4;
+
 	public RouteProfileConfiguration() {
 		extStorages = new HashMap<>();
 		graphBuilders = new HashMap<>();
@@ -336,5 +339,21 @@ public class RouteProfileConfiguration {
 	public void setMaximumSnappingRadius(int maximumSnappingRadius) {
 		this.maximumSnappingRadius = maximumSnappingRadius;
 		this.hasMaximumSnappingRadius = true;
+	}
+
+	public int getLocationIndexResolution() {
+		return locationIndexResolution;
+	}
+
+	public void setLocationIndexResolution(int locationIndexResolution) {
+		this.locationIndexResolution = locationIndexResolution;
+	}
+
+	public int getLocationIndexSearchIterations() {
+		return locationIndexSearchIterations;
+	}
+
+	public void setLocationIndexSearchIterations(int locationIndexSearchIterations) {
+		this.locationIndexSearchIterations = locationIndexSearchIterations;
 	}
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/configuration/RoutingManagerConfiguration.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/configuration/RoutingManagerConfiguration.java
@@ -184,6 +184,12 @@ public class RoutingManagerConfiguration  {
 					case "maximum_snapping_radius":
 						profile.setMaximumSnappingRadius(Integer.parseInt(paramItem.getValue().toString()));
 						break;
+					case "location_index_resolution":
+						profile.setLocationIndexResolution(Integer.parseInt(paramItem.getValue().toString()));
+						break;
+					case "location_index_search_iterations":
+						profile.setLocationIndexSearchIterations(Integer.parseInt(paramItem.getValue().toString()));
+						break;
 					default:
 					}
 				}


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #712 .

### Information about the changes
- Key functionality added: enable control over location index storage resolution and coordinates lookup.

- Reason for change: address the dreaded "Could not find point" error message for remote locations away from OSM-mapped roads.

### Examples and reasons for differences between live ORS routes and those generated from this pull request

As a specific example consider location in Australia [reported in the ask forum](https://ask.openrouteservice.org/t/can-not-find-point-within-radius/1543/20).  With the current default internal settings (`index.high_resolution=500` and `index.max_region_search=4`) the location cannot be found even when disabling the ORS snapping radius limit.

`[2010] Could not find point 0: 115.4614830 -29.6923130 within a radius of -1.0 meters.`

With this update is is possible to increase the search area in app.config file by setting `location_index_search_iterations=6` such that the location gets snapped.

``` r
library(openrouteservice)
library(leaflet)

options(openrouteservice.url = "http://localhost:8082/ors")

coordinates <- data.frame(lng = c(115.4614830, 115.871436), lat = c(-29.6923130, -29.675383))

res <- ors_directions(coordinates, preference="fastest", radiuses = c(-1, 350))

leaflet() %>%
  addTiles() %>%
  fitBBox(res$bbox) %>%
  addGeoJSON(res, fill=FALSE) %>%
  addMarkers(coordinates$lng, coordinates$lat)
```

![image](https://user-images.githubusercontent.com/6545356/81498670-8faed100-92c6-11ea-8948-3534b7f45183.png)

Reducing `location_index_resolution` increases memory requirements. For example, once the default value `500` is reduced to  `300` the `location_index` file size for _Australia_  increases from 29MB to 55MB. The reduced resolution needs to be compensated by increasing `location_index_search_iterations` in order to keep the search area extent the same.  For example, in order to be able to resolve the particular location from the example above the following minimal settings are required.

```
location_index_resolution=300
location_index_search_iterations=10
```

### Required changes to app.config (if applicable)

Optional parameters `location_index_resolution` and `location_index_search_iterations` to set the internal GraphHopper location index storage parameters `index.high_resolution` and `index.max_region_search`, respectively, as documented on the [wiki](https://github.com/GIScience/openrouteservice/wiki/Configuration-(app.config)).
