### PR TITLE
Added check during building of instructions for via points during a r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Roads tagged with destination access are penalized the same way for hgv as for car ([#525](https://github.com/GIScience/openrouteservice/issues/525))
 - JAVA_OPTS and CATALINA_OPTS were not correctly set in Docker setup ([#696](https://github.com/GIScience/openrouteservice/issues/696))
 - Suitability values in extra info are not underestimated ([#722](https://github.com/GIScience/openrouteservice/issues/722))
+- Fixed problem with incorrect way point values being referenced for round trip ([#724](https://github.com/GIScience/openrouteservice/issues/724))
 ### Changed
 - Refactor the algorithm selection process
 - Use ALT/A* Beeline for roundtrips. Enable Core-ALT-only for pedestrian profile.

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -14,6 +14,7 @@
 package org.heigit.ors.v2.services.routing;
 
 import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
 import junit.framework.Assert;
 import org.heigit.ors.v2.services.common.EndPointAnnotation;
 import org.heigit.ors.v2.services.common.ServiceTest;
@@ -2916,6 +2917,58 @@ public class ResultTest extends ServiceTest {
                 .body("routes.size()", is(1))
                 .body("routes[0].summary.distance", anyOf(is(2519.8f), is(2496.8f)))
                 .body("routes[0].summary.duration", anyOf(is(1814.2f), is(1797.6f)))
+                .statusCode(200);
+    }
+
+    @Test
+    public void testWaypointCount() {
+        JSONObject body = new JSONObject();
+        JSONArray coordinates = new JSONArray();
+        JSONArray coord1 = new JSONArray();
+        coord1.put(8.673191);
+        coord1.put(49.446812);
+        coordinates.put(coord1);
+        body.put("coordinates", coordinates);
+        body.put("preference", "shortest");
+
+        JSONObject roundTripOptions = new JSONObject();
+        roundTripOptions.put("length", "2000");
+        JSONObject options = new JSONObject();
+
+        options.put("round_trip", roundTripOptions);
+        body.put("options", options);
+        body.put("instructions", false);
+
+        given()
+                .header("Accept", "application/geo+json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when().log().ifValidationFails()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("features[0].properties.way_points[1]", is(65))
+                .statusCode(200);
+
+        body = new JSONObject();
+        JSONArray coord2 = new JSONArray();
+        coord2.put(8.687782);
+        coord2.put(49.424597);
+        coordinates.put(coord2);
+        body.put("coordinates", coordinates);
+        body.put("preference", "shortest");
+
+        given()
+                .header("Accept", "application/geo+json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("footProfile"))
+                .body(body.toString())
+                .when().log().ifValidationFails()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("features[0].properties.way_points[1]", is(93))
                 .statusCode(200);
     }
     

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResultBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResultBuilder.java
@@ -156,6 +156,10 @@ class RouteResultBuilder
                 RouteStep step = new RouteStep();
 
                 Instruction instr = instructions.get(ii);
+                if (instr instanceof ViaInstruction && request.isRoundTripRequest()) {
+                    // if this is a via instruction, then we don't want to process it in the case of a round trip
+                    continue;
+                }
                 InstructionType instrType = getInstructionType(ii == 0, instr);
 
                 PointList currentStepPoints = instr.getPoints();

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingRequest.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingRequest.java
@@ -220,4 +220,8 @@ public class RoutingRequest extends ServiceRequest {
 	public String getResponseFormat() {
 		return this.responseFormat;
 	}
+
+	public boolean isRoundTripRequest() {
+		return this.coordinates.length == 1 && this.searchParameters.getRoundTripLength() > 0;
+	}
 }


### PR DESCRIPTION
…ound trip

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #724 .

### Information about the changes
- Key functionality added: Added a check during route result construction to skip any segments that are via instructions when doing round trip
- Reason for change: The openrouteservice code handles via points completely differently to GraphHopper, but the round trip route uses GH's via points to produce the roundness. These are returned as via instructions in the result from GH, and the openrouteservice code then incorrectly updates the current waypoint in the list meaning that towards the end of the list, the waypoint index exceeds the count of waypoints.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
- 

### Required changes to app.config (if applicable)
-
