### PR TITLE
Create project automation actions

### DIFF
--- a/.github/workflows/project_automation_add.yml
+++ b/.github/workflows/project_automation_add.yml
@@ -1,0 +1,25 @@
+name: project_automation_add
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.PROJECT_AUTOMATION }}
+
+jobs:
+  handle_add:
+    runs-on: ubuntu-latest
+    steps:
+    - name: add without label
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: "!contains(github.event.issue.labels.*.name, ':bug: bug')"
+      with:
+        project: 'https://github.com/GIScience/openrouteservice/projects/16'
+    - name: add with label
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: "contains(github.event.issue.labels.*.name, ':bug: bug')"
+      with:
+        project: 'https://github.com/GIScience/openrouteservice/projects/16'
+        column_name: 'Priority'

--- a/.github/workflows/project_automation_labels.yml
+++ b/.github/workflows/project_automation_labels.yml
@@ -1,0 +1,17 @@
+# This is a workflow to automate handling action based on labelling
+name: project_automation_labels
+
+on:
+  issues:
+    types: [labeled]
+jobs:
+  Move_Labeled_Issue_On_Project_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.PROJECT_AUTOMATION }}"
+        project-url: "https://github.com/GIScience/openrouteservice/projects/16"
+        column-name: "Priority"
+        label-name: ":bug: bug"
+        columns-to-ignore: "Priority,Assigned,In progress,Review,Awaiting release,Last release"

--- a/.github/workflows/project_automation_labels.yml
+++ b/.github/workflows/project_automation_labels.yml
@@ -1,9 +1,9 @@
-# This is a workflow to automate handling of issues based on labelling
 name: project_automation_labels
 
 on:
   issues:
     types: [labeled]
+
 jobs:
   handle_labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/project_automation_labels.yml
+++ b/.github/workflows/project_automation_labels.yml
@@ -1,4 +1,4 @@
-# This is a workflow to automate handling action based on labelling
+# This is a workflow to automate handling of issues based on labelling
 name: project_automation_labels
 
 on:

--- a/.github/workflows/project_automation_labels.yml
+++ b/.github/workflows/project_automation_labels.yml
@@ -5,10 +5,11 @@ on:
   issues:
     types: [labeled]
 jobs:
-  Move_Labeled_Issue_On_Project_Board:
+  handle_labels:
     runs-on: ubuntu-latest
     steps:
-    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+    - name: move bugs to priority
+      uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
       with:
         action-token: "${{ secrets.PROJECT_AUTOMATION }}"
         project-url: "https://github.com/GIScience/openrouteservice/projects/16"


### PR DESCRIPTION
Adds two github action workflows: 
- add newly created issues and PRs to the project board
- move issues to 'Priority' when labeled as 'bug' later
