### PR TITLE
Refactor/addition weighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed fallback to dynamic routing methods if bearings parameter set ([#702](https://github.com/GIScience/openrouteservice/issues/702))
 - Enable elevation interpolation for bridges and tunnels ([#685](https://github.com/GIScience/openrouteservice/issues/685))
-- Fixed erroneous computation of duration in AdditionWeighting.calcMillis
+- Fixed erroneous duration computation of soft weightings such as green and quiet weightings
 ### Changed
 - Improve recommended weighting for cycling and walking profiles ([#665](https://github.com/GIScience/openrouteservice/issues/665))
 - Restructure AdditionWeighting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed fallback to dynamic routing methods if bearings parameter set ([#702](https://github.com/GIScience/openrouteservice/issues/702))
 - Enable elevation interpolation for bridges and tunnels ([#685](https://github.com/GIScience/openrouteservice/issues/685))
+- Fixed erroneous computation of duration in AdditionWeighting.calcMillis
 ### Changed
 - Improve recommended weighting for cycling and walking profiles ([#665](https://github.com/GIScience/openrouteservice/issues/665))
+- Restructure AdditionWeighting
 ### Deprecated
 
 ## [6.1.1] - 2020-06-02

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -2502,7 +2502,7 @@ public class ResultTest extends ServiceTest {
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('summary')", is(true))
                 .body("routes[0].summary.distance", is(2308.3f))
-                .body("routes[0].summary.duration", is(3323.9f))
+                .body("routes[0].summary.duration", is(1662.0f))
                 .statusCode(200);
     }
 
@@ -2546,7 +2546,7 @@ public class ResultTest extends ServiceTest {
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('summary')", is(true))
                 .body("routes[0].summary.distance", is(2878.7f))
-                .body("routes[0].summary.duration", is(4145.2f))
+                .body("routes[0].summary.duration", is(2072.6f))
                 .statusCode(200);
     }
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/weighting/AdditionWeighting.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/weighting/AdditionWeighting.java
@@ -44,11 +44,7 @@ public class AdditionWeighting extends AbstractWeighting {
 	
 	@Override
 	public long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
-    	long sumOfMillis = 0;
-    	for (Weighting w:weightings) {
-    		sumOfMillis += w.calcMillis(edgeState, reverse, prevOrNextEdgeId);
-		}
-		return superWeighting.calcMillis(edgeState, reverse, prevOrNextEdgeId) + sumOfMillis;
+    	return superWeighting.calcMillis(edgeState, reverse, prevOrNextEdgeId);
 	}
 
 	@Override

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/weighting/ConstantWeighting.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/weighting/ConstantWeighting.java
@@ -1,0 +1,46 @@
+package org.heigit.ors.routing.graphhopper.extensions.weighting;
+
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.util.HintsMap;
+import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.util.EdgeIteratorState;
+
+public class ConstantWeighting implements Weighting {
+    private final double weight;
+    private final long millis;
+
+    public ConstantWeighting(double weight, long millis) {
+        this.weight = weight;
+        this. millis = millis;
+    }
+
+    @Override
+    public double getMinWeight(double distance) {
+        return weight;
+    }
+
+    @Override
+    public double calcWeight(EdgeIteratorState edgeIteratorState, boolean reverse, int prevOrNextEdgeId) {
+        return weight;
+    }
+
+    @Override
+    public long calcMillis(EdgeIteratorState edgeIteratorState, boolean reverse, int prevOrNextEdgeId) {
+        return millis;
+    }
+
+    @Override
+    public FlagEncoder getFlagEncoder() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return "constant(" + weight + ")";
+    }
+
+    @Override
+    public boolean matches(HintsMap hintsMap) {
+        return false;
+    }
+}

--- a/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/weightings/AdditionWeightingTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/weightings/AdditionWeightingTest.java
@@ -1,0 +1,33 @@
+package org.heigit.ors.routing.graphhopper.extensions.weightings;
+
+import com.graphhopper.routing.util.EncodingManager;
+import org.heigit.ors.routing.graphhopper.extensions.ORSDefaultFlagEncoderFactory;
+import org.heigit.ors.routing.graphhopper.extensions.flagencoders.CarFlagEncoder;
+import org.heigit.ors.routing.graphhopper.extensions.flagencoders.FlagEncoderNames;
+import org.heigit.ors.routing.graphhopper.extensions.weighting.AdditionWeighting;
+import org.heigit.ors.routing.graphhopper.extensions.weighting.ConstantWeighting;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AdditionWeightingTest {
+    private final EncodingManager encodingManager;
+    private final CarFlagEncoder flagEncoder;
+
+    public AdditionWeightingTest() {
+        encodingManager = EncodingManager.create(new ORSDefaultFlagEncoderFactory(), FlagEncoderNames.CAR_ORS, 4);
+        flagEncoder = (CarFlagEncoder)encodingManager.getEncoder(FlagEncoderNames.CAR_ORS);
+    }
+
+    @Test
+    public void sumOfConstants () {
+        ConstantWeighting const1 = new ConstantWeighting(1,10);
+        ConstantWeighting const2 = new ConstantWeighting(2,20);
+        ConstantWeighting const3 = new ConstantWeighting(3,30);
+        ConstantWeighting factor = new ConstantWeighting(10, 100);
+
+        ConstantWeighting[] weightingsShort = {const1, const2, const3};
+        AdditionWeighting additionWeightingShort = new AdditionWeighting(weightingsShort,factor,flagEncoder);
+        assertEquals(60, additionWeightingShort.calcWeight(null, false, 0),0.0001);
+    }
+}

--- a/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/weightings/AdditionWeightingTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/weightings/AdditionWeightingTest.java
@@ -21,13 +21,14 @@ public class AdditionWeightingTest {
 
     @Test
     public void sumOfConstants () {
-        ConstantWeighting const1 = new ConstantWeighting(1,10);
-        ConstantWeighting const2 = new ConstantWeighting(2,20);
-        ConstantWeighting const3 = new ConstantWeighting(3,30);
-        ConstantWeighting factor = new ConstantWeighting(10, 100);
+        ConstantWeighting const1 = new ConstantWeighting(1, 10);
+        ConstantWeighting const2 = new ConstantWeighting(2, 20);
+        ConstantWeighting const3 = new ConstantWeighting(3, 30);
+        ConstantWeighting superWeighting = new ConstantWeighting(10, 100);
 
-        ConstantWeighting[] weightingsShort = {const1, const2, const3};
-        AdditionWeighting additionWeightingShort = new AdditionWeighting(weightingsShort,factor,flagEncoder);
-        assertEquals(60, additionWeightingShort.calcWeight(null, false, 0),0.0001);
+        ConstantWeighting[] weightings = {const1, const2, const3};
+        AdditionWeighting additionWeighting = new AdditionWeighting(weightings, superWeighting, flagEncoder);
+        assertEquals(60, additionWeighting.calcWeight(null, false, 0), 0.0001);
+        assertEquals(100, additionWeighting.calcMillis(null, false, 0), 0.0001);
     }
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

### Information about the changes
- Restructre AdditionWeighting
- Fix erroneous duration computation in AdditionWeighting.calcMillis