### PR TITLE
Avoid borders before routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Check whether routing points are within different countries before routing and break if they are and all borders should be avoided
 ### Fixed
 ### Changed
 ### Deprecated

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -444,6 +444,13 @@ public class ORSGraphHopper extends GraphHopper {
 		return result;
 	}
 
+	/**
+	 * Check whether the route processing has to start. If avoid all borders is set and the routing points are in different countries,
+	 * there is no need to even start routing.
+	 * @param processContext Used to get the bordersReader to check isOpen for avoid Controlled. Currently not used
+	 * @param request To get the avoid borders setting
+	 * @param queryResult To get the edges of the queries and check which country they're in
+	 */
 	private void checkAvoidBorders(GraphProcessContext processContext, GHRequest request, List<QueryResult> queryResult) {
 		/* Avoid borders */
 		ORSPMap params = (ORSPMap)request.getAdditionalHints();

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -33,24 +33,31 @@ import com.graphhopper.storage.CHProfile;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
+import com.graphhopper.util.exceptions.ConnectionNotFoundException;
 import com.graphhopper.util.exceptions.PointNotFoundException;
 import com.graphhopper.util.shapes.GHPoint;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
 import org.heigit.ors.mapmatching.RouteSegmentInfo;
+import org.heigit.ors.routing.RouteSearchParameters;
 import org.heigit.ors.routing.RoutingProfileCategory;
 import org.heigit.ors.routing.graphhopper.extensions.core.CoreAlgoFactoryDecorator;
 import org.heigit.ors.routing.graphhopper.extensions.core.CoreLMAlgoFactoryDecorator;
 import org.heigit.ors.routing.graphhopper.extensions.core.PrepareCore;
+import org.heigit.ors.routing.graphhopper.extensions.edgefilters.AvoidBordersEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.EdgeFilterSequence;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.AvoidBordersCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.AvoidFeaturesCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.HeavyVehicleCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.WheelchairCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.MaximumSpeedCoreEdgeFilter;
+import org.heigit.ors.routing.graphhopper.extensions.storages.BordersGraphStorage;
+import org.heigit.ors.routing.graphhopper.extensions.storages.GraphStorageUtils;
+import org.heigit.ors.routing.graphhopper.extensions.util.ORSPMap;
 import org.heigit.ors.routing.graphhopper.extensions.weighting.MaximumSpeedWeighting;
 import org.heigit.ors.routing.graphhopper.extensions.util.ORSParameters;
+import org.heigit.ors.routing.pathprocessors.BordersExtractor;
 import org.heigit.ors.util.CoordTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -256,6 +263,7 @@ public class ORSGraphHopper extends GraphHopper {
 				StopWatch sw = new StopWatch().start();
 				List<QueryResult> qResults = routingTemplate.lookup(points, encoder);
 				double[] radiuses = request.getMaxSearchDistances();
+				checkAvoidBorders(request, qResults);
 				if (points.size() == qResults.size()) {
 					for (int placeIndex = 0; placeIndex < points.size(); placeIndex++) {
 						QueryResult qr = qResults.get(placeIndex);
@@ -264,7 +272,6 @@ public class ORSGraphHopper extends GraphHopper {
 						}
 					}
 				}
-
 				ghRsp.addDebugInfo("idLookup:" + sw.stop().getSeconds() + "s");
 				if (ghRsp.hasErrors())
 					return Collections.emptyList();
@@ -433,6 +440,28 @@ public class ORSGraphHopper extends GraphHopper {
 		}
 
 		return result;
+	}
+
+	private void checkAvoidBorders(GHRequest request, List<QueryResult> queryResult) {
+		/* Avoid borders */
+		ORSPMap params = (ORSPMap)request.getAdditionalHints();
+		boolean isRouteable = true;
+
+			if (params.hasObj("avoid_borders")) {
+				RouteSearchParameters routeSearchParameters = (RouteSearchParameters) params.getObj("avoid_borders");
+				if(routeSearchParameters.hasAvoidBorders() && routeSearchParameters.getAvoidBorders() == BordersExtractor.Avoid.ALL) {
+					List<Integer> edgeIds =  new ArrayList<>();
+					for (int placeIndex = 0; placeIndex < queryResult.size(); placeIndex++) {
+						edgeIds.add(queryResult.get(placeIndex).getClosestEdge().getEdge());
+					}
+					BordersExtractor bordersExtractor = new BordersExtractor(GraphStorageUtils.getGraphExtension(getGraphHopperStorage(), BordersGraphStorage.class), null);
+					isRouteable = bordersExtractor.isSameCountry(edgeIds);
+				}
+			}
+			//TODO add support for avoiding controlled borders
+		if(!isRouteable)
+			throw new ConnectionNotFoundException("Route not found due to avoiding borders", Collections.<String, Object>emptyMap());
+
 	}
 
     public GHResponse constructFreeHandRoute(GHRequest request) {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/BordersExtractor.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/BordersExtractor.java
@@ -2,6 +2,8 @@ package org.heigit.ors.routing.pathprocessors;
 
 import org.heigit.ors.routing.graphhopper.extensions.storages.BordersGraphStorage;
 
+import java.util.ArrayList;
+import java.util.List;
 
 public class BordersExtractor {
     public enum Avoid { CONTROLLED, NONE, ALL }
@@ -41,5 +43,16 @@ public class BordersExtractor {
             }
         }
         return false;
+    }
+
+    public boolean isSameCountry(List<Integer> edgeIds){
+        List<Short> countryIds = new ArrayList<>();
+        for(int edgeId : edgeIds) {
+            countryIds.add(storage.getEdgeValue(edgeId, BordersGraphStorage.Property.START));
+            countryIds.add(storage.getEdgeValue(edgeId, BordersGraphStorage.Property.END));
+        }
+
+        return countryIds.isEmpty() || countryIds.stream().allMatch(countryIds.get(0)::equals);
+
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/BordersExtractor.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/BordersExtractor.java
@@ -48,7 +48,7 @@ public class BordersExtractor {
 
     /**
      * Check whether the start and end nodes of a list of edges are in the same country.
-     * @param edgeIds
+     * @param edgeIds Edges that the country should be checked for
      * @return true if at least one node is in the same country
      */
     public boolean isSameCountry(List<Integer> edgeIds){

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/BordersExtractor.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/BordersExtractor.java
@@ -1,5 +1,6 @@
 package org.heigit.ors.routing.pathprocessors;
 
+import com.carrotsearch.hppc.IntHashSet;
 import org.heigit.ors.routing.graphhopper.extensions.storages.BordersGraphStorage;
 
 import java.util.ArrayList;
@@ -45,14 +46,26 @@ public class BordersExtractor {
         return false;
     }
 
+    /**
+     * Check whether the start and end nodes of a list of edges are in the same country.
+     * @param edgeIds
+     * @return true if at least one node is in the same country
+     */
     public boolean isSameCountry(List<Integer> edgeIds){
-        List<Short> countryIds = new ArrayList<>();
+        if(edgeIds.isEmpty())
+            return true;
+
+        short country0 = storage.getEdgeValue(edgeIds.get(0), BordersGraphStorage.Property.START);
+        short country1 = storage.getEdgeValue(edgeIds.get(0), BordersGraphStorage.Property.END);
         for(int edgeId : edgeIds) {
-            countryIds.add(storage.getEdgeValue(edgeId, BordersGraphStorage.Property.START));
-            countryIds.add(storage.getEdgeValue(edgeId, BordersGraphStorage.Property.END));
+            short country2 = storage.getEdgeValue(edgeId, BordersGraphStorage.Property.START);
+            short country3 = storage.getEdgeValue(edgeId, BordersGraphStorage.Property.END);
+            if(country0 != country2
+            && country0 != country3
+            && country1 != country2
+            && country1 != country3)
+                return false;
         }
-
-        return countryIds.isEmpty() || countryIds.stream().allMatch(countryIds.get(0)::equals);
-
+        return true;
     }
 }

--- a/openrouteservice/src/test/java/org/heigit/ors/routing/pathprocessors/BordersExtractorTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/routing/pathprocessors/BordersExtractorTest.java
@@ -25,8 +25,10 @@ import org.heigit.ors.routing.graphhopper.extensions.flagencoders.FlagEncoderNam
 import org.heigit.ors.routing.graphhopper.extensions.storages.BordersGraphStorage;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class BordersExtractorTest {
     private final EncodingManager encodingManager= EncodingManager.create(new ORSDefaultFlagEncoderFactory(), FlagEncoderNames.CAR_ORS, 4);
@@ -37,13 +39,17 @@ public class BordersExtractorTest {
         // Initialise a graph storage with dummy data
         _graphstorage = new BordersGraphStorage();
         _graphstorage.init(null, new GHDirectory("", DAType.RAM_STORE));
-        _graphstorage.create(3);
+        _graphstorage.create(5);
 
         // (edgeId, borderType, startCountry, endCountry)
 
         _graphstorage.setEdgeValue(1, BordersGraphStorage.CONTROLLED_BORDER, (short)1, (short)2);
         _graphstorage.setEdgeValue(2, BordersGraphStorage.OPEN_BORDER, (short)3, (short)4);
         _graphstorage.setEdgeValue(3, BordersGraphStorage.NO_BORDER, (short)5, (short)5);
+        _graphstorage.setEdgeValue(4, BordersGraphStorage.NO_BORDER, (short)5, (short)6);
+        _graphstorage.setEdgeValue(5, BordersGraphStorage.NO_BORDER, (short)7, (short)7);
+        _graphstorage.setEdgeValue(6, BordersGraphStorage.NO_BORDER, (short)7, (short)7);
+
     }
 
     private VirtualEdgeIteratorState generateEdge(int id) {
@@ -102,5 +108,30 @@ public class BordersExtractorTest {
         assertEquals(true, be.restrictedCountry(1));
         assertEquals(true, be.restrictedCountry(2));
         assertEquals(false, be.restrictedCountry(3));
+    }
+
+    @Test
+    public void TestIsSameCountry() {
+        VirtualEdgeIteratorState ve1 = generateEdge(1);
+        VirtualEdgeIteratorState ve2 = generateEdge(2);
+        VirtualEdgeIteratorState ve3 = generateEdge(3);
+
+        BordersExtractor be = new BordersExtractor(_graphstorage, new int[] {2, 4});
+        List<Integer> countries = new ArrayList<>();
+        countries.add(1);
+        countries.add(2);
+        assertFalse(be.isSameCountry(countries));
+        countries = new ArrayList<>();
+        countries.add(3);
+        countries.add(4);
+        assertTrue(be.isSameCountry(countries));
+        countries = new ArrayList<>();
+        countries.add(4);
+        countries.add(5);
+        assertFalse(be.isSameCountry(countries));
+        countries = new ArrayList<>();
+        countries.add(5);
+        countries.add(6);
+        assertTrue(be.isSameCountry(countries));
     }
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes # .

### Information about the changes
- Key functionality added: Break the routing request before any algorithm runs if avoid all borders is enabled and the points in the request are in differnt countries
- Reason for change: It is possible to brick the server by forcing AStart Beeline with avoid polygons and then requesting a route from karlsruhe to strassbourg with avoid all borders. This leads to a search that cannot find a path, even though the routing request constraints already implicate that no route can possibly be found. This PR aims to filter out requests of this nature.

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
