### PR TITLE
Allow configuration of app.config at docker run time (Fix #772)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,8 +23,9 @@ fi
 if [ -d "/usr/local/tomcat/webapps/ors" ]; then
 	cp -f /ors-conf/app.config $tomcat_appconfig
 else
-	if [ ! -f /ors-conf/app.config ]; then
-		cp -f $source_appconfig /ors-conf/app.config
+	# if the user mounts an app.config file in /ors-conf, use the custom app.config
+	if [ -f /ors-conf/app.config ]; then
+		cp -f /ors-conf/app.config $source_appconfig
 	fi
 	echo "### Package openrouteservice and deploy to Tomcat ###"
 	mvn -q -f /ors-core/openrouteservice/pom.xml package -DskipTests && \


### PR DESCRIPTION
This PR fixes #772.

I understand that you want the image to be able to run a demo out of the box, but also be usable as a base for custom app.configs.

In that case it would make sense to copy the app.config in the /ors-conf directory in the image to the $source_appconfig path if it exists.

This does not allow a user that does not supply an app.config to view the default app.config, but that use case is less important than the custom app.config use case in my opinion. This can easily be clarified in the documentation.

The logic is then:
```
# if Tomcat built before, copy the mounted app.config to the Tomcat webapp app.config, else copy it from the source
if [ -d "/usr/local/tomcat/webapps/ors" ]; then
	cp -f /ors-conf/app.config $tomcat_appconfig
else
	# if the user mounts an app.config file in /ors-conf, use the custom app.config
	if [ -f /ors-conf/app.config ]; then
		cp -f /ors-conf/app.config $source_appconfig
	fi
	echo "### Package openrouteservice and deploy to Tomcat ###"
	mvn -q -f /ors-core/openrouteservice/pom.xml package -DskipTests && \
	cp -f /ors-core/openrouteservice/target/*.war /usr/local/tomcat/webapps/ors.war
fi
```

I'll make a new PR for this fix.