### PR TITLE
Use constants defined in FlagEncoderNames rather than hard coded names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Check whether routing points are within different countries before routing and break if they are and all borders should be avoided
 ### Fixed
 - Updated Docker process to use Java 11 ([#777](https://github.com/GIScience/openrouteservice/issues/777))
+- Correctly resolve routing profile categories when initializing core edge filters in preprocessing ([#785](https://github.com/GIScience/openrouteservice/issues/785))
 ### Changed
 ### Deprecated
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfileCategory.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfileCategory.java
@@ -14,6 +14,7 @@
 package org.heigit.ors.routing;
 
 import com.graphhopper.routing.util.EncodingManager;
+import org.heigit.ors.routing.graphhopper.extensions.flagencoders.FlagEncoderNames;
 
 public class RoutingProfileCategory {
 	public static final int UNKNOWN = 0;
@@ -39,17 +40,17 @@ public class RoutingProfileCategory {
 	}
 
 	public static int getFromEncoder(EncodingManager encodingManager) {
-		if (encodingManager.hasEncoder("car-ors") || encodingManager.hasEncoder("heavyvehicle"))
+		if (encodingManager.hasEncoder(FlagEncoderNames.CAR_ORS) || encodingManager.hasEncoder(FlagEncoderNames.HEAVYVEHICLE))
 			return RoutingProfileCategory.DRIVING;
 
-		if (encodingManager.hasEncoder("bike") || encodingManager.hasEncoder("mtb") || encodingManager.hasEncoder("racingbike")
-		 || encodingManager.hasEncoder("safetybike") || encodingManager.hasEncoder("cycletourbike") || encodingManager.hasEncoder("electrobike"))
+		if (encodingManager.hasEncoder(FlagEncoderNames.BIKE_ORS) || encodingManager.hasEncoder(FlagEncoderNames.MTB_ORS) || encodingManager.hasEncoder(FlagEncoderNames.ROADBIKE_ORS)
+		 || encodingManager.hasEncoder(FlagEncoderNames.BIKE_ELECTRO))
 			return RoutingProfileCategory.CYCLING;
 
-		if (encodingManager.hasEncoder("foot") || encodingManager.hasEncoder("hiking"))
+		if (encodingManager.hasEncoder(FlagEncoderNames.PEDESTRIAN_ORS) || encodingManager.hasEncoder(FlagEncoderNames.HIKING_ORS))
 			return RoutingProfileCategory.WALKING;
 
-		if (encodingManager.hasEncoder("wheelchair"))
+		if (encodingManager.hasEncoder(FlagEncoderNames.WHEELCHAIR))
 			return RoutingProfileCategory.WHEELCHAIR;
 
 		return RoutingProfileCategory.UNKNOWN;

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfileManager.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfileManager.java
@@ -14,6 +14,7 @@
 package org.heigit.ors.routing;
 
 import com.graphhopper.GHResponse;
+import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.DistanceCalc;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PointList;
@@ -578,7 +579,7 @@ public class RoutingProfileManager {
             if(searchParams.getMaximumSpeed() < config.getMaximumSpeedLowerBound()) {
                 throw new ParameterValueException(RoutingErrorCodes.INVALID_PARAMETER_VALUE, RouteRequest.PARAM_MAXIMUM_SPEED, String.valueOf(searchParams.getMaximumSpeed()), "The maximum speed must not be lower than " + config.getMaximumSpeedLowerBound() + " km/h.");
             }
-            if(!(rp.getGraphhopper().getEncodingManager().hasEncoder("heavyvehicle") || rp.getGraphhopper().getEncodingManager().hasEncoder("car-ors")) ){
+            if(RoutingProfileCategory.getFromEncoder(rp.getGraphhopper().getEncodingManager()) != RoutingProfileCategory.DRIVING){
                 throw new ParameterValueException(RoutingErrorCodes.INCOMPATIBLE_PARAMETERS, "The maximum speed feature can only be used with cars and heavy vehicles.");
             }
         }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -45,17 +45,15 @@ import org.heigit.ors.routing.RoutingProfileCategory;
 import org.heigit.ors.routing.graphhopper.extensions.core.CoreAlgoFactoryDecorator;
 import org.heigit.ors.routing.graphhopper.extensions.core.CoreLMAlgoFactoryDecorator;
 import org.heigit.ors.routing.graphhopper.extensions.core.PrepareCore;
-import org.heigit.ors.routing.graphhopper.extensions.edgefilters.AvoidBordersEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.EdgeFilterSequence;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.AvoidBordersCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.AvoidFeaturesCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.HeavyVehicleCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.WheelchairCoreEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.MaximumSpeedCoreEdgeFilter;
-import org.heigit.ors.routing.graphhopper.extensions.reader.borders.CountryBordersReader;
+import org.heigit.ors.routing.graphhopper.extensions.flagencoders.FlagEncoderNames;
 import org.heigit.ors.routing.graphhopper.extensions.storages.BordersGraphStorage;
 import org.heigit.ors.routing.graphhopper.extensions.storages.GraphStorageUtils;
-import org.heigit.ors.routing.graphhopper.extensions.storages.builders.GraphStorageBuilder;
 import org.heigit.ors.routing.graphhopper.extensions.util.ORSPMap;
 import org.heigit.ors.routing.graphhopper.extensions.weighting.MaximumSpeedWeighting;
 import org.heigit.ors.routing.graphhopper.extensions.util.ORSParameters;
@@ -582,7 +580,7 @@ public class ORSGraphHopper extends GraphHopper {
 		EdgeFilterSequence coreEdgeFilter = new EdgeFilterSequence();
 		/* Heavy vehicle filter */
 
-		if (encodingManager.hasEncoder("heavyvehicle")) {
+		if (encodingManager.hasEncoder(FlagEncoderNames.HEAVYVEHICLE)) {
 			coreEdgeFilter.add(new HeavyVehicleCoreEdgeFilter(gs));
 		}
 
@@ -605,12 +603,12 @@ public class ORSGraphHopper extends GraphHopper {
 		/* Maximum Speed Filter */
 		if ((routingProfileCategory & RoutingProfileCategory.DRIVING) !=0 ) {
 			FlagEncoder flagEncoder = null;
-			if(encodingManager.hasEncoder("heavyvehicle")) {
-				flagEncoder = getEncodingManager().getEncoder("heavyvehicle");
+			if(encodingManager.hasEncoder(FlagEncoderNames.HEAVYVEHICLE)) {
+				flagEncoder = getEncodingManager().getEncoder(FlagEncoderNames.HEAVYVEHICLE);
 				coreEdgeFilter.add(new MaximumSpeedCoreEdgeFilter(flagEncoder, maximumSpeedLowerBound));
 			}
-			else if(encodingManager.hasEncoder("car-ors")) {
-				flagEncoder = getEncodingManager().getEncoder("car-ors");
+			else if(encodingManager.hasEncoder(FlagEncoderNames.CAR_ORS)) {
+				flagEncoder = getEncodingManager().getEncoder(FlagEncoderNames.CAR_ORS);
 				coreEdgeFilter.add(new MaximumSpeedCoreEdgeFilter(flagEncoder, maximumSpeedLowerBound));
 			}
 		}

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/PrepareCore.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/PrepareCore.java
@@ -63,7 +63,7 @@ public class PrepareCore extends AbstractAlgoPreparation implements RoutingAlgor
     private int periodicUpdatesPercentage = 10;
     private int lastNodesLazyUpdatePercentage = 10;
     private int neighborUpdatePercentage = 90;
-    private double nodesContractedPercentage = 99.75;
+    private double nodesContractedPercentage = 99;//TODO: needs further investigation and fine tuning
     private double logMessagesPercentage = 20;
     private double dijkstraTime;
     private double periodTime;

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/FlagEncoderNames.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/FlagEncoderNames.java
@@ -4,9 +4,8 @@ public class FlagEncoderNames {
     public static final String CAR_ORS          = "car-ors";
     public static final String HEAVYVEHICLE     = "heavyvehicle";
     public static final String EMERGENCY        = "emergency";
-    // MARQ24 NO eVEHICLE FlagEncoder implemented yet!!!
-    public static final String EVEHICLE         = "evehicle";       // NOT IN USE!
-    public static final String RUNNING          = "running";        // NOT IN USE!
+    public static final String EVEHICLE         = "evehicle";       // NOT IMPLEMENTED
+    public static final String RUNNING          = "running";        // NOT IMPLEMENTED
 
     public static final String WHEELCHAIR       = "wheelchair";
 
@@ -28,8 +27,6 @@ public class FlagEncoderNames {
     public static final String GH_MTB           = "mtb";
     public static final String GH_BIKE          = "bike";
     public static final String GH_BIKE2         = "bike2";
-    public static final String GH_GENERIC       = "generic";
-    public static final String GH_PT            = "pt";
 
     private FlagEncoderNames() {}
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #785.

### Information about the changes

- Reason for change: core edge filters for cycling and walking profiles were not correctly initialized during preparation because of flag encoder names mismatch when resolving profile categories. 
