### PR TITLE
Fix swagger info & CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+<!--
+This is how a Changelog entry should look like:
+
+## [version] - YYYY-MM-DD
+
+### Added
+- for new features.
+### Changed
+- existing functionality.
+### Deprecated
+- soon-to-be removed features.
+### Removed
+- now removed features.
+### Fixed
+- any bug.
+### Security
+- in case of vulnerabilities. (Use for vulnerability fixes)
+
+RELEASING:
+1. Change Unreleased to new release number
+2. Add today's Date
+3. Change unreleased link to compare new release:
+[unreleased]: https://github.com/GIScience/openrouteservice/compare/vnew...HEAD
+4. Add new compare link below
+[new]: https://github.com/GIScience/openrouteservice/compare/vlast...vnew
+5. Git tag release commit with vX.X.X to enable links
+6. Double check issue links are valid
+7. Bump version in pom.xml
+ -->
+
 ## [Unreleased]
 ### Added
 - New fast isochrone algorithm based on preprocessed data
-### Fixed
-### Changed
-### Deprecated
 
 ## [6.2.1] - 2020-08-13
 ### Added
@@ -16,8 +43,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Updated Docker process to use Java 11 ([#777](https://github.com/GIScience/openrouteservice/issues/777))
 - Correctly resolve routing profile categories when initializing core edge filters in preprocessing ([#785](https://github.com/GIScience/openrouteservice/issues/785))
-### Changed
-### Deprecated
 
 ## [6.2.0] - 2020-07-15
 ### Added
@@ -57,7 +82,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Enable CH and Core-ALT preprocessing with recommended weighting for all profiles.
 - Refactor wheelchair builder
 - Running a Docker container will now create a `app.config` on the host machine, so it's now usable from Dockerhub
-### Deprecated
 
 ## [6.1.0] - 2020-03-06
 ### Added
@@ -79,7 +103,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Make Docker setup more flexible wrt customizations ([#627](https://github.com/GIScience/openrouteservice/issues/627))
 - Updated GraphHopper to newer version (0.13)
 - Give more details to green and quiet routing API descriptions ([#632](https://github.com/GIScience/openrouteservice/issues/632))
-### Deprecated
 
 ## [6.0.0] - 2019-12-03
 ### Added
@@ -126,7 +149,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Removed obsolete storages ([#536](https://github.com/GIScience/openrouteservice/issues/536))
 - Refactor fallback to preprocessing-independent algorithm for certain routing request params
 - Removed some landmark sets as default from app.config.sample
-### Deprecated
 
 ## [5.0.1] - 2019-04-08
 ### Added
@@ -152,7 +174,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Removed the code that was inserted for the prototype traffic weightings as it was not used and made GH updates more complicated.
 
 
-## [5.0] - 2019-02-25
+## [5.0.0] - 2019-02-25
 ### Added
 - Updated api code to use the Spring framework, with the v2 api being added ([Issue #233](https://github.com/GIScience/openrouteservice/issues/233))
 - Added support for ISO 3166-1 Alpha-2 / Alpha-3 codes for routing directions option avoid_countries ([Issue #195](https://github.com/GIScience/openrouteservice/issues/195))
@@ -169,7 +191,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Added /directions as an endpoint for routing ([Issue #384](https://github.com/GIScience/openrouteservice/issues/384))
 - Removed the following avoid features: pavedroads, unpavedroads, tunnels, tracks and hills, as well as the option to set maximum speed; for cycling and walking profiles the option to specify difficulty settings such as fitness level and maximum steepness ([issue #396](https://github.com/GIScience/openrouteservice/issues/396))
 - Updated pom to always build ors.war ([Issue #432](https://github.com/GIScience/openrouteservice/issues/432))
-### Deprecated
 
 ## [4.7.2] - 2018-12-10
 ### Added
@@ -187,7 +208,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Updated checks on pedestrian way filter for access restrictions
 ### Changed
 - Allowed access for cars and hgvs on access=destination roads ([Issue #342](https://github.com/GIScience/openrouteservice/issues/342))
-### Deprecated
 
 ## [4.7.1] - 2018-10-24
 ### Added
@@ -203,9 +223,8 @@ Added area_units for isochrones API as units being misleading ([Issue #272](http
 - Changed app.config.sample for docker to consider split profiles ([Issue #320](https://github.com/GIScience/openrouteservice/issues/320))
 - Changed minor information in pom.xml
 - Updated API test starting coordinates to be on a road ([Issue #328](https://github.com/GIScience/openrouteservice/issues/328))
-### Deprecated
 
-## [4.7] - 2018-10-10
+## [4.7.0] - 2018-10-10
 ### Added
 - Removed locations code as this will be handled by openpoiservice in the future ([Issue #120](https://github.com/GIScience/openrouteservice/issues/120))
 - Removed Geocoding code as this will be handled by the geocoder service rather than within ORS
@@ -264,7 +283,7 @@ are attached to roads. ([Issue #162](https://github.com/GIScience/openrouteservi
 - Updated the error response for geocding when no address found ([Issue #134](https://github.com/GIScience/openrouteservice/issues/134))
 
 
-## [4.5] - 2018-02-27
+## [4.5.0] - 2018-02-27
 ### Added
 - Functionality has been added to restrict routes so that they do not cross all borders, controlled borders, or the borders of specific countries ([Issue #41](https://github.com/GIScience/openrouteservice/issues/41))
 - Added GeoJson export for routing exports ([Issue #54](https://github.com/GIScience/openrouteservice/issues/54))
@@ -326,11 +345,20 @@ are attached to roads. ([Issue #162](https://github.com/GIScience/openrouteservi
 - Fix bug in RPHAST when location lies on a oneway road.
 - Consider turn restrictions if optimized=false is passed.
 
-### Changed
--
-
-### Removed
--
-
-### Deprecated
--
+[unreleased]: https://github.com/GIScience/openrouteservice/compare/v6.2.1...HEAD
+[6.2.1]: https://github.com/GIScience/openrouteservice/compare/v6.2.0...v6.2.1
+[6.2.0]: https://github.com/GIScience/openrouteservice/compare/v6.1.1...v6.2.0
+[6.1.1]: https://github.com/GIScience/openrouteservice/compare/v6.1.0...v6.1.1
+[6.1.0]: https://github.com/GIScience/openrouteservice/compare/v6.0.0...v6.1.0
+[6.0.0]: https://github.com/GIScience/openrouteservice/compare/v5.0.2...v6.0.0
+[5.0.2]: https://github.com/GIScience/openrouteservice/compare/v5.0.1...v5.0.2
+[5.0.1]: https://github.com/GIScience/openrouteservice/compare/5.0.0...v5.0.1
+[5.0.0]: https://github.com/GIScience/openrouteservice/compare/v4.7.2...5.0.0
+[4.7.2]: https://github.com/GIScience/openrouteservice/compare/4.7.1...v4.7.2
+[4.7.1]: https://github.com/GIScience/openrouteservice/compare/4.7.0...4.7.1
+[4.7.0]: https://github.com/GIScience/openrouteservice/compare/4.5.1...4.7.0
+[4.5.1]: https://github.com/GIScience/openrouteservice/compare/4.5.0...4.5.1
+[4.5.0]: https://github.com/GIScience/openrouteservice/compare/4.4.2...4.5.0
+[4.4.2]: https://github.com/GIScience/openrouteservice/compare/4.4.1...4.4.2
+[4.4.1]: https://github.com/GIScience/openrouteservice/compare/4.4.0...4.4.1
+[4.4.0]: https://github.com/GIScience/openrouteservice/compare/4.3.0...4.4.0

--- a/openrouteservice/src/main/java/org/heigit/ors/api/SwaggerConfig.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/SwaggerConfig.java
@@ -34,11 +34,11 @@ import javax.servlet.ServletContext;
 public class SwaggerConfig {
     ApiInfo apiInfo() {
         return new ApiInfoBuilder()
-                .title("OpenRouteService")
+                .title("Openrouteservice")
                 .description("This is the openrouteservice API documentation")
                 .license("MIT")
                 .licenseUrl("https://github.com/swagger-api/swagger-ui/blob/master/LICENSE")
-                .contact(new Contact("","", "enquiry@openrouteservice.org"))
+                .contact(new Contact("","", "enquiry@openrouteservice.heigit.org"))
                 .build();
     }
     @Bean


### PR DESCRIPTION
### Information about the changes

swagger change:
- switch to heigit mail address
- change openrouteservice casing

changelog change:
- removed empty deprecated headings
- link to proper tag compare
- add usage hints

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] ~~3. I have documented my code using JDocs tags.~~
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] ~~5. I have written JUnit tests for any new methods/classes and ensured that they pass.~~
- [x] ~~6. I have created API tests for any new functionality exposed to the API.~~
- [x] ~~7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).~~
- [x] ~~8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing~~
- [x] ~~9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).~~
- [x] ~~10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).~~
- [x] ~~11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.~~
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

