### PR TITLE
Bugfix#683 storagebuilders init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ RELEASING:
  -->
 
 ## [Unreleased]
+### Fixed
+- Handle invalid combination of HillIndexStorage without elevation ([#683](https://github.com/GIScience/openrouteservice/issues/683))
+- Enabled turning off elevation data handling for profiles 
 
 ## [6.3.0] - 2020-09-14
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -176,7 +176,9 @@ public class RoutingProfile {
         // so the caching for elevation data will/can be reused across different vehicles. [the loadCntx is a single
         // Object that will shared across the (potential) multiple running instances]
         if(loadCntx.getElevationProvider() != null) {
-            gh.setElevationProvider(loadCntx.getElevationProvider());
+            if (args.has("graph.elevation.provider")) {
+                gh.setElevationProvider(loadCntx.getElevationProvider());
+            }
         }else {
             loadCntx.setElevationProvider(gh.getElevationProvider());
         }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/GraphProcessContext.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/GraphProcessContext.java
@@ -45,20 +45,11 @@ public class GraphProcessContext {
 
 		if (config.getExtStorages() != null) {
 			storageBuilders = mgrGraphStorageBuilders.createInstances(config.getExtStorages());
-
-			if (storageBuilders != null && !storageBuilders.isEmpty()) {
-				arrStorageBuilders = new GraphStorageBuilder[storageBuilders.size()];
-				arrStorageBuilders = storageBuilders.toArray(arrStorageBuilders);
-			}
 		}
 
 		PluginManager<GraphBuilder> mgrGraphBuilders = PluginManager.getPluginManager(GraphBuilder.class);
 		if (config.getGraphBuilders() != null) {
 			graphBuilders = mgrGraphBuilders.createInstances(config.getGraphBuilders());
-			if (graphBuilders != null && !graphBuilders.isEmpty()) {
-				arrGraphBuilders = new GraphBuilder[graphBuilders.size()];
-				arrGraphBuilders = graphBuilders.toArray(arrGraphBuilders);
-			}
 		}
 
 		maximumSpeedLowerBound = config.getMaximumSpeedLowerBound();
@@ -73,6 +64,17 @@ public class GraphProcessContext {
 					LOGGER.warning(ex.getMessage());
 				}
 			}
+		}
+	}
+
+	public void initArrays() {
+		if (storageBuilders != null && !storageBuilders.isEmpty()) {
+			arrStorageBuilders = new GraphStorageBuilder[storageBuilders.size()];
+			arrStorageBuilders = storageBuilders.toArray(arrStorageBuilders);
+		}
+		if (graphBuilders != null && !graphBuilders.isEmpty()) {
+			arrGraphBuilders = new GraphBuilder[graphBuilders.size()];
+			arrGraphBuilders = graphBuilders.toArray(arrGraphBuilders);
 		}
 	}
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -123,7 +123,6 @@ public class ORSGraphHopper extends GraphHopper {
 		fastIsochroneFactory.init(args);
 		minNetworkSize = args.getInt("prepare.min_network_size", minNetworkSize);
 		minOneWayNetworkSize = args.getInt("prepare.min_one_way_network_size", minOneWayNetworkSize);
-
 		return ret;
 	}
 
@@ -141,6 +140,7 @@ public class ORSGraphHopper extends GraphHopper {
 			if (LOGGER.isInfoEnabled())
 				LOGGER.info(String.format("will create PrepareRoutingSubnetworks with:%n\tNodeCountBefore: '%d'%n\tgetAllEdges().getMaxId(): '%d'%n\tList<FlagEncoder>: '%s'%n\tminNetworkSize: '%d'%n\tminOneWayNetworkSize: '%d'", prevNodeCount, ex, list, minNetworkSize, minOneWayNetworkSize)
 			);
+			ghs.getProperties().put("elevation", hasElevation());
 		} else {
 			LOGGER.info("graph GraphHopperStorage is null?!");
 		}

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphStorageFactory.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphStorageFactory.java
@@ -52,12 +52,14 @@ public class ORSGraphStorageFactory implements GraphStorageFactory {
 		}
 
 		if (graphStorageBuilders != null) {
-			for(GraphStorageBuilder builder : graphStorageBuilders) {
+			List<GraphStorageBuilder> iterateGraphStorageBuilders = new ArrayList<>(graphStorageBuilders);
+			for(GraphStorageBuilder builder : iterateGraphStorageBuilders) {
 				try {
 					GraphExtension ext = builder.init(gh);
 					if (ext != null)
 						graphExtensions.add(ext);
 				} catch(Exception ex) {
+					graphStorageBuilders.remove(builder);
 					LOGGER.error(ex);
 				}
 			}

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
@@ -61,6 +61,7 @@ public class ORSOSMReader extends OSMReader {
 
 		setCalcDistance3D(false);
 		this.procCntx = procCntx;
+		this.procCntx.initArrays();
 		this.readerCntx = new OSMDataReaderContext(this);
 
 		initNodeTagsToStore(new HashSet<>(Arrays.asList("maxheight", "maxweight", "maxweight:hgv", "maxwidth", "maxlength", "maxlength:hgv", "maxaxleload")));

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/HillIndexGraphStorageBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/HillIndexGraphStorageBuilder.java
@@ -34,8 +34,7 @@ public class HillIndexGraphStorageBuilder extends AbstractGraphStorageBuilder {
 			
 			return storage;
 		}
-		else 
-			return null;
+		throw new Exception("HillIndexGraphStorageBuilder cannot be initialized since elevation is deactivated for this profile.");
 	}
 
 	public void processWay(ReaderWay way) {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
@@ -162,8 +162,12 @@ public class ExtraInfoProcessor implements PathProcessor {
 			}
 
 			if (includeExtraInfo(extraInfo, RouteExtraInfoFlag.STEEPNESS)) {
-				steepnessInfo = new RouteExtraInfo("steepness");
-				steepnessInfoBuilder = new AppendableSteepnessExtraInfoBuilder(steepnessInfo);
+				if ("true".equals(graphHopperStorage.getProperties().get("elevation"))) {
+					steepnessInfo = new RouteExtraInfo("steepness");
+					steepnessInfoBuilder = new AppendableSteepnessExtraInfoBuilder(steepnessInfo);
+				} else {
+					skippedExtras.add("steepness");
+				}
 			}
 
 			if (includeExtraInfo(extraInfo, RouteExtraInfoFlag.SUITABILITY)) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #683  .

### Information about the changes
- Reason for change:
Correctly handle the HillIndexStorage not being able to initialize (if elevation data missing). Also added checks and feedback during ExtraInfoProcessor instantiation. 
Also fixed: Setting the elevation parameter to false for a profile was ignored if previous profiles had it enabled, 