### PR TITLE
Set borderness values one by one as byte instead of bitset all together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ RELEASING:
 ## [Unreleased]
 ### Fixed
 - Updated documentation for running in Docker  ([#798](https://github.com/GIScience/openrouteservice/issues/798))
+- Fixed a bug in fast isochrones preprocessing
 
 ## [6.3.0] - 2020-09-14
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/fastisochrones/storage/ByteConversion.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/fastisochrones/storage/ByteConversion.java
@@ -1,7 +1,6 @@
 package org.heigit.ors.fastisochrones.storage;
 
 import java.nio.ByteBuffer;
-import java.util.BitSet;
 
 public class ByteConversion {
     private ByteConversion() {
@@ -41,19 +40,5 @@ public class ByteConversion {
         if (bytes.length != Integer.BYTES)
             throw new IllegalArgumentException("Byte counts do not match, expected " + Integer.BYTES + " but is " + bytes.length);
         return ByteBuffer.wrap(bytes).getInt();
-    }
-
-    public static BitSet booleanArrayToBitSet(boolean[] bits) {
-        BitSet bitset = new BitSet(bits.length);
-        for (int i = 0; i < bits.length; i++)
-            bitset.set(i, bits[i]);
-
-        return bitset;
-    }
-
-    public static boolean isByteSetAtPosition(byte byteToCheck, byte position)
-    {
-        int newByte = byteToCheck >> position;
-        return (newByte & 1) == 1;
     }
 }

--- a/openrouteservice/src/test/java/org/heigit/ors/fastisochrones/partitioning/CellAndIsochroneNodeStorageTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/fastisochrones/partitioning/CellAndIsochroneNodeStorageTest.java
@@ -54,6 +54,19 @@ public class CellAndIsochroneNodeStorageTest {
         assertEquals(expectedCellIds, ins.getCellIds());
     }
 
+    @Test
+    public void testBigIsochroneNodeStorage() {
+        GraphHopperStorage ghStorage = createGHStorage();
+        int size = 1048576*16 + 2;
+        IsochroneNodeStorage ins = new IsochroneNodeStorage(size, ghStorage.getDirectory());
+        assertFalse(ins.loadExisting());
+        int[] cellIds = new int[size];
+        boolean[] borderNess = new boolean[size];
+        borderNess[1048576*16 + 1] = true;
+        ins.setCellIds(cellIds);
+        ins.setBorderness(borderNess);
+    }
+
     @Test(expected = IllegalStateException.class)
     public void testUnfilledCells() {
         GraphHopperStorage ghStorage = createGHStorage();


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes # .

### Information about the changes
- Key functionality added: Fix bug in fast isochrones storage
- Reason for change: is buggy

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
