### PR TITLE
Fixing #839 and #845

### DIFF
--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -78,7 +78,7 @@
           "default_params": {
             "encoder_flags_size": 8,
             "graphs_root_path": "graphs",
-            "elevation_provider": "multi",
+            "elevation_provider": "gmted",
             "elevation_cache_path": "cgiar_provider",
             "elevation_cache_clear": false,
             "instructions": true,
@@ -121,7 +121,7 @@
               "encoder_flags_size": 8,
               "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=false",
               "maximum_distance": 100000,
-              "elevation": true,
+              "elevation": false,
               "maximum_snapping_radius": 350,
               "preparation": {
                 "min_network_size": 200,
@@ -179,7 +179,7 @@
               "encoder_flags_size": 8,
               "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=false",
               "maximum_distance": 100000,
-              "elevation": true,
+              "elevation": false,
               "preparation": {
                 "min_network_size": 200,
                 "min_one_way_network_size": 200,
@@ -234,7 +234,7 @@
             "profiles": "cycling-regular",
             "parameters": {
               "encoder_options": "consider_elevation=true|turn_costs=true|block_fords=false",
-              "elevation": true,
+              "elevation": false,
               "ext_storages": {
                 "WayCategory": {},
                 "WaySurfaceType": {},
@@ -247,7 +247,7 @@
             "profiles": "cycling-mountain",
             "parameters": {
               "encoder_options": "consider_elevation=true|turn_costs=true|block_fords=false",
-              "elevation": true,
+              "elevation": false,
               "ext_storages": {
                 "WayCategory": {},
                 "WaySurfaceType": {},
@@ -260,7 +260,7 @@
             "profiles": "cycling-road",
             "parameters": {
               "encoder_options": "consider_elevation=true|turn_costs=true|block_fords=false",
-              "elevation": true,
+              "elevation": false,
               "ext_storages": {
                 "WayCategory": {},
                 "WaySurfaceType": {},
@@ -273,7 +273,7 @@
             "profiles": "cycling-electric",
             "parameters": {
               "encoder_options": "consider_elevation=true|turn_costs=true|block_fords=false",
-              "elevation": true,
+              "elevation": false,
               "ext_storages": {
                 "WayCategory": {},
                 "WaySurfaceType": {},
@@ -286,7 +286,7 @@
             "profiles": "foot-walking",
             "parameters": {
               "encoder_options": "block_fords=false",
-              "elevation": true,
+              "elevation": false,
               "ext_storages": {
                 "WayCategory": {},
                 "WaySurfaceType": {},
@@ -299,7 +299,7 @@
             "profiles": "foot-hiking",
             "parameters": {
               "encoder_options": "block_fords=false",
-              "elevation": true,
+              "elevation": false,
               "ext_storages": {
                 "WayCategory": {},
                 "WaySurfaceType": {},
@@ -313,7 +313,7 @@
             "profiles": "wheelchair",
             "parameters": {
               "encoder_options": "block_fords=true",
-              "elevation": true,
+              "elevation": false,
               "maximum_snapping_radius": 50,
               "ext_storages": {
                 "WayCategory": {},


### PR DESCRIPTION
As discussed in #839, I have modified the `app.config.sample` file, but I have to admit I am not 100% sure if it fixes the problem. I have done the following:

* Modified the file to change the default elevation provider and **disabling elevation in every profile**
* Created custom docker-compose according to documentation, pointing to project Dockerfile:

```
version: '2.4'
services:
  ors-app:
    container_name: ors-app
    ports:
      - 8080:8080
      - 9001:9001
#    image: openrouteservice/openrouteservice
    build:
      context: ../openrouteservice/
#      args:
#        APP_CONFIG: ./openrouteservice/src/main/resources/app.config.sample
#        OSM_FILE: ./openrouteservice/src/main/files/heidelberg.osm.gz
    volumes:
      - ./graphs:/ors-core/data/graphs
      - ./elevation_cache:/ors-core/data/elevation_cache
      - ./logs/ors:/var/log/ors
      - ./logs/tomcat:/usr/local/tomcat/logs
      - ./conf:/ors-conf
      - ./austria-latest.osm.pbf:/ors-core/data/osm_file.pbf
    environment:
      - BUILD_GRAPHS=True  # Forces the container to rebuild the graphs, e.g. when PBF is changed
      - "JAVA_OPTS=-Djava.awt.headless=true -server -XX:TargetSurvivorRatio=75 -XX:SurvivorRatio=64 -XX:MaxTenuringThreshold=3 -XX:+UseG1GC -XX:+ScavengeBeforeFullGC -XX:ParallelGCThreads=4 -Xms1g -Xmx2g"
      - "CATALINA_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9001 -Dcom.sun.management.jmxremote.rmi.port=9001 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost"

```
* Ran docker compose

It does show signs of life with lines such as 

```
05 Jan 15:07:33 INFO [core.PrepareCore] - 1 513 428, updates:8, nodes: 378 356, shortcuts:570 896, dijkstras:41 159 321, t(dijk):194.95, t(period):163.47, t(lazy):0.0, t(neighbor):49.73, meanDegree:3, algo:28MB, totalMB:1787, usedMB:1003
05 Jan 15:08:39 INFO [core.PrepareCore] - took:301, new shortcuts: 953 104, prepare|fastest, dijkstras:48675906, t(dijk):252.31, t(period):169.46, t(lazy):8.47, t(neighbor):90.75, meanDegree:3, initSize:1891784, periodic:10, lazy:10, neighbor:90, totalMB:1787, usedMB:994
05 Jan 15:08:46 INFO [core.PrepareCore] - 0, updates:0, nodes: 1 891 784, shortcuts:0, dijkstras:6 621 641, t(dijk):2.87, t(period):0.0, t(lazy):0.0, t(neighbor):0.0, meanDegree:1, algo:28MB, totalMB:1787, usedMB:1071
05 Jan 15:09:42 INFO [core.PrepareCore] - 378 357, updates:2, nodes: 1 513 427, shortcuts:1 190, dijkstras:18 284 541, t(dijk):49.13, t(period):50.46, t(lazy):0.0, t(neighbor):4.73, meanDegree:1, algo:28MB, totalMB:1787, usedMB:1181
05 Jan 15:10:27 INFO [core.PrepareCore] - 756 714, updates:4, nodes: 1 135 070, shortcuts:1 212, dijkstras:26 952 696, t(dijk):86.15, t(period):91.2, t(lazy):0.0, t(neighbor):8.63, meanDegree:2, algo:28MB, totalMB:1787, usedMB:1313
05 Jan 15:11:19 INFO [core.PrepareCore] - 1 135 071, updates:6, nodes: 756 713, shortcuts:262 802, dijkstras:35 280 401, t(dijk):128.49, t(period):123.97, t(lazy):0.0, t(neighbor):22.95, meanDegree:2, algo:28MB, totalMB:1787, usedMB:1163
05 Jan 15:12:09 INFO [core.PrepareCore] - 1 513 428, updates:8, nodes: 378 356, shortcuts:620 802, dijkstras:42 891 597, t(dijk):170.23, t(period):147.22, t(lazy):0.0, t(neighbor):44.31, meanDegree:2, algo:28MB, totalMB:1787, usedMB:1027
05 Jan 15:13:58 INFO [core.PrepareCore] - took:318, new shortcuts: 1 167 305, prepare|shortest, dijkstras:58732053, t(dijk):266.18, t(period):154.07, t(lazy):12.89, t(neighbor):120.26, meanDegree:4, initSize:1891784, periodic:10, lazy:10, neighbor:90, totalMB:1787, usedMB:1075
```

**BUT**:

* I still could not use routing because of "missing profile", although I have try all combinations (car included). I curl'ed `http://localhost:8080/ors/v2/directions?profile=foot-walking&start=8.676581,49.418204&end=8.692803,49.409465` and got:
```
{"error":{"code":2001,"message":"Parameter 'profile' is missing."},"info":{"engine":{"version":"6.3.2","build_date":"2021-01-05T14:57:09Z"},"timestamp":1609860040294}}
```
* I noticed that active profile has changed
*app.config.sample*:
```
        "profiles": {
          "active": [
            "car",
            "hgv",
            "bike-regular",
            "bike-mountain",
            "bike-road",
            "bike-electric",
            "walking",
            "hiking",
            "wheelchair"
          ],
```
*./conf/app.config*:

```
        "profiles": {
          "active": [
            "car"
          ],
```
 
