### PR TITLE
include distance, duration and steps in all route segments in API res…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ RELEASING:
 - API endpoint "centrality" to calculate [betweenness centrality](https://en.wikipedia.org/wiki/Betweenness_centrality) values for nodes inside a given bounding box. Centrality is calculated using Brandes' algorithm. 
 ### Fixed
 - Fixed calculation of route distance limits with skipped segments ([#814](https://github.com/GIScience/openrouteservice/issues/814))
+- fixed missing segment distance and duration ([#695](https://github.com/GIScience/openrouteservice/issues/695)
 
 ## [6.3.6] - 2021-02-02
 ### Fixed

--- a/openrouteservice/src/main/java/org/heigit/ors/api/responses/routing/json/JSONSegment.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/responses/routing/json/JSONSegment.java
@@ -33,12 +33,15 @@ import java.util.List;
 public class JSONSegment {
     @ApiModelProperty(value = "Contains the distance of the segment in specified units.", example = "253")
     @JsonProperty("distance")
+    @JsonInclude()
     private Double distance;
     @ApiModelProperty(value = "Contains the duration of the segment in seconds.", example = "37.7")
     @JsonProperty("duration")
+    @JsonInclude()
     private Double duration;
     @ApiModelProperty("List containing the specific steps the segment consists of.")
     @JsonProperty("steps")
+    @JsonInclude()
     private List<JSONStep> steps;
     @ApiModelProperty(value = "Contains the deviation compared to a straight line that would have the factor `1`. Double the Distance would be a `2`. CUSTOM_KEYS:{'validWhen':{'ref':'attributes','valueContains':'detourfactor'}}", example = "0.5")
     @JsonProperty("detourfactor")


### PR DESCRIPTION
…ponse

fixes #695
Distance and duration might be 0 if the same coord is sent twice. They should be included nevertheless.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.