### PR TITLE
correct matrix response documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ RELEASING:
 
 ## [Unreleased]
 
+### Fixed
+ - Fixed incorrect matrix response documentation ([#873](https://github.com/GIScience/openrouteservice/issues/873)
+
 ## [6.4.0] - 2021-03-26
 ### Added
 - API endpoint "centrality" to calculate [betweenness centrality](https://en.wikipedia.org/wiki/Betweenness_centrality) values for nodes inside a given bounding box. Centrality is calculated using Brandes' algorithm. 

--- a/openrouteservice/src/main/java/org/heigit/ors/api/controllers/MatrixAPI.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/controllers/MatrixAPI.java
@@ -74,8 +74,8 @@ public class MatrixAPI {
     // Functional request methods
 
     @PostMapping(value = "/{profile}", produces = {"application/json;charset=UTF-8"})
-    @ApiOperation(value = "Matrix Service", notes = "Returns duration or distance matrix for mutliple source and destination points.\n" +
-            "By default a symmetric duration matrix is returned where every point in locations is paired with each other. The result is null if a value can’t be determined.", httpMethod = "POST", consumes = "application/json", produces = "application/json")
+    @ApiOperation(value = "Matrix Service", notes = "Returns duration or distance matrix for multiple source and destination points.\n" +
+            "By default a square duration matrix is returned where every point in locations is paired with each other. The result is null if a value can’t be determined.", httpMethod = "POST", consumes = "application/json", produces = "application/json")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Standard response for successfully processed requests. Returns JSON.", response = JSONMatrixResponse.class)
     })


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #873.

### Information about the changes
Matrix response documentation was misleading and is now correct:
The matrix response returns a square matrix by default, not a symmetric
one.
