### PR TITLE
Allow to disable conditional storage encoders via config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,13 @@ RELEASING:
  -->
 
 ## [Unreleased]
+### Added
+- Allow to disable OSM conditional access and speed encoders via parameter in config file
 
 ## [6.4.1] - 2021-03-31
 ### Fixed
-- Fixed incorrect matrix response documentation ([#873](https://github.com/GIScience/openrouteservice/issues/873)
-- Fixed incorrect indexing of waypoints for consecutive identical coordinates ([#762](https://github.com/GIScience/openrouteservice/issues/762)
+- Fixed incorrect matrix response documentation ([#873](https://github.com/GIScience/openrouteservice/issues/873))
+- Fixed incorrect indexing of waypoints for consecutive identical coordinates ([#762](https://github.com/GIScience/openrouteservice/issues/762))
 - Changed isochrone polygon calculation to use more buffering
 
 ## [6.4.0] - 2021-03-26
@@ -50,7 +52,7 @@ RELEASING:
 - Remove Isochrones v1 api tests
 ### Fixed
 - Fixed calculation of route distance limits with skipped segments ([#814](https://github.com/GIScience/openrouteservice/issues/814))
-- Fixed missing segment distance and duration ([#695](https://github.com/GIScience/openrouteservice/issues/695)
+- Fixed missing segment distance and duration ([#695](https://github.com/GIScience/openrouteservice/issues/695))
 - Fixed no response when asking for isochrone intersections ([#675](https://github.com/GIScience/openrouteservice/issues/675))
 - Fixed continue_straight option with no bearing on CH-enabled profiles
 

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -379,19 +379,19 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>v0.13.10</version>
+            <version>v0.13.12</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-reader-osm</artifactId>
-            <version>v0.13.10</version>
+            <version>v0.13.12</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-api</artifactId>
-            <version>v0.13.10</version>
+            <version>v0.13.12</version>
         </dependency>
 
         <!-- remove the comment to enable debugging

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
@@ -43,14 +43,8 @@ public class CarFlagEncoder extends VehicleFlagEncoder {
         this((int) properties.getLong("speed_bits", 5),
                 properties.getDouble("speed_factor", 5),
                 properties.getBool("turn_costs", false) ? 1 : 0);
-        this.properties = properties;
-        speedTwoDirections = properties.getBool("speed_two_directions", true);
-        this.setBlockFords(properties.getBool("block_fords", true));
-        this.setBlockByDefault(properties.getBool("block_barriers", true));
 
-        useAcceleration = properties.getBool("use_acceleration", false);
-
-        maxTrackGradeLevel = properties.getInt("maximum_grade_level", 3);
+        setProperties(properties);
     }
 
     public CarFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -40,7 +40,7 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
     protected final HashSet<String> backwardKeys = new HashSet<>(5);
     protected final List<String> hgvAccess = new ArrayList<>(5);
 
-    protected int maxTrackGradeLevel = 3;
+    protected int maxTrackGradeLevel = 1;
 
     private static final int MEAN_SPEED = 70;
 
@@ -60,16 +60,9 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
         		properties.getDouble("speed_factor", 5),
         		properties.getBool("turn_costs", false) ? 3 : 0);
         
-        setBlockFords(false);
+        setProperties(properties);
 
-        setBlockFords(properties.getBool("block_fords", true));
-        setBlockByDefault(properties.getBool("block_barriers", true));
-
-        speedTwoDirections = properties.getBool("speed_two_directions", true);
-
-        maxTrackGradeLevel = properties.getInt("maximum_grade_level", 1);
-
-        useAcceleration = properties.getBool("use_acceleration", false);
+        maxTrackGradeLevel = properties.getInt("maximum_grade_level", maxTrackGradeLevel);
     }
 
     public HeavyVehicleFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
@@ -22,6 +22,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.*;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.PriorityWeighting;
+import com.graphhopper.storage.ConditionalEdges;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import org.heigit.ors.routing.graphhopper.extensions.flagencoders.ORSAbstractFlagEncoder;
@@ -31,7 +32,6 @@ import java.util.*;
 
 import static com.graphhopper.routing.util.EncodingManager.getKey;
 import static com.graphhopper.routing.util.PriorityCode.*;
-import static com.graphhopper.util.Helper.keepIn;
 
 /**
  * Defines bit layout of bicycles (not motorcycles) for speed, access and relations (network).
@@ -89,7 +89,7 @@ public abstract class CommonBikeFlagEncoder extends ORSAbstractFlagEncoder {
     // This is the specific bicycle class
     private String classBicycleKey;
 
-    private BooleanEncodedValue conditionalEncoder;
+    private BooleanEncodedValue conditionalAccessEncoder;
 
     // MARQ24 MOD START
     // MARQ24 ADDON in the case of the RoadBike Encoder we want to skip some
@@ -103,6 +103,11 @@ public abstract class CommonBikeFlagEncoder extends ORSAbstractFlagEncoder {
         this(speedBits, speedFactor, maxTurnCosts, false);
     }
     // MARQ24 MOD END
+
+    protected void setProperties(PMap properties) {
+        this.properties = properties;
+        this.setBlockFords(properties.getBool("block_fords", true));
+    }
 
     // MARQ24 MOD START
     protected CommonBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts, boolean considerElevation) {
@@ -262,8 +267,8 @@ public abstract class CommonBikeFlagEncoder extends ORSAbstractFlagEncoder {
         registerNewEncodedValue.add(wayTypeEncoder);
         priorityWayEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false);
         registerNewEncodedValue.add(priorityWayEncoder);
-        registerNewEncodedValue.add(conditionalEncoder = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, "conditional_access"), false));
-
+        if (properties.getBool(ConditionalEdges.ACCESS, false))
+            registerNewEncodedValue.add(conditionalAccessEncoder = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, ConditionalEdges.ACCESS), false));
     }
 
     @Override
@@ -407,8 +412,8 @@ public abstract class CommonBikeFlagEncoder extends ORSAbstractFlagEncoder {
             wayTypeSpeed = applyMaxSpeed(way, wayTypeSpeed);
             handleSpeed(edgeFlags, way, wayTypeSpeed);
             handleBikeRelated(edgeFlags, way, relationFlags > UNCHANGED.getValue());
-            if (access.isConditional())
-                conditionalEncoder.setBool(false, edgeFlags, true);
+            if (access.isConditional() && conditionalAccessEncoder!=null)
+                conditionalAccessEncoder.setBool(false, edgeFlags, true);
             boolean isRoundabout = way.hasTag(KEY_JUNCTION, "roundabout") || way.hasTag(KEY_JUNCTION, "circular");
             if (isRoundabout) {
                 roundaboutEnc.setBool(true, edgeFlags, true);

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/ElectroBikeFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/ElectroBikeFlagEncoder.java
@@ -20,13 +20,12 @@ public class ElectroBikeFlagEncoder extends CommonBikeFlagEncoder
 {
     private static final int MEAN_SPEED = 20;
 
-    public ElectroBikeFlagEncoder(PMap properties )
+    public ElectroBikeFlagEncoder(PMap properties)
     {
         this((int) properties.getLong("speed_bits", 4) + (properties.getBool("consider_elevation", false) ? 1 : 0),
                 properties.getLong("speed_factor", 2),
                 properties.getBool("turn_costs", false) ? 1 : 0, properties.getBool("consider_elevation", false));
-        this.properties = properties;
-        this.setBlockFords(properties.getBool("block_fords", true));
+        setProperties(properties);
     }
     
     public ElectroBikeFlagEncoder( int speedBits, double speedFactor, int maxTurnCosts, boolean considerElevation)

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/MountainBikeFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/MountainBikeFlagEncoder.java
@@ -44,8 +44,7 @@ public class MountainBikeFlagEncoder extends CommonBikeFlagEncoder {
             properties.getBool("turn_costs", false) ? 1 : 0,
             properties.getBool("consider_elevation", false)
         );
-        this.properties = properties;
-        this.setBlockFords(properties.getBool("block_fords", true));
+        setProperties(properties);
     }
 
     public MountainBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts, boolean considerElevation) {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/RegularBikeFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/RegularBikeFlagEncoder.java
@@ -42,8 +42,7 @@ public class RegularBikeFlagEncoder extends CommonBikeFlagEncoder {
             ,properties.getBool("consider_elevation", false)
             // MARQ24 MOD END
         );
-        this.properties = properties;
-        this.setBlockFords(properties.getBool("block_fords", true));
+        setProperties(properties);
     }
 
     public RegularBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts, boolean considerElevation) {

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/RoadBikeFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/RoadBikeFlagEncoder.java
@@ -64,8 +64,7 @@ public class RoadBikeFlagEncoder extends CommonBikeFlagEncoder {
             ,properties.getBool("consider_elevation", false)
             // MARQ24 MOD END
         );
-        this.properties = properties;
-        setBlockFords(properties.getBool("block_fords", true));
+        setProperties(properties);
     }
 
     public RoadBikeFlagEncoder(String propertiesStr) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

**IMPORTANT**: This PR is set-up to run against GH v0.13.12 which is expected to include https://github.com/GIScience/graphhopper/pull/38.

### Information about the changes
- Key functionality added:

Allows to disable the previously hard-coded conditional storage encoders via a config file setting. Unlike previously the default now is to have them disabled. This is so because these encoders matter only for time-dependent routing which is not part of ORS public API yet.

- Reason for change:

Prerequisite for future developments around time-dependent routing.

### Required changes to app.config (if applicable)

In order to enable OSM conditional encoders use the following. Note that this will affect only the profiles which have the corresponding conditional access/speed encoders implemented (currently ones inheriting from `VehicleFlagEncoder` and `CommonBikeFlagEncoder`).  

`"encoder_options": "conditional_access=true|conditional_speed=true"`
