### PR TITLE
set HGV speed calculation parameter in app.config.sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ RELEASING:
 ## [Unreleased]
 ### Added
 - Allow to disable OSM conditional access and speed encoders via parameter in config file
+### Changed
+- app.config.sample HGV profile has now same settings regarding speed calculation as public API ([#806](https://github.com/GIScience/openrouteservice/issues/806))
 ### Fixed
 - Fixed isochrones algorithm selection for location_type parameter ([#676](https://github.com/GIScience/openrouteservice/issues/676)
 - Updated link to client translations in readme

--- a/openrouteservice-api-tests/.gitignore
+++ b/openrouteservice-api-tests/.gitignore
@@ -1,4 +1,5 @@
 /target/
 /.classpath
 /.gitignore
-/data/elevation/srtm_38_03.gh
+/data/elevation/*
+!/data/elevation/srtm_38_03.zip

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -177,7 +177,7 @@
             "profiles": "driving-hgv",
             "parameters": {
               "encoder_flags_size": 8,
-              "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=false",
+              "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=true",
               "maximum_distance": 100000,
               "elevation": true,
               "maximum_speed_lower_bound": 75,

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -180,6 +180,7 @@
               "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=false",
               "maximum_distance": 100000,
               "elevation": true,
+              "maximum_speed_lower_bound": 75,
               "preparation": {
                 "min_network_size": 200,
                 "min_one_way_network_size": 200,

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -119,7 +119,7 @@
             "profiles": "driving-car",
             "parameters": {
               "encoder_flags_size": 8,
-              "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=false",
+              "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=true",
               "maximum_distance": 100000,
               "elevation": true,
               "maximum_snapping_radius": 350,
@@ -180,7 +180,6 @@
               "encoder_options": "turn_costs=true|block_fords=false|use_acceleration=true",
               "maximum_distance": 100000,
               "elevation": true,
-              "maximum_speed_lower_bound": 75,
               "preparation": {
                 "min_network_size": 200,
                 "min_one_way_network_size": 200,
@@ -190,12 +189,6 @@
                     "enabled": true,
                     "threads": 1,
                     "weightings": "recommended"
-                  },
-                  "lm": {
-                    "enabled": true,
-                    "threads": 1,
-                    "weightings": "recommended,shortest",
-                    "landmarks": 16
                   },
                   "core": {
                     "enabled": true,
@@ -210,10 +203,6 @@
                 "methods": {
                   "ch": {
                     "disabling_allowed": true
-                  },
-                  "lm": {
-                    "disabling_allowed": true,
-                    "active_landmarks": 6
                   },
                   "core": {
                     "disabling_allowed": true,


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #806 .

### Information about the changes
- Reason for change:
app.config.sample HGV profile has now same settings regarding speed calculation as public API, to avoid user confusion. 
