### PR TITLE
Create separate core edge filter instances for each weighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ RELEASING:
 - Allow to disable OSM conditional access and speed encoders via parameter in config file
 - Turkish language support (thanks to [kucar17](https://github.com/kucar17) for the translation)
 ### Fixed
-- Fixed isochrones algorithm selection for location_type parameter ([#676](https://github.com/GIScience/openrouteservice/issues/676)
+- Fixed isochrones algorithm selection for location_type parameter ([#676](https://github.com/GIScience/openrouteservice/issues/676))
 - Updated link to client translations in readme
+- Concurrency bug in core edge filters which caused crashes during CALT graph preparation ([#905](https://github.com/GIScience/openrouteservice/issues/905))
 
 ## [6.4.1] - 2021-03-31
 ### Fixed

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreAlgoFactoryDecorator.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreAlgoFactoryDecorator.java
@@ -16,11 +16,19 @@ package org.heigit.ors.routing.graphhopper.extensions.core;
 import com.graphhopper.routing.RoutingAlgorithmFactory;
 import com.graphhopper.routing.RoutingAlgorithmFactoryDecorator;
 import com.graphhopper.routing.util.EdgeFilter;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.routing.weighting.AbstractWeighting;
+import com.graphhopper.routing.weighting.TurnWeighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.CmdArgs;
 import com.graphhopper.util.Helper;
+import org.heigit.ors.routing.RoutingProfileCategory;
+import org.heigit.ors.routing.graphhopper.extensions.GraphProcessContext;
+import org.heigit.ors.routing.graphhopper.extensions.edgefilters.EdgeFilterSequence;
+import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.*;
+import org.heigit.ors.routing.graphhopper.extensions.flagencoders.FlagEncoderNames;
 import org.heigit.ors.routing.graphhopper.extensions.util.ORSParameters.Core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -307,16 +315,17 @@ public class CoreAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorato
         }
     }
 
-    public void createPreparations(GraphHopperStorage ghStorage, EdgeFilter restrictionFilter) {
+    public void createPreparations(GraphHopperStorage ghStorage, GraphProcessContext processContext) {
         if (!isEnabled() || !preparations.isEmpty())
             return;
         if (!hasCHProfiles())
             throw new IllegalStateException("No profiles found");
 
         for (CHProfile chProfile : chProfiles) {
-            addPreparation(createCHPreparation(ghStorage, chProfile, restrictionFilter));
+            addPreparation(createCHPreparation(ghStorage, chProfile, createCoreEdgeFilter(ghStorage, processContext)));
         }
     }
+
     private PrepareCore createCHPreparation(GraphHopperStorage ghStorage, CHProfile chProfile, EdgeFilter restrictionFilter) {
         PrepareCore tmpPrepareCore = new PrepareCore(
                 new GHDirectory("", DAType.RAM_INT), ghStorage, ghStorage.getCHGraph(chProfile), restrictionFilter);
@@ -326,4 +335,49 @@ public class CoreAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorato
                 setLogMessages(preparationLogMessages);
         return tmpPrepareCore;
     }
+
+    private EdgeFilter createCoreEdgeFilter(GraphHopperStorage gs, GraphProcessContext processContext) {
+        EncodingManager encodingManager = gs.getEncodingManager();
+
+        int routingProfileCategory = RoutingProfileCategory.getFromEncoder(encodingManager);
+
+        /* Initialize edge filter sequence */
+        EdgeFilterSequence edgeFilterSequence = new EdgeFilterSequence();
+
+        /* Heavy vehicle filter */
+        if (encodingManager.hasEncoder(FlagEncoderNames.HEAVYVEHICLE)) {
+            edgeFilterSequence.add(new HeavyVehicleCoreEdgeFilter(gs));
+        }
+
+        /* Avoid features */
+        if ((routingProfileCategory & (RoutingProfileCategory.DRIVING | RoutingProfileCategory.CYCLING | RoutingProfileCategory.WALKING | RoutingProfileCategory.WHEELCHAIR)) != 0) {
+            edgeFilterSequence.add(new AvoidFeaturesCoreEdgeFilter(gs, routingProfileCategory));
+        }
+
+        /* Avoid borders */
+        if ((routingProfileCategory & (RoutingProfileCategory.DRIVING | RoutingProfileCategory.CYCLING)) != 0) {
+            edgeFilterSequence.add(new AvoidBordersCoreEdgeFilter(gs));
+        }
+
+        if (routingProfileCategory == RoutingProfileCategory.WHEELCHAIR) {
+            edgeFilterSequence.add(new WheelchairCoreEdgeFilter(gs));
+        }
+
+        /* Maximum speed & turn restrictions */
+        if ((routingProfileCategory & RoutingProfileCategory.DRIVING) !=0) {
+            String[] encoders = {FlagEncoderNames.CAR_ORS, FlagEncoderNames.HEAVYVEHICLE};
+            for (String encoderName: encoders) {
+                if (encodingManager.hasEncoder(encoderName)) {
+                    FlagEncoder flagEncoder = encodingManager.getEncoder(encoderName);
+                    edgeFilterSequence.add(new MaximumSpeedCoreEdgeFilter(flagEncoder, processContext.getMaximumSpeedLowerBound()));
+                    if (flagEncoder.supports(TurnWeighting.class))
+                        edgeFilterSequence.add(new TurnRestrictionsCoreEdgeFilter(flagEncoder, gs));
+                    break;
+                }
+            }
+        }
+
+        return edgeFilterSequence;
+    }
+
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/PrepareCore.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/PrepareCore.java
@@ -41,7 +41,6 @@ public class PrepareCore extends AbstractAlgoPreparation implements RoutingAlgor
     private static final Logger LOGGER = Logger.getLogger(PrepareCore.class);
     private final CHProfile chProfile;
     private final PreparationWeighting prepareWeighting;
-    private final TraversalMode traversalMode;
     private final EdgeFilter restrictionFilter;
     private final GraphHopperStorage ghStorage;
     private final CHGraphImpl prepareGraph;
@@ -85,7 +84,6 @@ public class PrepareCore extends AbstractAlgoPreparation implements RoutingAlgor
         this.ghStorage = ghStorage;
         this.prepareGraph = (CHGraphImpl) chGraph;
         this.chProfile = chGraph.getCHProfile();
-        this.traversalMode = chProfile.getTraversalMode();
         this.weighting = chProfile.getWeighting();
         this.flagEncoder = weighting.getFlagEncoder();
         this.restrictionFilter = restrictionFilter;


### PR DESCRIPTION


### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #905.

### Information about the changes

- Reason for change: Fixes concurrency issues when multiple threads are used for core preparations.

