### PR TITLE
ignore invalid call to GZIPResponseStream.flush() without throwing Ex…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ RELEASING:
  -->
 
 ## [Unreleased]
+- Reduced unnecessary warning messages caused by spring output stream handling ([#899](https://github.com/GIScience/openrouteservice/issues/899)
 
 ## [6.4.2] - 2021-04-21
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/servlet/filters/GZIPResponseStream.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/servlet/filters/GZIPResponseStream.java
@@ -63,7 +63,7 @@ class GZIPResponseStream extends ServletOutputStream {
 	@Override
 	public void flush() throws IOException {
 		if (closed)
-			throw new IOException("Cannot flush a closed output stream");
+			return; // already closed, nothing to do
 		
 		gzipOutputStream.flush();
 	}

--- a/openrouteservice/src/main/resources/logs/DEBUG_LOGGING.json
+++ b/openrouteservice/src/main/resources/logs/DEBUG_LOGGING.json
@@ -37,7 +37,7 @@
         },
         {
           "name": "org.springframework",
-          "level": "error",
+          "level": "warn",
           "additivity": "false",
           "AppenderRef": {
             "ref": "stdout"
@@ -45,7 +45,7 @@
         },
         {
           "name": "org.hibernate",
-          "level": "error",
+          "level": "warn",
           "additivity": "false",
           "AppenderRef": {
             "ref": "stdout"

--- a/openrouteservice/src/main/resources/logs/PRODUCTION_LOGGING.json
+++ b/openrouteservice/src/main/resources/logs/PRODUCTION_LOGGING.json
@@ -43,7 +43,7 @@
         },
         {
           "name": "org.springframework",
-          "level": "warn",
+          "level": "error",
           "additivity": "false",
           "AppenderRef": {
             "ref": "stdout"
@@ -51,7 +51,7 @@
         },
         {
           "name": "org.hibernate",
-          "level": "warn",
+          "level": "error",
           "additivity": "false",
           "AppenderRef": {
             "ref": "stdout"


### PR DESCRIPTION
…ception

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #899 .

### Information about the changes
- Reason for change:
Fixed the logging definition files, spring warning messages should be displayed for the debug setting and not for production setting. 
Additionally, I figured out that for the newer version of tomcat we use now, throwing an exception within a custom output stream in cases where flush() is called after it has been closed would lead to followup errors; it appears these cases can be simply ignored.

The reason this issue went unnoticed is the use of the `tomcat7:run` goal in debugging configuration, since the GZIPOutputStream was not being used as in the production configuration. To mitigate, it is advisable to use the `tomcat7:run-war` goal instead.  
