### PR TITLE
Use as default fallback A* rather than Dijkstra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ RELEASING:
 ## [Unreleased]
 ### Added
 - Time-dependent core-based routing algorithms
-  
 ### Fixed
-- prioritize graph build date over data date in routing request ([#925](https://github.com/GIScience/openrouteservice/issues/925))
+- Prioritize graph build date over data date in routing request ([#925](https://github.com/GIScience/openrouteservice/issues/925))
+- Make sure A* with beeline approximation is used as default fallback algorithm ([#926](https://github.com/GIScience/openrouteservice/issues/926))
 
 ## [6.4.3] - 2021-04-28
 ### Changed

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -111,7 +111,6 @@ public class RoutingProfile {
     private static final String KEY_ACTIVE_LANDMARKS = "active_landmarks";
     private static final String KEY_TOTAL_POP = "total_pop";
     private static final String KEY_TOTAL_AREA_KM = "total_area_km";
-    private static final String KEY_ASTARBI = Parameters.Algorithms.ASTAR_BI;
     private static final int KEY_FLEX_STATIC = 0;
     private static final int KEY_FLEX_PREPROCESSED = 1;
     private static final int KEY_FLEX_FULLY = 2;
@@ -918,7 +917,7 @@ public class RoutingProfile {
                 req = new GHRequest(new GHPoint(lat0, lon0), new GHPoint(lat1, lon1), bearings[0].getValue(), bearings[1].getValue());
 
             req.setVehicle(searchCntx.getEncoder().toString());
-            req.setAlgorithm(Parameters.Algorithms.DIJKSTRA_BI);
+            req.setAlgorithm(Parameters.Algorithms.ASTAR_BI);
 
             if (radiuses != null)
                 req.setMaxSearchDistance(radiuses);
@@ -1072,8 +1071,8 @@ public class RoutingProfile {
         req.getHints().put(KEY_CORE_DISABLE, !useCore);
         req.getHints().put(KEY_LM_DISABLE, !useALT);
 
-        if(!useCH)
-            req.setAlgorithm(KEY_ASTARBI);
+        if (useCH)
+            req.setAlgorithm(Parameters.Algorithms.DIJKSTRA_BI);
     }
 
     boolean hasTimeDependentSpeed (RouteSearchParameters searchParams, RouteSearchContext searchCntx) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #926 .

### Information about the changes
- Reason for change: There have been issues in the past that in certain constellations routing defaulted to Dijkstra rather than A*.