### PR TITLE
Fix config file parameter to set the number of active core landmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ RELEASING:
   
 ### Fixed
 - prioritize graph build date over data date in routing request ([#925](https://github.com/GIScience/openrouteservice/issues/925))
+- Config file parameter to set the number of active landmarks for core routing ([#930](https://github.com/GIScience/openrouteservice/issues/930))
 
 ## [6.4.3] - 2021-04-28
 ### Changed

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -103,6 +103,7 @@ public class RoutingProfile {
     private static final String VAL_ENABLED = "enabled";
     private static final String KEY_THREADS = "threads";
     private static final String KEY_WEIGHTINGS = "weightings";
+    private static final String KEY_LMSETS = "lmsets";
     private static final String KEY_MAXCELLNODES = "maxcellnodes";
     private static final String KEY_METHODS_LM = "methods.lm";
     private static final String KEY_LANDMARKS = "landmarks";
@@ -342,8 +343,8 @@ public class RoutingProfile {
                             args.put("prepare.core.threads", coreOpts.getInt(KEY_THREADS));
                         if (coreOpts.hasPath(KEY_WEIGHTINGS))
                             args.put(KEY_PREPARE_CORE_WEIGHTINGS, StringUtility.trimQuotes(coreOpts.getString(KEY_WEIGHTINGS)));
-                        if (coreOpts.hasPath("lmsets"))
-                            args.put("prepare.corelm.lmsets", StringUtility.trimQuotes(coreOpts.getString("lmsets")));
+                        if (coreOpts.hasPath(KEY_LMSETS))
+                            args.put("prepare.corelm.lmsets", StringUtility.trimQuotes(coreOpts.getString(KEY_LMSETS)));
                         if (coreOpts.hasPath(KEY_LANDMARKS))
                             args.put("prepare.corelm.landmarks", coreOpts.getInt(KEY_LANDMARKS));
                     }
@@ -354,14 +355,17 @@ public class RoutingProfile {
         if (config.getExecutionOpts() != null) {
             Config opts = config.getExecutionOpts();
             if (opts.hasPath(KEY_METHODS_CH)) {
-                Config coreOpts = opts.getConfig(KEY_METHODS_CH);
-                if (coreOpts.hasPath(KEY_DISABLING_ALLOWED))
-                    args.put("routing.ch.disabling_allowed", coreOpts.getBoolean(KEY_DISABLING_ALLOWED));
+                Config chOpts = opts.getConfig(KEY_METHODS_CH);
+                if (chOpts.hasPath(KEY_DISABLING_ALLOWED))
+                    args.put("routing.ch.disabling_allowed", chOpts.getBoolean(KEY_DISABLING_ALLOWED));
             }
             if (opts.hasPath(KEY_METHODS_CORE)) {
-                Config chOpts = opts.getConfig(KEY_METHODS_CORE);
-                if (chOpts.hasPath(KEY_DISABLING_ALLOWED))
-                    args.put("routing.core.disabling_allowed", chOpts.getBoolean(KEY_DISABLING_ALLOWED));
+                Config coreOpts = opts.getConfig(KEY_METHODS_CORE);
+                if (coreOpts.hasPath(KEY_DISABLING_ALLOWED))
+                    args.put("routing.core.disabling_allowed", coreOpts.getBoolean(KEY_DISABLING_ALLOWED));
+
+                if (coreOpts.hasPath(KEY_ACTIVE_LANDMARKS))
+                    args.put("routing.corelm.active_landmarks", coreOpts.getInt(KEY_ACTIVE_LANDMARKS));
             }
             if (opts.hasPath(KEY_METHODS_LM)) {
                 Config lmOpts = opts.getConfig(KEY_METHODS_LM);
@@ -370,14 +374,6 @@ public class RoutingProfile {
 
                 if (lmOpts.hasPath(KEY_ACTIVE_LANDMARKS))
                     args.put("routing.lm.active_landmarks", lmOpts.getInt(KEY_ACTIVE_LANDMARKS));
-            }
-            if (opts.hasPath("methods.corelm")) {
-                Config lmOpts = opts.getConfig("methods.corelm");
-                if (lmOpts.hasPath(KEY_DISABLING_ALLOWED))
-                    args.put("routing.lm.disabling_allowed", lmOpts.getBoolean(KEY_DISABLING_ALLOWED));
-
-                if (lmOpts.hasPath(KEY_ACTIVE_LANDMARKS))
-                    args.put("routing.corelm.active_landmarks", lmOpts.getInt(KEY_ACTIVE_LANDMARKS));
             }
         }
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLMAlgoFactoryDecorator.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLMAlgoFactoryDecorator.java
@@ -81,7 +81,7 @@ public class CoreLMAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecora
         setPreparationThreads(args.getInt(CoreLandmark.PREPARE + "threads", getPreparationThreads()));
 
         landmarkCount = args.getInt(CoreLandmark.COUNT, landmarkCount);
-        activeLandmarkCount = args.getInt(CoreLandmark.ACTIVE_COUNT, Math.min(4, landmarkCount));
+        activeLandmarkCount = args.getInt(CoreLandmark.ACTIVE_COUNT_DEFAULT, Math.min(4, landmarkCount));
         logDetails = args.getBool(CoreLandmark.PREPARE + "log_details", false);
         minNodes = args.getInt(CoreLandmark.PREPARE + "min_network_size", -1);
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/ORSParameters.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/ORSParameters.java
@@ -55,7 +55,7 @@ public class ORSParameters {
 
         public static final String PREPARE = "prepare.corelm.";
         /**
-         * This property name in HintsMap configures at runtime if CH routing should be ignored.
+         * Specifies landmark sets.
          */
         public static final String LMSETS = PREPARE + "lmsets";
         /**
@@ -65,7 +65,7 @@ public class ORSParameters {
         /**
          * Specifies how many active landmarks should be used when routing
          */
-        public static final String ACTIVE_COUNT = ROUTING_INIT_PREFIX + "corelm.active_landmarks";
+        public static final String ACTIVE_COUNT = "corelm.active_landmarks";
         /**
          * Default for active count
          */


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #930 .

### Information about the changes
- Reason for change: config file parameter `active_landmarks` to set the number of active core landmarks for routing was not taken into account.