### PR TITLE
Config file parameter to disable edge-based core routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ RELEASING:
 ## [Unreleased]
 ### Added
 - Time-dependent core-based routing algorithms
+- Option to disable edge-based routing in core for a single weighting ([#928](https://github.com/GIScience/openrouteservice/issues/928))
 ### Fixed
 - Config file parameter to set the number of active landmarks for core routing ([#930](https://github.com/GIScience/openrouteservice/issues/930))
 - Make sure A* with beeline approximation is used as default fallback algorithm ([#926](https://github.com/GIScience/openrouteservice/issues/926))

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreAlgoFactoryDecorator.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreAlgoFactoryDecorator.java
@@ -322,7 +322,7 @@ public class CoreAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorato
             throw new IllegalStateException("No profiles found");
 
         for (CHProfile chProfile : chProfiles) {
-            addPreparation(createCHPreparation(ghStorage, chProfile, createCoreEdgeFilter(ghStorage, processContext)));
+            addPreparation(createCHPreparation(ghStorage, chProfile, createCoreEdgeFilter(chProfile, ghStorage, processContext)));
         }
     }
 
@@ -336,7 +336,7 @@ public class CoreAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorato
         return tmpPrepareCore;
     }
 
-    private EdgeFilter createCoreEdgeFilter(GraphHopperStorage gs, GraphProcessContext processContext) {
+    private EdgeFilter createCoreEdgeFilter(CHProfile chProfile, GraphHopperStorage gs, GraphProcessContext processContext) {
         EncodingManager encodingManager = gs.getEncodingManager();
 
         int routingProfileCategory = RoutingProfileCategory.getFromEncoder(encodingManager);
@@ -370,7 +370,7 @@ public class CoreAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorato
                 if (encodingManager.hasEncoder(encoderName)) {
                     FlagEncoder flagEncoder = encodingManager.getEncoder(encoderName);
                     edgeFilterSequence.add(new MaximumSpeedCoreEdgeFilter(flagEncoder, processContext.getMaximumSpeedLowerBound()));
-                    if (flagEncoder.supports(TurnWeighting.class))
+                    if (chProfile.isEdgeBased() && flagEncoder.supports(TurnWeighting.class))
                         edgeFilterSequence.add(new TurnRestrictionsCoreEdgeFilter(flagEncoder, gs));
                     break;
                 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreNodeContractor.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreNodeContractor.java
@@ -19,6 +19,7 @@ import com.graphhopper.routing.ch.PrepareEncoder;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.AbstractWeighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.*;
@@ -57,9 +58,6 @@ public class CoreNodeContractor {
     private int maxLevel;
 
     public CoreNodeContractor(Directory dir, GraphHopperStorage ghStorage, CHGraph prepareGraph, CHProfile chProfile) {
-        if (chProfile.getTraversalMode().isEdgeBased()) {
-            throw new IllegalArgumentException("Contraction Hierarchies only support node based traversal so far, given: " + chProfile.getTraversalMode());
-        }
         // todo: it would be nice to check if ghStorage is frozen here
         this.ghStorage = ghStorage;
         this.prepareGraph = prepareGraph;
@@ -79,7 +77,8 @@ public class CoreNodeContractor {
         FlagEncoder prepareFlagEncoder = prepareWeighting.getFlagEncoder();
         vehicleInExplorer = prepareGraph.createEdgeExplorer(DefaultEdgeFilter.inEdges(prepareFlagEncoder));
         vehicleOutExplorer = prepareGraph.createEdgeExplorer(DefaultEdgeFilter.outEdges(prepareFlagEncoder));
-        prepareAlgo = new DijkstraOneToMany(prepareGraph, prepareWeighting, chProfile.getTraversalMode());
+        // always use node-based traversal because all turn restrictions are in the core
+        prepareAlgo = new DijkstraOneToMany(prepareGraph, prepareWeighting, TraversalMode.NODE_BASED);
     }
 
     public void close() {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #928 .

### Information about the changes
- Key functionality added: option to disable edge-based core routing.
- Reason for change: more granular control over core routing config.

### Required changes to app.config (if applicable)

CALT defaults to edge-based routing as long as `turn_costs` are set and supported by a given flag encoder. Edge-based rather than node-based routing is neccessary for obeying turn restrictions. This behavior can now be altered for a given weighting by specifying the `edge_based` flag like so:

```
"preparation": {
                                "min_network_size": 200,
                                "min_one_way_network_size": 200,
                                "methods": {
                                    "core": {
                                        "enabled": true,
                                        "threads": 8,
                                        "weightings": "fastest,shortest|edge_based=false",
                                        "landmarks": 8,
                                        "lmsets": "highways;allow_all"
                                    }
                                }
                            }
```
It is a preparation rather than execution setting because there is no point in including turn restrictions in the core if they are not used afterwards.
