### PR TITLE
change rebase from development to master

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -67,7 +67,7 @@ We'd like all pull requests to adhere to the following rules:
 ```
 git checkout my-new-feat
 git stash
-git rebase development
+git rebase master
 git stash pop
 ```
 


### PR DESCRIPTION
I guess 
```
git rebase development
```
should be `master` instead.