### PR TITLE
More consistent handling of low-speed edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ RELEASING:
 ### Added
 - Time-dependent core-based routing algorithms
 - Option to disable edge-based routing in core for a single weighting ([#928](https://github.com/GIScience/openrouteservice/issues/928))
+### Changed
+- Speed values falling below encoder's resolution are consequently stored as lowest possible non-zero value rather than being rounded to zero together with setting access to the corresponding edges to false ([#944](https://github.com/GIScience/openrouteservice/issues/944))
 ### Fixed
 - Do not consider ill-defined "maxspeed = 0" OSM tags ([#940](https://github.com/GIScience/openrouteservice/issues/940))
 - Use JSON definitions of country-specific speed limits ([#939](https://github.com/GIScience/openrouteservice/issues/939))

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
@@ -224,18 +224,13 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
 
             speed = getSurfaceSpeed(way, speed);
 
-            if(way.hasTag(KEY_ESTIMATED_DISTANCE)) {
-                if(this.useAcceleration) {
+            if (way.hasTag(KEY_ESTIMATED_DISTANCE)) {
+                if (way.hasTag(KEY_HIGHWAY, KEY_RESIDENTIAL)) {
+                    speed = addResedentialPenalty(speed, way);
+                }
+                else if (this.useAcceleration) {
                     double estDist = way.getTag(KEY_ESTIMATED_DISTANCE, Double.MAX_VALUE);
-                    if(way.hasTag(KEY_HIGHWAY, KEY_RESIDENTIAL)) {
-                        speed = addResedentialPenalty(speed, way);
-                    } else {
-                        speed = Math.max(adjustSpeedForAcceleration(estDist, speed), speedFactor);
-                    }
-                } else {
-                    if(way.hasTag(KEY_HIGHWAY, KEY_RESIDENTIAL)) {
-                        speed = addResedentialPenalty(speed, way);
-                    }
+                    speed = Math.max(adjustSpeedForAcceleration(estDist, speed), speedFactor);
                 }
             }
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #944 .

### Information about the changes
Refactored handling of edges whose resolved speed falls below encoder's resolution in order to prevent ending up with edges with speed set to 0. For a detailed description see #944.
