### PR TITLE
Do not use virtual edges for building isochrone geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ RELEASING:
 ### Added
 - Accept single value and array of length 1 as `radiuses`-parameter ([#923](https://github.com/GIScience/openrouteservice/issues/923))
 ### Fixed
+- Rare bug where virtual edges are used to construct geometry of isochrone. Check whether edge is virtual before using it.
 - Clarified "Point not found"-Error message ([#922](https://github.com/GIScience/openrouteservice/issues/922))
 
 ## [6.5.0] - 2021-05-17

--- a/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -332,6 +332,7 @@ public class ConcaveBallsIsochroneMapBuilder implements IsochroneMapBuilder {
 		GraphHopperStorage graph = searchContext.getGraphHopper().getGraphHopperStorage();
 		NodeAccess nodeAccess = graph.getNodeAccess();
 		int maxNodeId = graph.getNodes();
+		int maxEdgeId = graph.getEdges() - 1;
 
 		DistanceCalc dcFast = new DistancePlaneProjection();
 		double bufferSize = 0.0018;
@@ -365,7 +366,7 @@ public class ConcaveBallsIsochroneMapBuilder implements IsochroneMapBuilder {
 			edgeId = goalEdge.originalEdge;
 			nodeId = goalEdge.adjNode;
 
-			if (edgeId == -1 || nodeId == -1 || nodeId > maxNodeId)
+			if (edgeId == -1 || nodeId == -1 || nodeId > maxNodeId || edgeId > maxEdgeId)
 				continue;
 
 			float maxCost = (float) goalEdge.weight;

--- a/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -331,7 +331,7 @@ public class ConcaveBallsIsochroneMapBuilder implements IsochroneMapBuilder {
 
 		GraphHopperStorage graph = searchContext.getGraphHopper().getGraphHopperStorage();
 		NodeAccess nodeAccess = graph.getNodeAccess();
-		int maxNodeId = graph.getNodes();
+		int maxNodeId = graph.getNodes() - 1;
 		int maxEdgeId = graph.getEdges() - 1;
 
 		DistanceCalc dcFast = new DistancePlaneProjection();

--- a/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
@@ -512,7 +512,7 @@ public class FastIsochroneMapBuilder implements IsochroneMapBuilder {
         GraphHopperStorage graphHopperStorage = searchcontext.getGraphHopper().getGraphHopperStorage();
         Quadtree qtree = new Quadtree();
 
-        int maxNodeId = graphHopperStorage.getNodes();
+        int maxNodeId = graphHopperStorage.getNodes() - 1;
         int maxEdgeId = graphHopperStorage.getEdges() - 1;
 
         SPTEntry goalEdge;

--- a/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
@@ -513,6 +513,7 @@ public class FastIsochroneMapBuilder implements IsochroneMapBuilder {
         Quadtree qtree = new Quadtree();
 
         int maxNodeId = graphHopperStorage.getNodes();
+        int maxEdgeId = graphHopperStorage.getEdges() - 1;
 
         SPTEntry goalEdge;
 
@@ -548,7 +549,7 @@ public class FastIsochroneMapBuilder implements IsochroneMapBuilder {
             int edgeId = goalEdge.originalEdge;
             int nodeId = goalEdge.adjNode;
 
-            if (edgeId == -1 || nodeId == -1 || nodeId > maxNodeId)
+            if (edgeId == -1 || nodeId == -1 || nodeId > maxNodeId || edgeId > maxEdgeId)
                 continue;
 
             float maxCost = (float) goalEdge.weight;


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.
- [x] 13. For changes touching the API documentation, i have tested that the API playground [renders correctly](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation).

Fixes # .

### Information about the changes
- Key functionality added: Check whether edge is virtual before processing in isochrone geometry. Virtual edges have no geometry -> fails. Was added because one of the last changes added QueryGraph usage for isochrones for fixing another bug.
- Reason for change:

### Examples and reasons for differences between live ORS routes and those generated from this pull request
-

### Required changes to app.config (if applicable)
-
