### PR TITLE
Fix duplicate parameter in centrality docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ RELEASING:
 ### Fixed
 - Rare bug where virtual edges are used to construct geometry of isochrone. Check whether edge is virtual before using it.
 - Clarified "Point not found"-Error message ([#922](https://github.com/GIScience/openrouteservice/issues/922))
+- Duplicate parameter in centrality docs due to spring reading getters for docs
 
 ## [6.5.0] - 2021-05-17
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/api/requests/centrality/CentralityRequest.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/requests/centrality/CentralityRequest.java
@@ -21,7 +21,7 @@ public class CentralityRequest {
     public static final String PARAM_FORMAT = "format";
 
     @ApiModelProperty(name = PARAM_ID, value = "Arbitrary identification string of the request reflected in the meta information.",
-            example = "routing_request")
+            example = "centrality_request")
     @JsonProperty(PARAM_ID)
     private String id;
     @JsonIgnore
@@ -46,7 +46,7 @@ public class CentralityRequest {
     @JsonProperty(PARAM_FORMAT)
     private APIEnums.CentralityResponseType responseType = APIEnums.CentralityResponseType.JSON;
 
-     @ApiModelProperty(name = PARAM_MODE, value = "Specifies the centrality calculation mode. Currently, node-based and edge-based centrality calculation is supported.", example = "nodes")
+    @ApiModelProperty(name = PARAM_MODE, value = "Specifies the centrality calculation mode. Currently, node-based and edge-based centrality calculation is supported.", example = "nodes")
     @JsonProperty(PARAM_MODE)
     private CentralityRequestEnums.Mode mode = CentralityRequestEnums.Mode.NODES;
 
@@ -68,11 +68,11 @@ public class CentralityRequest {
         this.hasId = true;
     }
 
-    public List<List<Double>> getBoundingBox() {
+    public List<List<Double>> getBbox () {
         return bbox;
     }
 
-    public void setBoundingBox(List<List<Double>> bbox ) {
+    public void setBbox(List<List<Double>> bbox ) {
         this.bbox = bbox;
     }
 

--- a/openrouteservice/src/main/java/org/heigit/ors/api/requests/centrality/CentralityRequestHandler.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/requests/centrality/CentralityRequestHandler.java
@@ -45,7 +45,7 @@ public class CentralityRequestHandler extends GenericHandler {
             throw new ParameterValueException(CentralityErrorCodes.INVALID_PARAMETER_VALUE, CentralityRequest.PARAM_PROFILE);
         }
 
-        centralityRequest.setBoundingBox(convertBBox(request.getBoundingBox()));
+        centralityRequest.setBoundingBox(convertBBox(request.getBbox()));
 
         centralityRequest.setMode(request.getMode().toString());
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.
- [x] 13. For changes touching the API documentation, i have tested that the API playground [renders correctly](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation).

The getter and setter for the bbox parameter were named in a way that confused the spring/swagger api-doc generation and lead to a boundingBox parameter showing up in the `swagger.json`-file that is not actually present.
The easiest fix for this is to rename them.
