### PR TITLE
Correct isochrones response documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ RELEASING:
 ### Fixed
 - Rare bug where virtual edges are used to construct geometry of isochrone. Check whether edge is virtual before using it.
 - Clarified "Point not found"-Error message ([#922](https://github.com/GIScience/openrouteservice/issues/922))
+- Correct isochrones response documentation ([#670](https://github.com/GIScience/openrouteservice/issues/670))
 
 ## [6.5.0] - 2021-05-17
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/api/responses/isochrones/IsochronesResponseInfo.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/responses/isochrones/IsochronesResponseInfo.java
@@ -27,7 +27,7 @@ import org.heigit.ors.services.isochrones.IsochronesServiceSettings;
 import org.heigit.ors.util.AppInfo;
 import org.json.JSONObject;
 
-@ApiModel(value = "RouteResponseInfo", description = "Information about the request")
+@ApiModel(value = "IsochronesResponseInfo", description = "Information about the request")
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class IsochronesResponseInfo {
     @ApiModelProperty(value = "ID of the request (as passed in by the query)", example = "request123")
@@ -47,11 +47,11 @@ public class IsochronesResponseInfo {
     @JsonProperty("timestamp")
     private long timeStamp;
 
-    @ApiModelProperty(value = "The information that was used for generating the route")
+    @ApiModelProperty(value = "The information that was used for generating the isochrones")
     @JsonProperty("query")
     private IsochronesRequest request;
 
-    @ApiModelProperty(value = "Information about the routing service")
+    @ApiModelProperty(value = "Information about the isochrones service")
     @JsonProperty("engine")
     private EngineInfo engineInfo;
 
@@ -83,7 +83,7 @@ public class IsochronesResponseInfo {
         engineInfo.setGraphDate(graphDate);
     }
 
-    @ApiModel(description = "Information about the version of the openrouteservice that was used to generate the route")
+    @ApiModel(description = "Information about the version of the openrouteservice that was used to generate the isochrones")
     private class EngineInfo {
         @ApiModelProperty(value = "The backend version of the openrouteservice that was queried", example = "5.0")
         @JsonProperty("version")


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.
- [x] 13. For changes touching the API documentation, i have tested that the API playground [renders correctly](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation).

Fixes #670 