### PR TITLE
Round maneuver location to correct precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ RELEASING:
 ### Added
 - Accept single value and array of length 1 as `radiuses`-parameter ([#923](https://github.com/GIScience/openrouteservice/issues/923))
 - Useful error message for isochrone range/interval mismatches
+### Changed
+- Coordinate precision of locations in `maneuver`-object to 6 decimal places
+
 ### Fixed
 - Rare bug where virtual edges are used to construct geometry of isochrone. Check whether edge is virtual before using it.
 - Clarified "Point not found"-Error message ([#922](https://github.com/GIScience/openrouteservice/issues/922))

--- a/openrouteservice/src/main/java/org/heigit/ors/api/responses/routing/json/JSONStepManeuver.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/responses/routing/json/JSONStepManeuver.java
@@ -21,10 +21,15 @@ import com.vividsolutions.jts.geom.Coordinate;
 import org.heigit.ors.routing.RouteStepManeuver;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.heigit.ors.util.FormatUtility;
 
 @ApiModel(description = "Maneuver object of the step")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class JSONStepManeuver {
+    private static final int COORDINATE_PRECISION = 6;
+    private static final int ELEVATION_DECIMAL_PLACES = 2;
+
+
     @ApiModelProperty(value = "The coordinate of the point where a maneuver takes place.", example = "[8.678962,49.407819]")
     @JsonProperty("location")
     private Double[] location;
@@ -40,12 +45,12 @@ public class JSONStepManeuver {
         if(coordinate != null) {
             if (!Double.isNaN(coordinate.z)) {
                 location = new Double[3];
-                location[2] = coordinate.z;
+                location[2] = FormatUtility.roundToDecimals(coordinate.z, ELEVATION_DECIMAL_PLACES);
             } else {
                 location = new Double[2];
             }
-            location[0] = coordinate.x;
-            location[1] = coordinate.y;
+            location[0] = FormatUtility.roundToDecimals(coordinate.x, COORDINATE_PRECISION);
+            location[1] = FormatUtility.roundToDecimals(coordinate.y, COORDINATE_PRECISION);
         }
 
         bearingAfter = maneuver.getBearingAfter();


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

### Information about the changes
Previously, coordinate precision of `locations` in `maneuvers` was floating point precision, which makes no sense.
They now get rounded to the default 6 decimal places everywhere.