### PR TITLE
Adding BUILD_GRAPHS argument to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV MAVEN_CLI_OPTS="--batch-mode --errors --fail-at-end --show-version -Dinstall
 
 ARG APP_CONFIG=./openrouteservice/src/main/resources/app.config.sample
 ARG OSM_FILE=./openrouteservice/src/main/files/heidelberg.osm.gz
+ARG BUILD_GRAPHS="False"
 
 WORKDIR /ors-core
 


### PR DESCRIPTION
Just defaulting the BUILD_GRAPHS environment variable to False. This is implicit of course since the variable doesn't exist prior and the only test I could find in the codebase was a string comparison at:

https://github.com/GIScience/openrouteservice/blob/90e3f171a26f532576e08469b37170c5e78fe187/docker-entrypoint.sh#L18-L20

This way the variable is set and it is clear from the Dockerfile that it is used without needing to check the documentation. This could save some headscratchers.