### PR TITLE
Initialize edge-centrality-values correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ RELEASING:
 ## [Unreleased]
 ### Fixed
 - made ORSKafkaConsumerInitContextListener non-blocking
-- edgeBetweenness only initializes edges within bbo
+- Initialize edge centrality scores only for edges fully within bbox
 
 ## [6.6.0] - 2021-06-08
 ### Added
@@ -52,7 +52,6 @@ RELEASING:
 - Rare bug where virtual edges are used to construct geometry of isochrone. Check whether edge is virtual before using it.
 - Duplicate parameter in centrality docs due to spring reading getters for docs
 - Bug where supercell subcell ids were out of bounds in storage
-- Correct initialization of edge centrality scores
 
 ## [6.5.0] - 2021-05-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ RELEASING:
 ## [Unreleased]
 ### Fixed
 - made ORSKafkaConsumerInitContextListener non-blocking
+- edgeBetweenness only initializes edges within bbo
 
 ## [6.6.0] - 2021-06-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ RELEASING:
 - Rare bug where virtual edges are used to construct geometry of isochrone. Check whether edge is virtual before using it.
 - Duplicate parameter in centrality docs due to spring reading getters for docs
 - Bug where supercell subcell ids were out of bounds in storage
+- Correct initialization of edge centrality scores
 
 ## [6.5.0] - 2021-05-17
 ### Added

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/centrality/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/centrality/ResultTest.java
@@ -1,0 +1,69 @@
+package org.heigit.ors.v2.services.centrality;
+
+import io.restassured.response.Response;
+import org.heigit.ors.v2.services.common.EndPointAnnotation;
+import org.heigit.ors.v2.services.common.ServiceTest;
+import org.heigit.ors.v2.services.common.VersionAnnotation;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@EndPointAnnotation(name = "centrality")
+@VersionAnnotation(version = "v2")
+public class ResultTest extends ServiceTest {
+
+    public ResultTest() {
+        // set up coordinates for testing later
+        JSONArray lowerLeft = new JSONArray();
+        JSONArray upperRight = new JSONArray();
+        JSONArray additionalComponentCoordinate = new JSONArray();
+        JSONArray missingComponentCoordinate = new JSONArray();
+        lowerLeft.put(8.677139);
+        lowerLeft.put(49.412872);
+        upperRight.put(8.690443);
+        upperRight.put(49.421080);
+        additionalComponentCoordinate.put(8.677139);
+        additionalComponentCoordinate.put(49.395446);
+        additionalComponentCoordinate.put(49.395446);
+        missingComponentCoordinate.put(8.65538);
+
+        // set up valid bounding box encompassing Neuenheim
+        JSONArray neuenheimBBox = new JSONArray();
+        neuenheimBBox.put(lowerLeft);
+        neuenheimBBox.put(upperRight);
+        addParameter("neuenheimBox", neuenheimBBox);
+
+        // set different profiles
+        addParameter("profile", "cycling-regular");
+        addParameter("carProfile", "driving-car");
+        addParameter("footProfile", "foot-walking");
+
+    }
+
+    @Test
+    public void testAllEdgeBetweennessNodeIdsInLocations() {
+        JSONObject body = new JSONObject();
+        body.put("bbox", getParameter("neuenheimBox"));
+        body.put("mode", "edges");
+
+        // edgeBetweenness-initialization also initialized edges whose to-node wasn't contained in the bbox.
+        // this test makes sure that all node ids in edgeScores are also present in locations
+        Response response = given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .post(getEndPointPath() + "/{profile}/json");
+
+        List<Integer> nodeIds = response.jsonPath().getList("locations.nodeId");
+        response.then()
+                .log().ifValidationFails()
+                .body("edgeScores.fromId", everyItem(is(in(nodeIds))))
+                .body("edgeScores.toId", everyItem(is(in(nodeIds))));
+    }
+}

--- a/openrouteservice/src/main/java/org/heigit/ors/centrality/algorithms/brandes/BrandesCentralityAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/centrality/algorithms/brandes/BrandesCentralityAlgorithm.java
@@ -205,7 +205,6 @@ public class BrandesCentralityAlgorithm implements CentralityAlgorithm {
                     int w = iter.getAdjNode(); // this is the node this edge state is "pointing to"
                     if (!nodesInBBox.contains(w)) {
                         // Node not in bbox, skipping edge
-                        System.out.printf("Skipping edge from %d to %d\n", v, w);
                         continue;
                     }
 

--- a/openrouteservice/src/main/java/org/heigit/ors/centrality/algorithms/brandes/BrandesCentralityAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/centrality/algorithms/brandes/BrandesCentralityAlgorithm.java
@@ -147,11 +147,14 @@ public class BrandesCentralityAlgorithm implements CentralityAlgorithm {
         Map<Pair<Integer, Integer>, Double> edgeBetweenness = new HashMap<>();
 
         //initialize betweenness for all edges
-        for (int s : nodesInBBox) {
-            EdgeIterator iter = explorer.setBaseNode(s);
+        for (int from : nodesInBBox) {
+            EdgeIterator iter = explorer.setBaseNode(from);
             while (iter.next()) {
-                Pair<Integer, Integer> p = new Pair<>(iter.getBaseNode(), iter.getAdjNode());
-                edgeBetweenness.put(p, 0d);
+                int to = iter.getAdjNode();
+                if (nodesInBBox.contains(to)) {
+                    Pair<Integer, Integer> p = new Pair<>(from, to);
+                    edgeBetweenness.put(p, 0d);
+                }
             }
         }
 
@@ -202,6 +205,7 @@ public class BrandesCentralityAlgorithm implements CentralityAlgorithm {
                     int w = iter.getAdjNode(); // this is the node this edge state is "pointing to"
                     if (!nodesInBBox.contains(w)) {
                         // Node not in bbox, skipping edge
+                        System.out.printf("Skipping edge from %d to %d\n", v, w);
                         continue;
                     }
 
@@ -240,7 +244,13 @@ public class BrandesCentralityAlgorithm implements CentralityAlgorithm {
                 Double coefficient = (1 + delta.get(w)) / sigma.get(w);
                 for (Integer v : P.get(w)) {
                     delta.merge(v, sigma.get(v) * coefficient, Double::sum);
-                    edgeBetweenness.merge(new Pair<>(v,w), sigma.get(v) * coefficient, Double::sum);
+                    // This is where we write edge betweenness.
+                    // Let's check whether all nodes we enter are in the bbox:
+                    if (nodesInBBox.contains(v) && nodesInBBox.contains(w)) {
+                        edgeBetweenness.merge(new Pair<>(v, w), sigma.get(v) * coefficient, Double::sum);
+                    } else {
+
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [X] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [X] 3. I have documented my code using JDocs tags.
- [X] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [X] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [X] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [X] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [X] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [X] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [X] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [X] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.
- [X] 13. For changes touching the API documentation, i have tested that the API playground [renders correctly](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation).

### Information about the changes
- Key functionality added: correct initialization of edge Scores, test that every node Id present in edge scores is resolvable to a coordinate via locations
