### PR TITLE
Feature/#994 add cors header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ RELEASING:
 ### Added
 - optional `encoder_options` for wheelchair routing: speed factors for ways classified as problematic/preferred ([#980](https://github.com/GIScience/openrouteservice/pull/980))
 - optional routing API parameters `allow_unsuitable` / `surface_quality_known` for wheelchair profile ([#980](https://github.com/GIScience/openrouteservice/pull/980))
-- Docs folder aggregating documentation from openrouteservice-docs, wiki, README.md and docker-subfolder
+- docs folder aggregating documentation from openrouteservice-docs, wiki, README.md and docker-subfolder
+- configurable CORS Header to Responses ([#994](https://github.com/GIScience/openrouteservice/issues/994))
+
 ### Changed
 - Refactored `smoothness-type`-parameter into Enum ([#1007](https://github.com/GIScience/openrouteservice/issues/1007))
 - Improved wheelchair routing ([#980](https://github.com/GIScience/openrouteservice/pull/980))

--- a/openrouteservice-api-tests/conf/app.config.test
+++ b/openrouteservice-api-tests/conf/app.config.test
@@ -6,6 +6,9 @@
       author_tag: "openrouteservice",
       content_licence: "LGPL 3.0"
     },
+    api_settings: {
+      allowed_origins: ["https://test.com", "test2"]
+    },
     services: {
       matrix: {
         enabled: true,

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/apiSettings/CORSHeaderTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/apiSettings/CORSHeaderTest.java
@@ -1,0 +1,64 @@
+/*  This file is part of Openrouteservice.
+ *
+ *  Openrouteservice is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+
+ *  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+
+ *  You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, see <https://www.gnu.org/licenses/>.
+ */
+package org.heigit.ors.v2.services.apiSettings;
+
+import org.heigit.ors.v2.services.common.EndPointAnnotation;
+import org.heigit.ors.v2.services.common.ServiceTest;
+import org.heigit.ors.v2.services.common.VersionAnnotation;
+import org.heigit.ors.v2.services.config.AppConfig;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+
+
+@EndPointAnnotation(name = "status")
+@VersionAnnotation(version = "v2")
+public class CORSHeaderTest extends ServiceTest {
+    List<String> configuredOrigins = AppConfig.Global().getStringList("ors.api_settings.allowed_origins");
+
+    @Test
+    public void testNoOrigin() {
+        given()
+                .get(getEndPointPath())
+                .then().log().ifValidationFails()
+                .assertThat()
+                .statusCode(200);
+    }
+
+    @Test
+    public void testAllowedOrigin() {
+        for (String origin :
+                configuredOrigins) {
+            given()
+                    .header("Origin", origin)
+                    .get(getEndPointPath())
+                    .then().log().ifValidationFails()
+                    .assertThat()
+                    .header("Access-Control-Allow-Origin", origin)
+                    .statusCode(200);
+        }
+    }
+
+    @Test
+    public void testNotAllowedOrigin() {
+        given()
+                .header("Origin", "https://notAllowed.com")
+                .get(getEndPointPath())
+                .then().log().ifValidationFails()
+                .assertThat()
+                .statusCode(403);
+    }
+}

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/config/AppConfig.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/config/AppConfig.java
@@ -19,6 +19,7 @@ import com.typesafe.config.ConfigException.WrongType;
 import org.apache.log4j.Logger;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,6 +100,15 @@ public class AppConfig {
         }
 
         return null;
+    }
+
+    public List<String> getStringList(String path) {
+        try {
+            return _config.getStringList(path);
+        } catch (Exception e) {
+            // IGNORE
+        }
+        return new ArrayList<>();
     }
 
     public List<String> getServiceParametersList(String serviceName, String paramName) {

--- a/openrouteservice/src/main/java/org/heigit/ors/api/ApiConfig.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/ApiConfig.java
@@ -22,11 +22,15 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.heigit.ors.api.converters.APIRequestProfileConverter;
 import org.heigit.ors.api.converters.APIRequestSingleCoordinateConverter;
+import org.heigit.ors.config.AppConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class ApiConfig implements WebMvcConfigurer {
@@ -45,6 +49,18 @@ public class ApiConfig implements WebMvcConfigurer {
         registry.addResourceHandler("/webjars/**")
                 .addResourceLocations("classpath:/META-INF/resources/webjars/");
 
+    }
+
+    /**
+     * Adds Access Control for allowed origins specified in the app.config.
+     * Incoming requests with a different `Origin` header are forbidden.
+     * Default configuration should be * to allow pairing of web applications with local ors instances.
+     */
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        List<String> allowed_origins = AppConfig.getGlobal().getStringList("ors.api_settings.allowed_origins");
+        registry.addMapping("/**")
+                .allowedOrigins(allowed_origins.toArray(new String[0]));
     }
 
     @Bean

--- a/openrouteservice/src/main/java/org/heigit/ors/config/AppConfig.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/config/AppConfig.java
@@ -168,6 +168,15 @@ public class AppConfig {
 		return new ArrayList<>();
 	}
 
+	public List<String> getStringList(String path) {
+		try {
+			return config.getStringList(path);
+		} catch (Exception e) {
+			// IGNORE
+		}
+		return new ArrayList<>();
+	}
+
 	public List<String> getServiceParametersList(String serviceName, String paramName) {
 		try {
 			return config.getStringList(PREFIX_ORS_SERVICES + serviceName + "." + paramName);

--- a/openrouteservice/src/main/resources/app.config.sample
+++ b/openrouteservice/src/main/resources/app.config.sample
@@ -6,6 +6,9 @@
       "author_tag": "openrouteservice",
       "content_licence": "LGPL 3.0"
     },
+    "api_settings": {
+      "allowed_origins": ["*"]
+    },
     "services": {
       "matrix": {
         "enabled": true,


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [ ] ~4. I have removed unnecessary commented out code, imports and System.out.println statements.~
- [ ] ~5. I have written JUnit tests for any new methods/classes and ensured that they pass.~
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] ~10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).~
- [ ] ~11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.~
- [ ] ~12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.~
- [ ] ~13. For changes touching the API documentation, i have tested that the API playground [renders correctly](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation).~

Closes #994

### Information about the changes
- Key functionality added:
  - Add `Access-Control-Allow-Origin` Header to all responses.
  - Allow AppConfig class to read string-lists from the app.config
- Reason for change:
  - CORS issues when pairing web applications with local ors instances

### Required changes to app.config (if applicable)
- not "needed" for production instance, as tyk adds this header with `*` value (allow all origins).
- local instances can add to ors object
```
    "api_settings": {
      "allowed_origins": ["*"]
    },
    "services": {...
```
