### PR TITLE
reduce verbosity of the wheelchair flag encoder

### DIFF
--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/WheelchairFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/WheelchairFlagEncoder.java
@@ -300,7 +300,7 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
     public EncodingManager.Access getAccess(ReaderWay way ) {
     	// check access restrictions
         if (way.hasTag(restrictions, restrictedValues) && !(way.hasTag(restrictions, intendedValues) || way.hasTag(KEY_SIDEWALK, usableSidewalkValues))) {
-            LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "access restrictions", way.getId(), way.getTags().toString()));
+            LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "access restrictions", way.getId(), way.getTags().toString()));
             return EncodingManager.Access.CAN_SKIP;
         }
 
@@ -317,7 +317,7 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
                 	}
                 	// wheelchair=no, restricted, private
                 	if (way.hasTag(KEY_WHEELCHAIR, restrictedValues)) {
-                        LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "no wheelchair ferry", way.getId(), way.getTags().toString()));
+                        LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "no wheelchair ferry", way.getId(), way.getTags().toString()));
                 		return EncodingManager.Access.CAN_SKIP;
                 	}
                 }
@@ -328,7 +328,7 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
                 	}
                 	// foot=no, restricted, private
                 	if (way.hasTag("foot", restrictedValues)) {
-                        LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "no pedestrian ferry", way.getId(), way.getTags().toString()));
+                        LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "no pedestrian ferry", way.getId(), way.getTags().toString()));
                         return EncodingManager.Access.CAN_SKIP;
                 	}
             	}
@@ -346,7 +346,7 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
                 	}
                 	// wheelchair=no, restricted, private
                 	if (way.hasTag(KEY_WHEELCHAIR, restrictedValues)) {
-                        LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "no wheelchair public transport", way.getId(), way.getTags().toString()));
+                        LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "no wheelchair public transport", way.getId(), way.getTags().toString()));
                         return EncodingManager.Access.CAN_SKIP;
                 	}
                 }
@@ -357,14 +357,14 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
                 	}
                 	// foot=no, restricted, private
                 	if (way.hasTag("foot", restrictedValues)) {
-                        LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "no pedestrian public transport", way.getId(), way.getTags().toString()));
+                        LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "no pedestrian public transport", way.getId(), way.getTags().toString()));
                         return EncodingManager.Access.CAN_SKIP;
                 	}
             	}
                 return EncodingManager.Access.WAY;
             }
             // no highway, no ferry, no railway? --> do not accept way
-            LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "no highway, no ferry, no railway", way.getId(), way.getTags().toString()));
+            LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "no highway, no ferry, no railway", way.getId(), way.getTags().toString()));
             return EncodingManager.Access.CAN_SKIP;
         }
         // highway != null
@@ -372,25 +372,25 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
             // http://wiki.openstreetmap.org/wiki/DE:Key:sac_scale
             if (way.hasTag("sac_scale", inaccessibleSacScales)) {
                 // everything except "hiking" is probably not possible for wheelchair user
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "bad sac scale", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "bad sac scale", way.getId(), way.getTags().toString()));
                 return EncodingManager.Access.CAN_SKIP;
             }
 
             if (way.hasTag(KEY_SURFACE, inaccessibleSurfaces)) {
                 // earth, grass, dirt, mud, sand, snow, ice
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "bad surface", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "bad surface", way.getId(), way.getTags().toString()));
                 return EncodingManager.Access.CAN_SKIP;
             }
 
             if (way.hasTag(KEY_SMOOTHNESS, inaccessibleSmoothnesses)) {
                 // bad or worse
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "bad smoothness", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "bad smoothness", way.getId(), way.getTags().toString()));
                 return EncodingManager.Access.CAN_SKIP;
             }
 
             if (way.hasTag(KEY_TRACKTYPE, inaccessibleTracktypes)) {
                 // grade4 and grade5
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "bad tracktype", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "bad tracktype", way.getId(), way.getTags().toString()));
                 return EncodingManager.Access.CAN_SKIP;
             }
 
@@ -400,14 +400,14 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
         	}
         	// wheelchair=no, restricted, private
         	if (way.hasTag(KEY_WHEELCHAIR, restrictedValues)) {
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "wheelchair no, restricted or private", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "wheelchair no, restricted or private", way.getId(), way.getTags().toString()));
         		return EncodingManager.Access.CAN_SKIP;
         	}
         	
         	// do not include nonWheelchairAccessibleHighways
             if (nonWheelchairAccessibleHighways.contains(highwayValue)) {
             	// check for wheelchair accessibility
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "in nonWheelchairAccessibleHighways list", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "in nonWheelchairAccessibleHighways list", way.getId(), way.getTags().toString()));
             	return EncodingManager.Access.CAN_SKIP;
             }
         	
@@ -418,7 +418,7 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
         	
         	// foot=no, restricted, private
         	if (way.hasTag("foot", restrictedValues)) {
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "pedestrian no, restricted or private", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "pedestrian no, restricted or private", way.getId(), way.getTags().toString()));
         		return EncodingManager.Access.CAN_SKIP;
         	}
         	
@@ -427,19 +427,19 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
             }
             
             if (way.hasTag(KEY_SIDEWALK, noSidewalkValues) && assumedWheelchairAccessibleHighways.contains(highwayValue)) {
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "in assumedWheelchairAccessibleHighways list with no sidewalks", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "in assumedWheelchairAccessibleHighways list with no sidewalks", way.getId(), way.getTags().toString()));
                 return EncodingManager.Access.CAN_SKIP;
             }
 
             // explicit motorroads are not usable
             if (way.hasTag("motorroad", "yes")) {
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "motorroad", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "motorroad", way.getId(), way.getTags().toString()));
                 return EncodingManager.Access.CAN_SKIP;
             }
 
             // do not get our feet wet, "yes" is already included above
             if (isBlockFords() && (way.hasTag(KEY_HIGHWAY, "ford") || way.hasTag("ford"))) {
-                LOGGER.debug(String.format(DEBUG_MSG_SKIPPED, "ford", way.getId(), way.getTags().toString()));
+                LOGGER.trace(String.format(DEBUG_MSG_SKIPPED, "ford", way.getId(), way.getTags().toString()));
                 return EncodingManager.Access.CAN_SKIP;
             }
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the [app.config documentation][config] along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.
- [ ] 13. For changes touching the API documentation, i have tested that the API playground [renders correctly][api].

### Information about the changes
- Reason for change:
Reduced the verbosity of the debug output of class `WheelchairFlagEncoder`, since they are only needed in rare cases when debugging the actual graph building process in terms of which OSM ways are not taken into the graph and why. Replaced debug() with trace(), so they can be reactivated by setting logging level to `ALL`. 