### PR TITLE
fix missing profile in isochrones request

### DIFF
--- a/openrouteservice-api-tests/conf/ors-config-test.json
+++ b/openrouteservice-api-tests/conf/ors-config-test.json
@@ -16,6 +16,7 @@
       },
       "isochrones": {
         "enabled": true,
+        "attribution": "openrouteservice.org, OpenStreetMap contributors, tmc - BASt",
         "maximum_range_distance": [
           {
             "profiles": "any",

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/ResultTest.java
@@ -444,7 +444,7 @@ public class ResultTest extends ServiceTest {
     }
 
     @Test
-    public void testIdInSummary() {
+    public void testCompleteMetadata() {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
         body.put("range", getParameter("ranges_400"));
@@ -462,6 +462,24 @@ public class ResultTest extends ServiceTest {
                 .body("any {it.key == 'metadata'}", is(true))
                 .body("metadata.containsKey('id')", is(true))
                 .body("metadata.id", is("request123"))
+                .body("metadata.containsKey('attribution')", is(true))
+                .body("metadata.service", is("isochrones"))
+                .body("metadata.containsKey('timestamp')", is(true))
+                .body("metadata.containsKey('query')", is(true))
+                .body("metadata.query.id", is("request123"))
+                .body("metadata.query.containsKey('locations')", is(true))
+                .body("metadata.query.locations.size()", is(1))
+                .body("metadata.query.locations[0][0]", is(8.684177f))
+                .body("metadata.query.locations[0][1]", is(49.423034f))
+                .body("metadata.query.containsKey('range')", is(true))
+                .body("metadata.query.range.size()", is(1))
+                .body("metadata.query.range[0]", is(400.0f))
+                .body("metadata.query.profile", is("cycling-regular"))
+                .body("metadata.query.id", is("request123"))
+                .body("metadata.engine.containsKey('version')", is(true))
+                .body("metadata.engine.containsKey('build_date')", is(true))
+                .body("metadata.engine.containsKey('graph_date')", is(true))
+                .body("metadata.containsKey('system_message')", is(true))
                 .statusCode(200);
     }
 }

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -714,6 +714,44 @@ public class ResultTest extends ServiceTest {
     }
 
     @Test
+    public void testCompleteMetadata() {
+        JSONObject body = new JSONObject();
+        body.put("coordinates", getParameter("coordinatesShort"));
+        body.put("id", "request123");
+
+        given()
+                .header("Accept", "application/geo+json")
+                .header("Content-Type", "application/json")
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .assertThat()
+                .body("any {it.key == 'metadata'}", is(true))
+                .body("metadata.containsKey('id')", is(true))
+                .body("metadata.id", is("request123"))
+                .body("metadata.containsKey('attribution')", is(true))
+                .body("metadata.service", is("routing"))
+                .body("metadata.containsKey('timestamp')", is(true))
+                .body("metadata.containsKey('query')", is(true))
+                .body("metadata.query.id", is("request123"))
+                .body("metadata.query.containsKey('coordinates')", is(true))
+                .body("metadata.query.coordinates.size()", is(2))
+                .body("metadata.query.coordinates[0][0]", is(8.678613f))
+                .body("metadata.query.coordinates[0][1]", is(49.411721f))
+                .body("metadata.query.coordinates[1][0]", is(8.687782f))
+                .body("metadata.query.coordinates[1][1]", is(49.424597f))
+                .body("metadata.query.profile", is("driving-car"))
+                .body("metadata.query.id", is("request123"))
+                .body("metadata.engine.containsKey('version')", is(true))
+                .body("metadata.engine.containsKey('build_date')", is(true))
+                .body("metadata.engine.containsKey('graph_date')", is(true))
+                .body("metadata.containsKey('system_message')", is(true))
+                .statusCode(200);
+    }
+
+    @Test
     public void expectSegmentsToMatchCoordinates() {
         JSONObject body = new JSONObject();
         body.put("coordinates", getParameter("coordinatesLong"));

--- a/openrouteservice/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
@@ -95,7 +95,6 @@ public class IsochronesRequest {
     private boolean hasRangeUnits = false;
 
     @ApiModelProperty(name = PARAM_PROFILE, hidden = true, required = true)
-    @JsonIgnore
     private APIEnums.Profile profile;
 
     @ApiModelProperty(name = PARAM_OPTIONS,


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1024  .

### Information about the changes
- Key functionality added: The isochrones results now return the profile. The api tests now test for metadata completeness.
- Reason for change: The isochrones requests metadata were missing the used profile information.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
- The test config needed attribution in the config file to allow for valid testing.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
