### PR TITLE
Check for virtual node before querying node's level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ RELEASING:
 - `ORS_APP_CONF` environment variable ([#1017](https://github.com/GIScience/openrouteservice/issues/1017))
 ### Fixed
 - Errors in travel speed explanation
+- Failing assertion with CALT routing ([#1047](https://github.com/GIScience/openrouteservice/issues/1047))
 
 ## [6.6.1] - 2021-07-05
 ### Fixed

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/AbstractCoreRoutingAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/AbstractCoreRoutingAlgorithm.java
@@ -60,7 +60,8 @@ public abstract class AbstractCoreRoutingAlgorithm extends AbstractRoutingAlgori
         int size = Math.min(2000, Math.max(200, graph.getNodes() / 10));
         initCollections(size);
 
-        chGraph = (CHGraph) ((QueryGraph) graph).getMainGraph();
+        qGraph = (QueryGraph) graph;
+        chGraph = (CHGraph) qGraph.getMainGraph();
         coreNodeLevel = chGraph.getNodes() + 1;
         turnRestrictedNodeLevel = coreNodeLevel + 1;
     }
@@ -68,6 +69,7 @@ public abstract class AbstractCoreRoutingAlgorithm extends AbstractRoutingAlgori
     protected abstract void initCollections(int size);
     protected PathBidirRef bestPath;
 
+    QueryGraph qGraph;
     CHGraph chGraph;
     protected final int coreNodeLevel;
     protected final int turnRestrictedNodeLevel;
@@ -200,7 +202,7 @@ public abstract class AbstractCoreRoutingAlgorithm extends AbstractRoutingAlgori
     }
 
     boolean isCoreNode(int node) {
-        return chGraph.getLevel(node) >= coreNodeLevel;
+        return !qGraph.isVirtualNode(node) && chGraph.getLevel(node) >= coreNodeLevel;
     }
 
     boolean isTurnRestrictedNode(int node) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box when you have checked you have done them): -->
- [x] 1. I have [**rebased**](https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines) the latest version of the master branch into my feature branch and all conflicts have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the app.config file, I have added these to the app.config wiki page on github along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset (at least Germany) and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the importer etc.), I have generated longer distance routes for the affected profiles with different options (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end points generated from the current live ORS. If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage and why the change was needed.

Fixes #1047.

### Information about the changes

In case a given node is a virtual node `AbstractCoreRoutingAlgorithm.isCoreNode()` method returns `false` and does not attempt to query for node's level.

