### PR TITLE
Changing BUILD_GRAPHS to ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV MAVEN_CLI_OPTS="--batch-mode --errors --fail-at-end --show-version -Dinstall
 
 ARG ORS_CONFIG=./openrouteservice/src/main/resources/ors-config-sample.json
 ARG OSM_FILE=./openrouteservice/src/main/files/heidelberg.osm.gz
-ARG BUILD_GRAPHS="False"
+ENV BUILD_GRAPHS="False"
 ARG UID=1000
 ARG TOMCAT_VERSION=8.5.69
 


### PR DESCRIPTION
Based on comments in #967 , looking to change BUILD_GRAPHS to an environment variable instead of a build argument. This way someone can set the environment variable at container start and it will clear the graph dir. With `ARG` this would, theoretically, only remove the graphs when they don't exist if this build directory is empty at build time.

Kudos to @joker234 for the suggestion.