### PR TITLE
`sett` as default minimum wheelchair surface type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ RELEASING:
 - Formatting of tag filtering
 - test config format and filetype to JSON
 - docker `APP_CONFIG` argument to `ORS_CONFIG` ([#1017](https://github.com/GIScience/openrouteservice/issues/1017))
+- default minimum `surface-type` for wheelchair to `sett` ([#1059](https://github.com/GIScience/openrouteservice/issues/1059))
 ### Deprecated
 - `ors_app_config` system property ([#1017](https://github.com/GIScience/openrouteservice/issues/1017))
 - `app.config` ors configuration file name ([#1017](https://github.com/GIScience/openrouteservice/issues/1017))

--- a/openrouteservice/src/main/java/org/heigit/ors/api/requests/routing/RequestProfileParamsRestrictions.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/requests/routing/RequestProfileParamsRestrictions.java
@@ -80,8 +80,8 @@ public class RequestProfileParamsRestrictions {
     @JsonIgnore
     private boolean hasHazardousMaterial = false;
 
-    @ApiModelProperty(name = PARAM_SURFACE_TYPE, value = "Specifies the minimum surface type. Default is `cobblestone:flattened`. " +
-            "CUSTOM_KEYS:{'apiDefault':'cobblestone:flattened','validWhen':{'ref':'profile','value':['wheelchair']}}",
+    @ApiModelProperty(name = PARAM_SURFACE_TYPE, value = "Specifies the minimum surface type. Default is `sett`. " +
+            "CUSTOM_KEYS:{'apiDefault':'sett','validWhen':{'ref':'profile','value':['wheelchair']}}",
             example = "asphalt")
     @JsonProperty(PARAM_SURFACE_TYPE)
     private String surfaceType;


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] ~3. I have documented my code using JDocs tags.~
- [ ] ~4. I have removed unnecessary commented out code, imports and System.out.println statements.~
- [ ] ~5. I have written JUnit tests for any new methods/classes and ensured that they pass.~
- [ ] ~6. I have created API tests for any new functionality exposed to the API.~
- [ ] ~7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).~
- [ ] ~8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing~
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] ~10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).~
- [ ] ~11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.~
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1059 .

### Information about the changes
The osm wiki denotes the previous default of `cobblestone:flattened` as
not to use. All three of `sett`, `unhewn_cobblestone` and
`cobblestone:flattened` are encoded as the same value, so no changes to
the codebase are required, it is only a matter of correct documentation.

Since `sett` is way more prevalent, it will be used as the default.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
