### PR TITLE
Fix IsochronesRequest swagger entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ RELEASING:
 - backend documentation about encoded polylines without elevation data ([#1094](https://github.com/GIScience/openrouteservice/issues/1094))
 - python code on decoding polylines including elevation data
 
+### Fixed
+- internal properties of `IsochronesRequest` model not ignored for swagger file generation 
+
 ## [6.7.0] - 2022-01-04
 ### Added
 - add core matrix algorithm

--- a/openrouteservice/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
@@ -173,7 +173,9 @@ public class IsochronesRequest extends APIRequest {
     @JsonIgnore
     private boolean hasTime = false;
 
+    @JsonIgnore
     private IsochroneMapCollection isoMaps;
+    @JsonIgnore
     private IsochroneRequest isochroneRequest;
 
     @JsonCreator


### PR DESCRIPTION
the internal 'isoMaps' and 'isochroneRequest' properties were
not ignored during generation of the API docs.
This led to a circular dependency, impossible to resolve during
preparation of the swagger file for the API playground.
Introduced in https://github.com/GIScience/openrouteservice/pull/1086

The above properties are now ignored.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes the broken swagger specs, so the API playground renders correctly.

### Information about the changes
- Reason for change: swagger specs leaked internal classes

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
