### PR TITLE
remove non-parameter `metricsStrings` from API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ RELEASING:
 ### Fixed
 - improved log file settings error message ([#1110](https://github.com/GIScience/openrouteservice/issues/1110)) 
 - Dockerfile now creates intermediate directories if they are not present ([#1109](https://github.com/GIScience/openrouteservice/issues/1109))
-- internal properties of `IsochronesRequest` model not ignored for swagger file generation 
+- internal properties of `IsochronesRequest` model not ignored for swagger file generation
+- remove non-parameter `metricsStrings` from API documentation ([#756](https://github.com/GIScience/openrouteservice/issues/756))
 
 ## [6.7.0] - 2022-01-04
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
@@ -173,6 +173,7 @@ public class MatrixRequest extends APIRequest {
         return metrics;
     }
 
+    @JsonIgnore
     public Set<String> getMetricsStrings() {
         Set<String> ret = new HashSet<>();
         if (metrics != null) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #756 .

### Information about the changes
The `metricsStrings`-parameter from the matrix API showed up since the annotated Getter existed.
Other possibilities would be to move the method to another class, to rename it to something not starting with `get` or maybe to change the `@JsonInclude()`-directive at the top of the file

I am not sure, which way the right one to go would be. The road I took seems to fix the issue though.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
