### PR TITLE
Parse incline tag "down" as decline

### DIFF
--- a/openrouteservice/src/main/java/org/heigit/ors/util/UnitsConverter.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/util/UnitsConverter.java
@@ -185,7 +185,7 @@ public class UnitsConverter {
 
                 // Replace textual descriptions with assumed values
                 unprocessedInclineValue = unprocessedInclineValue.replace("up", "10");
-                unprocessedInclineValue = unprocessedInclineValue.replace("down", "10");
+                unprocessedInclineValue = unprocessedInclineValue.replace("down", "-10");
                 unprocessedInclineValue = unprocessedInclineValue.replace("yes", "10");
                 unprocessedInclineValue = unprocessedInclineValue.replace("steep", "15");
                 unprocessedInclineValue = unprocessedInclineValue.replace("no", "0");


### PR DESCRIPTION
This is related to #1165.
As stated there, this change seems to be correct, yet it will not have any effect on the existing behavior.
For completeness, I'd still like to see this merged.

Once that is done, I will change the corresponding issue to track the underlying idea of differentiating between `maximum_incline` and `maximum_decline` in the wheelchair profile and put it on hold.

Is an entry to the changelog neccessary, and if so, what should it look like?
