### PR TITLE
Bugfix/#1177 waterway lock gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ RELEASING:
 - set default vehicle type for HGV profile ([#816](https://github.com/GIScience/openrouteservice/issues/816))
 - added missing matchTraffic override ([#1133](https://github.com/GIScience/openrouteservice/issues/1133))
 - typo in docker documentation
+- foot routing via `waterway=lock_gate` ([#1177](https://github.com/GIScience/openrouteservice/issues/1177))
 
 ## [6.7.0] - 2022-01-04
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/OSMTags.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/OSMTags.java
@@ -32,5 +32,6 @@ public class OSMTags {
         public static final String MAN_MADE = "man_made";
         public static final String TUNNEL = "tunnel";
         public static final String BICYCLE = "bicycle";
+        public static final String WATERWAY = "waterway";
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/FootFlagEncoder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/FootFlagEncoder.java
@@ -306,6 +306,15 @@ public abstract class FootFlagEncoder extends ORSAbstractFlagEncoder {
         if (way.hasTag(OSMTags.Keys.MAN_MADE, "pier"))
             acceptPotentially = EncodingManager.Access.WAY;
 
+
+        // only route via lock_gate if foot-tag allows for it.
+        if (way.hasTag(OSMTags.Keys.WATERWAY, "lock_gate")) {
+            if (way.hasTag(OSMTags.Keys.FOOT, intendedValues)) {
+                acceptPotentially = EncodingManager.Access.WAY;
+            }
+        }
+
+
         if (!acceptPotentially.canSkip()) {
             if (way.hasTag(restrictions, restrictedValues) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
                 return EncodingManager.Access.CAN_SKIP;

--- a/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoderTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoderTest.java
@@ -336,4 +336,27 @@ public class PedestrianFlagEncoderTest {
 //        assertTrue(throwsError);
     }
 
+    @Test
+    public void acceptLockGateFootAllowed() {
+        way.setTag("waterway", "lock_gate");
+        way.setTag("foot", "yes");
+
+        assertTrue(flagEncoder.getAccess(way).isWay());
+    }
+
+    @Test
+    public void rejectLockGateFootAccessMissing() {
+        way.setTag("waterway", "lock_gate");
+
+        assertTrue(flagEncoder.getAccess(way).canSkip());
+    }
+
+    @Test
+    public void rejectLockGateFootForbidden() {
+        way.setTag("waterway", "lock_gate");
+        way.setTag("foot", "no");
+
+        assertTrue(flagEncoder.getAccess(way).canSkip());
+    }
+
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- ~[ ] 3. I have documented my code using JDocs tags.~
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- ~[ ] 6. I have created API tests for any new functionality exposed to the API.~
- ~[ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).~
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- ~[ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).~
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- ~[ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].~

Fixes #1177 .

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
