### PR TITLE
Access values in hgv storage as bytes rather than shorts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ RELEASING:
 - added missing matchTraffic override ([#1133](https://github.com/GIScience/openrouteservice/issues/1133))
 - typo in docker documentation
 - foot routing via `waterway=lock_gate` ([#1177](https://github.com/GIScience/openrouteservice/issues/1177))
+- address data alignment issue in hgv extended storage which occasionally caused `ArrayIndexOutOfBoundsException` ([#1181](https://github.com/GIScience/openrouteservice/issues/1181))
 
 ## [6.7.0] - 2022-01-04
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
@@ -17,6 +17,7 @@ import com.graphhopper.storage.DataAccess;
 import com.graphhopper.storage.Directory;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphExtension;
+import com.graphhopper.util.BitUtil;
 import org.heigit.ors.routing.graphhopper.extensions.VehicleDimensionRestrictions;
 
 public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
@@ -32,6 +33,8 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
 	protected int edgesCount;
 
 	private static final double FACTOR = 100.0;
+
+	private final byte[] buffer = new byte[2];
 
 	public HeavyVehicleAttributesGraphStorage(boolean includeRestrictions) {
 		efVehicleType = nextBlockEntryIndex(1);
@@ -113,7 +116,8 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
 
 		for (int i = 0; i < VehicleDimensionRestrictions.COUNT; i++) {
 			short shortValue = (short) (restrictionValues[i] * FACTOR);
-			orsEdges.setShort(edgePointer + efRestrictions + i * EF_RESTRICTION_BYTES, shortValue);
+			BitUtil.LITTLE.fromShort(buffer, shortValue);
+			orsEdges.setBytes(edgePointer + efRestrictions + i * EF_RESTRICTION_BYTES, buffer, 2);
 		}
 	}
 
@@ -123,7 +127,7 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
 		if (efRestrictions == -1)
 			throw new IllegalStateException(MSG_EF_RESTRICTION_IS_NOT_SUPPORTED);
 
-		return orsEdges.getShort(edgeBase + efRestrictions + valueIndex * EF_RESTRICTION_BYTES) / FACTOR;
+		return getShort(edgeBase + efRestrictions + valueIndex * EF_RESTRICTION_BYTES) / FACTOR;
 	}
 
 	public boolean getEdgeRestrictionValues(int edgeId, double[] retValues) {
@@ -133,9 +137,14 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
 			throw new IllegalStateException(MSG_EF_RESTRICTION_IS_NOT_SUPPORTED);
 
 		for (int i = 0; i < VehicleDimensionRestrictions.COUNT; i++)
-			retValues[i] = orsEdges.getShort(edgeBase + efRestrictions + i * EF_RESTRICTION_BYTES) / FACTOR;
+			retValues[i] = getShort(edgeBase + efRestrictions + i * EF_RESTRICTION_BYTES) / FACTOR;
 
 		return true;
+	}
+
+	private short getShort(long bytePos) {
+		orsEdges.getBytes(bytePos, buffer, 2);
+		return BitUtil.LITTLE.toShort(buffer);
 	}
 
 	public int getEdgeVehicleType(int edgeId, byte[] buffer) {
@@ -160,7 +169,7 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
 
 		if (efRestrictions > 0)
 			for (int i = 0; i < VehicleDimensionRestrictions.COUNT; i++)
-				if (orsEdges.getShort(edgeBase + efRestrictions + i * EF_RESTRICTION_BYTES) != 0)
+				if (getShort(edgeBase + efRestrictions + i * EF_RESTRICTION_BYTES) != 0)
 					return true;
 
 		return false;


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1181.

### Information about the changes

This addresses a memory alignment issue in HGV extended storage which occasionally caused  `ArrayIndexOutOfBoundsException`. The problem originated from the fact that HGV storage entries are 11 bytes long. As this length is not a multiple of 2 it can happen that the two bytes constituting a short value get distributed over two different byte array segments. However, unlike the byte-reading/writing methods the methods to directly access shorts do not allow them to be split between segments.