### PR TITLE
Fix open spaces graph builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ RELEASING:
 - added missing matchTraffic override ([#1133](https://github.com/GIScience/openrouteservice/issues/1133))
 - typo in docker documentation
 - foot routing via `waterway=lock_gate` ([#1177](https://github.com/GIScience/openrouteservice/issues/1177))
+- graph builder for routing over open areas ([#1186](https://github.com/GIScience/openrouteservice/issues/1186))
 
 ## [6.7.0] - 2022-01-04
 ### Added

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -411,19 +411,19 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>v0.13.21</version>
+            <version>v0.13.22</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-reader-osm</artifactId>
-            <version>v0.13.21</version>
+            <version>v0.13.22</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-api</artifactId>
-            <version>v0.13.21</version>
+            <version>v0.13.22</version>
         </dependency>
 
         <!-- remove the comment to enable debugging

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -411,19 +411,19 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>v0.13.22</version>
+            <version>v0.13.22-1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-reader-osm</artifactId>
-            <version>v0.13.22</version>
+            <version>v0.13.22-1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-api</artifactId>
-            <version>v0.13.22</version>
+            <version>v0.13.22-1</version>
         </dependency>
 
         <!-- remove the comment to enable debugging

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -411,19 +411,19 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>v0.13.22-1</version>
+            <version>v0.13.22-3</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-reader-osm</artifactId>
-            <version>v0.13.22-1</version>
+            <version>v0.13.22-3</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-api</artifactId>
-            <version>v0.13.22-1</version>
+            <version>v0.13.22-3</version>
         </dependency>
 
         <!-- remove the comment to enable debugging

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/OSMDataReaderContext.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/OSMDataReaderContext.java
@@ -19,7 +19,6 @@ import com.graphhopper.reader.osm.OSMReader;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 public class OSMDataReaderContext implements DataReaderContext {
@@ -37,16 +36,16 @@ public class OSMDataReaderContext implements DataReaderContext {
 
 	@Override
 	public double getNodeLongitude(int nodeId) {
-		return 0;
+		return osmReader.getTmpLongitude(nodeId);
 	}
 
 	@Override
 	public double getNodeLatitude(int nodeId) {
-		return 0;
+		return osmReader.getTmpLatitude(nodeId);
 	}
 
 	@Override
 	public Collection<EdgeIteratorState> addWay(LongIndexedContainer subgraphNodes, IntsRef wayFlags, long wayId) {
-		return new ArrayList<>();
+		return osmReader.addOSMWay(subgraphNodes, wayFlags, wayId);
 	}
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/graphbuilders/InFieldGraphBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/graphbuilders/InFieldGraphBuilder.java
@@ -94,9 +94,9 @@ public class InFieldGraphBuilder extends AbstractGraphBuilder {
 				double latMain = readerCntx.getNodeLatitude(internalMainId);
 				double lonMain = readerCntx.getNodeLongitude(internalMainId);
 				// connect the boundary of the open space
-				long neighborOsmId = osmNodeIds.get(idxMain + 1);
-				int internalNeighborId = nodeMap.get(neighborOsmId);
 				int idxNeighbor = idxMain + 1;
+				long neighborOsmId = osmNodeIds.get(idxNeighbor);
+				int internalNeighborId = nodeMap.get(neighborOsmId);
 				double latNeighbor = readerCntx.getNodeLatitude(internalNeighborId);
 				double lonNeighbor = readerCntx.getNodeLongitude(internalNeighborId);
 				double distance = distCalc.calcDist(latMain, lonMain, latNeighbor, lonNeighbor);
@@ -108,7 +108,7 @@ public class InFieldGraphBuilder extends AbstractGraphBuilder {
 					int internalPartnerId = nodeMap.get(partnerOsmId);
 					// coordinates of second nodes
 					double latPartner = readerCntx.getNodeLatitude(internalPartnerId);
-					double lonPartner = readerCntx.getNodeLatitude(internalPartnerId);
+					double lonPartner = readerCntx.getNodeLongitude(internalPartnerId);
 					// connect nodes
 					LineString ls = geometryFactory.createLineString(new Coordinate[]{new Coordinate(lonMain, latMain), new Coordinate(lonPartner, latPartner)});
 					// check if new edge is within open space


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1186.

**IMPORTANT**: This PR is set-up to run against GH v0.13.22 which is expected to include https://github.com/GIScience/graphhopper/pull/50.

### Information about the changes
- Allows enabling of a specialized graph builder which generates additional edges in open spaces.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
- See examples in the [blogpost](http://k1z.blog.uni-heidelberg.de/2017/11/27/routing-through-open-spaces-%e2%80%93-a-performance-comparison-of-algorithms/).

### Required changes to ors config (if applicable)

In order to enable the additional graph processor add the following to a given profile definition.

```
"graph_processors": {
    "InField": {}
}
```

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
