### PR TITLE
Proper handling of virtual edges in RPHAST downward search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ RELEASING:
 - graph builder for routing over open areas ([#1186](https://github.com/GIScience/openrouteservice/issues/1186))
 - address data alignment issue in hgv extended storage which occasionally caused `ArrayIndexOutOfBoundsException` ([#1181](https://github.com/GIScience/openrouteservice/issues/1181))
 - fix minor spelling errors in Places.md ([#1196](https://github.com/GIScience/openrouteservice/issues/1196))
+- address matrix failures for HGV profile ([#1198](https://github.com/GIScience/openrouteservice/issues/1198))
 
 ## [6.7.0] - 2022-01-04
 ### Added

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
@@ -25,6 +25,7 @@ import com.graphhopper.storage.CHGraph;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.EdgeIteratorState;
 
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.ch.DownwardSearchEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.ch.UpwardSearchEdgeFilter;
@@ -285,7 +286,7 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
 			return;
 
 		while (iter.next()) {
-			edgeWeight = weighting.calcWeight(iter, false, 0);
+			edgeWeight = calcEdgeWeight(iter);
 
 			if (!Double.isInfinite(edgeWeight)) {
 				MultiTreeSPEntry ee = shortestWeightMap.get(iter.getAdjNode());
@@ -340,5 +341,12 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
 				}
 			}
 		}
+	}
+
+	private double calcEdgeWeight(EdgeIteratorState iter) {
+		if (iter instanceof SubGraph.EdgeIteratorLinkIterator)
+			iter = ((SubGraph.EdgeIteratorLinkIterator) iter).getCurrState();
+
+		return weighting.calcWeight(iter, false, 0);
 	}
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1198.

### Information about the changes
Use the edge iterator state extracted from the subgraph edge iterator for computing edge weight during RPHAST downwards search in order to be able to resolve original edge IDs in case of virtual edges. This is necessary e.g. for the HgvAccessWeighting to be able to reliably query the HGV storage.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
