### PR TITLE
refactor(test): Add common headers

### DIFF
--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/centrality/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/centrality/ParamsTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.jsonContent;
 
 @EndPointAnnotation(name = "centrality")
 @VersionAnnotation(version = "v2")
@@ -85,8 +86,7 @@ public class ParamsTest extends ServiceTest {
         body.put("bbox", getParameter("neuenheimBox"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -107,8 +107,7 @@ public class ParamsTest extends ServiceTest {
         // Since node IDs are not consistent over graph builds, they cannot be specified beforehand,
         // but have to be taken from a valid response
         List<Integer> nodeIds =  given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .post(getEndPointPath()+"/{profile}/json")
@@ -128,8 +127,7 @@ public class ParamsTest extends ServiceTest {
         body.put("excludeNodes", excludeNodes);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -151,8 +149,7 @@ public class ParamsTest extends ServiceTest {
         body.put("excludeNodes", getParameter("invalidNodes"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -170,8 +167,7 @@ public class ParamsTest extends ServiceTest {
         body.put("bbox", getParameter("missingCoordinatesBox"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -184,8 +180,7 @@ public class ParamsTest extends ServiceTest {
 
         body.put("bbox", getParameter("additionalCoordinatesBox"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -203,8 +198,7 @@ public class ParamsTest extends ServiceTest {
         body.put("bbox", getParameter("missingComponentCoordinateBox"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -217,8 +211,7 @@ public class ParamsTest extends ServiceTest {
 
         body.put("bbox", getParameter("additionalComponentCoordinateBox"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -236,8 +229,7 @@ public class ParamsTest extends ServiceTest {
         body.put("bbox", getParameter("emptyBox"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -258,8 +250,7 @@ public class ParamsTest extends ServiceTest {
         body.put("mode", "edges");
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -280,8 +271,7 @@ public class ParamsTest extends ServiceTest {
         body.put("mode", "nodes");
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -302,8 +292,7 @@ public class ParamsTest extends ServiceTest {
         body.put("mode", "wrongMode");
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/centrality/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/centrality/ResultTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.jsonContent;
 
 @EndPointAnnotation(name = "centrality")
 @VersionAnnotation(version = "v2")
@@ -54,8 +55,7 @@ public class ResultTest extends ServiceTest {
         // edgeBetweenness-initialization also initialized edges whose to-node wasn't contained in the bbox.
         // this test makes sure that all node ids in edgeScores are also present in locations
         Response response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .post(getEndPointPath() + "/{profile}/json");

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/ParamsTest.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.geoJsonContent;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.jsonContent;
 
 @EndPointAnnotation(name = "isochrones")
 @VersionAnnotation(version = "v2")
@@ -99,8 +101,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range", getParameter("ranges_2"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -118,8 +119,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations_2"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -137,8 +137,7 @@ public class ParamsTest extends ServiceTest {
         body.put("rangeee", getParameter("ranges_2"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -159,8 +158,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range", rangesFaulty);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -181,8 +179,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start123123");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -203,8 +200,7 @@ public class ParamsTest extends ServiceTest {
         body.put("interval", getParameter("interval_100"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -225,8 +221,7 @@ public class ParamsTest extends ServiceTest {
         body.put("interval", getParameter("interval_100"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -248,8 +243,7 @@ public class ParamsTest extends ServiceTest {
         body.put("units", "mfff");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -270,8 +264,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "blah");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -290,8 +283,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "blah");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -313,8 +305,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorAreaFaulty"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -327,8 +318,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", new JSONArray(Arrays.asList("blah", "reachfactor")));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -353,8 +343,7 @@ public class ParamsTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -378,8 +367,7 @@ public class ParamsTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -398,8 +386,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "time");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -410,8 +397,7 @@ public class ParamsTest extends ServiceTest {
                 .statusCode(406);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -433,8 +419,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "destination");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -454,8 +439,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -476,8 +460,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -499,8 +482,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -523,8 +505,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -549,8 +530,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "destination");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -577,8 +557,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "destination");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -599,8 +578,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "time");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -623,8 +601,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "distance");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -647,8 +624,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorArea"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -674,8 +650,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorAreaFaulty"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -699,8 +674,7 @@ public class ParamsTest extends ServiceTest {
         body.put("smoothing", "50");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -724,8 +698,7 @@ public class ParamsTest extends ServiceTest {
 
         // ten, 101, -1
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -737,8 +710,7 @@ public class ParamsTest extends ServiceTest {
         body.put("smoothing", "-1");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -750,8 +722,7 @@ public class ParamsTest extends ServiceTest {
         body.put("smoothing", "101");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/ResultTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.geoJsonContent;
 
 @EndPointAnnotation(name = "isochrones")
 @VersionAnnotation(version = "v2")
@@ -108,8 +109,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -137,8 +137,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -161,8 +160,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -181,8 +179,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -213,8 +210,7 @@ public class ResultTest extends ServiceTest {
         body.put("range_type", "time");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -225,8 +221,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("location_type", "destination");
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -245,8 +240,7 @@ public class ResultTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorArea"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -270,8 +264,7 @@ public class ResultTest extends ServiceTest {
         body.put("area_units", getParameter("m"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -295,8 +288,7 @@ public class ResultTest extends ServiceTest {
         body.put("area_units", "km");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -322,8 +314,7 @@ public class ResultTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorArea"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -346,8 +337,7 @@ public class ResultTest extends ServiceTest {
         body.put("area_units", "mi");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -371,8 +361,7 @@ public class ResultTest extends ServiceTest {
         body.put("intersections", "true");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -411,8 +400,7 @@ public class ResultTest extends ServiceTest {
 
 
         int lowSmoothingCoordinatesSize = given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -425,8 +413,7 @@ public class ResultTest extends ServiceTest {
         body.put("smoothing", "100");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -446,8 +433,7 @@ public class ResultTest extends ServiceTest {
         body.put("id", "request123");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/fast/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/fast/ParamsTest.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.geoJsonContent;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.jsonContent;
 
 @EndPointAnnotation(name = "isochrones")
 @VersionAnnotation(version = "v2")
@@ -99,8 +101,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range", getParameter("ranges_2"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -118,8 +119,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations_2"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -137,8 +137,7 @@ public class ParamsTest extends ServiceTest {
         body.put("rangeee", getParameter("ranges_2"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -159,8 +158,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range", rangesFaulty);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -181,8 +179,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start123123");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -203,8 +200,7 @@ public class ParamsTest extends ServiceTest {
         body.put("interval", getParameter("interval_100"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -225,8 +221,7 @@ public class ParamsTest extends ServiceTest {
         body.put("interval", getParameter("interval_100"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -248,8 +243,7 @@ public class ParamsTest extends ServiceTest {
         body.put("units", "mfff");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -270,8 +264,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "blah");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -290,8 +283,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "blah");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -313,8 +305,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorAreaFaulty"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -327,8 +318,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", new JSONArray(Arrays.asList("blah", "reachfactor")));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -353,8 +343,7 @@ public class ParamsTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -378,8 +367,7 @@ public class ParamsTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -398,8 +386,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "time");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -410,8 +397,7 @@ public class ParamsTest extends ServiceTest {
                 .statusCode(406);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -433,8 +419,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "destination");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -454,8 +439,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -476,8 +460,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -499,8 +482,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -523,8 +505,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "start");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -549,8 +530,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "destination");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -577,8 +557,7 @@ public class ParamsTest extends ServiceTest {
         body.put("location_type", "destination");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -599,8 +578,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "time");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -623,8 +601,7 @@ public class ParamsTest extends ServiceTest {
         body.put("range_type", "distance");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -647,8 +624,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorArea"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -674,8 +650,7 @@ public class ParamsTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorAreaFaulty"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -699,8 +674,7 @@ public class ParamsTest extends ServiceTest {
         body.put("smoothing", "50");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -724,8 +698,7 @@ public class ParamsTest extends ServiceTest {
 
         // ten, 101, -1
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -737,8 +710,7 @@ public class ParamsTest extends ServiceTest {
         body.put("smoothing", "-1");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -750,8 +722,7 @@ public class ParamsTest extends ServiceTest {
         body.put("smoothing", "101");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/fast/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/isochrones/fast/ResultTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.geoJsonContent;
 
 @EndPointAnnotation(name = "isochrones")
 @VersionAnnotation(version = "v2")
@@ -108,8 +109,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -137,8 +137,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -161,8 +160,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -181,8 +179,7 @@ public class ResultTest extends ServiceTest {
         body.put("range", getParameter("ranges_400"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -204,8 +201,7 @@ public class ResultTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorArea"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -229,8 +225,7 @@ public class ResultTest extends ServiceTest {
         body.put("area_units", getParameter("m"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -254,8 +249,7 @@ public class ResultTest extends ServiceTest {
         body.put("area_units", "km");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -281,8 +275,7 @@ public class ResultTest extends ServiceTest {
         body.put("attributes", getParameter("attributesReachfactorArea"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -305,8 +298,7 @@ public class ResultTest extends ServiceTest {
         body.put("area_units", "mi");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -330,8 +322,7 @@ public class ResultTest extends ServiceTest {
         body.put("intersections", "true");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -371,8 +362,7 @@ public class ResultTest extends ServiceTest {
         // so neighbourhood search results in slightly different results
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -385,8 +375,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("smoothing", "100");
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()
@@ -406,8 +395,7 @@ public class ResultTest extends ServiceTest {
         body.put("id", "request123");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/matrix/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/matrix/ParamsTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.geoJsonContent;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.jsonContent;
 
 @EndPointAnnotation(name = "matrix")
 @VersionAnnotation(version = "v2")
@@ -163,8 +165,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -180,8 +181,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car-123")
                 .body(body.toString())
                 .when()
@@ -198,8 +198,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("units", "j");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car-123")
                 .body(body.toString())
                 .when()
@@ -216,8 +215,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -228,8 +226,7 @@ public class ParamsTest extends ServiceTest {
                 .statusCode(406);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -245,8 +242,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("minimalLocations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "carProfile")
                 .body(body.toString())
                 .when()
@@ -263,8 +259,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath())
@@ -279,8 +274,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locationsFaulty"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -297,8 +291,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("sources", getParameter("faultySource"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -316,8 +309,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("maximumLocations"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -334,8 +326,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("resolve_locations", true);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -355,8 +346,7 @@ public class ParamsTest extends ServiceTest {
         body.put("metrics", getParameter("metricsDuration"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -373,8 +363,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("metrics", getParameter("metricsDistance"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -392,8 +381,7 @@ public class ParamsTest extends ServiceTest {
         body.put("metrics", getParameter("metricsAll"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -410,8 +398,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -432,8 +419,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -450,8 +436,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -468,8 +453,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("optimized", true);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -486,8 +470,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -505,8 +488,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -523,8 +505,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -542,8 +523,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("sources", new String[] {"all"});
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -561,8 +541,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("destinations", new String[] {"all"});
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -580,8 +559,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("metrics", new String[]{"distance"});
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -599,8 +577,7 @@ public class ParamsTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("units", "m");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -619,8 +596,7 @@ public class ParamsTest extends ServiceTest {
         body.put("resolve_locations", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -637,8 +613,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -654,8 +629,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -672,8 +646,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -689,8 +662,7 @@ public class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/matrix/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/matrix/ResultTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.jsonContent;
 
 @EndPointAnnotation(name = "matrix")
 @VersionAnnotation(version = "v2")
@@ -186,8 +187,7 @@ public class ResultTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("resolve_locations", true);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -212,8 +212,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -234,8 +233,7 @@ public class ResultTest extends ServiceTest {
         body.put("metrics", getParameter("metricsDuration"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -265,8 +263,7 @@ public class ResultTest extends ServiceTest {
         body.put("metrics", getParameter("metricsDistance"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -295,8 +292,7 @@ public class ResultTest extends ServiceTest {
         body.put("metrics", getParameter("metricsAll"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -340,8 +336,7 @@ public class ResultTest extends ServiceTest {
 
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -382,8 +377,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -410,8 +404,7 @@ public class ResultTest extends ServiceTest {
         body.put("resolve_locations", "true");
         body.put("sources", getParameter("source1"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -454,8 +447,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locationsLong"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -481,8 +473,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -501,8 +492,7 @@ public class ResultTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("units", "km");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -520,8 +510,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -539,8 +528,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -562,8 +550,7 @@ public class ResultTest extends ServiceTest {
         body.put("resolve_locations", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -583,8 +570,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -625,8 +611,7 @@ public class ResultTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("resolve_locations", true);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -672,8 +657,7 @@ public class ResultTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -714,8 +698,7 @@ public class ResultTest extends ServiceTest {
         body.put("locations", getParameter("locations"));
         body.put("resolve_locations", true);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -762,8 +745,7 @@ public class ResultTest extends ServiceTest {
         body.put("id", "request123");
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("cyclingProfile"))
                 .body(body.toString())
                 .when()
@@ -784,8 +766,7 @@ public class ResultTest extends ServiceTest {
         body.put("metrics", getParameter("metricsDuration"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -812,8 +793,7 @@ public class ResultTest extends ServiceTest {
         body.put("metrics", getParameter("metricsDuration"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -842,8 +822,7 @@ public class ResultTest extends ServiceTest {
         body.put("destinations", new JSONArray(new int[] {2,3,4}));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -873,8 +852,7 @@ public class ResultTest extends ServiceTest {
 
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ParamsTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.geoJsonContent;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.jsonContent;
 import static org.heigit.ors.v2.services.utils.HelperFunctions.constructCoords;
 
 @EndPointAnnotation(name = "directions")
@@ -115,8 +117,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("coordinates", (JSONArray) getParameter("coordinatesShort"));
         body.put("preference", getParameter("preference"));
 		given()
-				.header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+				.headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -135,8 +136,7 @@ public class ParamsTest extends ServiceTest {
         body.put("instructions", "false");
         body.put("preference", getParameter("preference"));
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -155,8 +155,7 @@ public class ParamsTest extends ServiceTest {
         body.put("instructions", "true");
         body.put("preference", getParameter("preference"));
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -177,8 +176,7 @@ public class ParamsTest extends ServiceTest {
         body.put("instructions_format", "text");
         body.put("preference", getParameter("preference"));
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -198,8 +196,7 @@ public class ParamsTest extends ServiceTest {
         body.put("instructions_format", "html");
         body.put("preference", getParameter("preference"));
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -218,8 +215,7 @@ public class ParamsTest extends ServiceTest {
         body.put("geometry", "true");
         body.put("preference", getParameter("preference"));
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -238,8 +234,7 @@ public class ParamsTest extends ServiceTest {
         body.put("geometry", "false");
         body.put("preference", getParameter("preference"));
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -263,8 +258,7 @@ public class ParamsTest extends ServiceTest {
         body.put("preference", getParameter("preference"));
 
 		given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -289,8 +283,7 @@ public class ParamsTest extends ServiceTest {
         body.put("preference", getParameter("preference"));
 
 		given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -311,8 +304,7 @@ public class ParamsTest extends ServiceTest {
         body.put("instructions", "false");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -336,8 +328,7 @@ public class ParamsTest extends ServiceTest {
         body.put("preference", getParameter("preference"));
 
 		given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -360,8 +351,7 @@ public class ParamsTest extends ServiceTest {
         body.put("preference", getParameter("preference"));
 
 		given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -385,8 +375,7 @@ public class ParamsTest extends ServiceTest {
         body.put("extra_info", getParameter("extra_info"));
 
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -411,8 +400,7 @@ public class ParamsTest extends ServiceTest {
         body.put("preference", getParameter("preference"));
 
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("profile"))
                 .body(body.toString())
                 .when()
@@ -433,8 +421,7 @@ public class ParamsTest extends ServiceTest {
         body.put("preference", getParameter("preference"));
 
 		given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car-123")
                 .body(body.toString())
                 .when()
@@ -488,8 +475,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("preference", getParameter("preference"));
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.body(body.toString())
 				.when()
 				.post(getEndPointPath())
@@ -507,8 +493,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("preference", getParameter("preference"));
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -528,8 +513,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("language", "yuhd");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -549,8 +533,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("preference", getParameter("preference"));
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -574,8 +557,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -601,8 +583,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -634,8 +615,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -668,8 +648,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -700,8 +679,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -724,8 +702,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -746,8 +723,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -781,8 +757,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", "cycling-road")
 				.body(body.toString())
 				.when()
@@ -809,8 +784,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -844,8 +818,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("bearings", bearings);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -872,8 +845,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("bearings", bearings);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -898,8 +870,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("radiuses", radii);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -920,8 +891,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("radiuses", radii);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -956,8 +926,7 @@ public class ParamsTest extends ServiceTest {
 
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -976,8 +945,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("units", "j");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -997,8 +965,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("instructions_format", "blah");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1016,8 +983,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("preference", "blah");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1036,8 +1002,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("language", "blah");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1056,8 +1021,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("attributes", Arrays.asList("blah"));
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1070,8 +1034,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("attributes", new JSONArray(Arrays.asList("blah", "percentage")));
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1094,8 +1057,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1117,8 +1079,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1136,8 +1097,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("preference", getParameter("preference"));
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1165,8 +1125,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("preference", "shortest");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1182,8 +1141,7 @@ public class ParamsTest extends ServiceTest {
 				.statusCode(200);
 
 		given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1220,8 +1178,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("suppress_warnings", "true");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1241,8 +1198,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("extra_info", getParameter("extra_info"));
 
 		given()
-				.header("Accept", "application/geo+json")
-				.header("Content-Type", "application/json")
+				.headers(geoJsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1271,8 +1227,7 @@ public class ParamsTest extends ServiceTest {
 
         body.put("skip_segments", skipSegmentsEmpty);
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1282,8 +1237,7 @@ public class ParamsTest extends ServiceTest {
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1295,8 +1249,7 @@ public class ParamsTest extends ServiceTest {
 
         body.put("skip_segments", skipSegmentsTooHigh);
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1306,8 +1259,7 @@ public class ParamsTest extends ServiceTest {
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1319,8 +1271,7 @@ public class ParamsTest extends ServiceTest {
 
         body.put("skip_segments", skipSegmentsTooSmall);
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1330,8 +1281,7 @@ public class ParamsTest extends ServiceTest {
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1343,8 +1293,7 @@ public class ParamsTest extends ServiceTest {
 
         body.put("skip_segments", skipSegmentsTooMany);
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1354,8 +1303,7 @@ public class ParamsTest extends ServiceTest {
                 .body("error.code", is(RoutingErrorCodes.INVALID_PARAMETER_VALUE))
                 .statusCode(400);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1377,8 +1325,7 @@ public class ParamsTest extends ServiceTest {
 
         body.put("skip_segments", skipSegments);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
 				.when().log().ifValidationFails()
@@ -1392,8 +1339,7 @@ public class ParamsTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
 				.when().log().ifValidationFails()
@@ -1425,8 +1371,7 @@ public class ParamsTest extends ServiceTest {
         body.put("coordinates", coords);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "cycling-mountain")
                 .body(body.toString())
 				.when().log().ifValidationFails()
@@ -1438,8 +1383,7 @@ public class ParamsTest extends ServiceTest {
         body.put("radiuses", new int[]{5, 10});
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "cycling-mountain")
                 .body(body.toString())
 				.when().log().ifValidationFails()
@@ -1457,8 +1401,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("coordinates", coords);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", "cycling-mountain")
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1471,8 +1414,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("radiuses", new int[]{100, 10});
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", "cycling-mountain")
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1490,8 +1432,7 @@ public class ParamsTest extends ServiceTest {
         body.put("coordinates", coords);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car")
                 .body(body.toString())
 				.when().log().ifValidationFails()
@@ -1504,8 +1445,7 @@ public class ParamsTest extends ServiceTest {
         body.put("radiuses", new int[]{150, 10});
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car")
                 .body(body.toString())
 				.when().log().ifValidationFails()
@@ -1529,8 +1469,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("footProfile"))
 				.body(body.toString())
 				.when()
@@ -1554,8 +1493,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("footProfile"))
 				.body(body.toString())
 				.when()
@@ -1577,8 +1515,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("alternative_routes", ar);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1601,8 +1538,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1630,8 +1566,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1653,8 +1588,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("coordinates", singleCoordinate);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1682,8 +1616,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1711,8 +1644,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("options", options);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when().log().ifValidationFails()
@@ -1732,8 +1664,7 @@ public class ParamsTest extends ServiceTest {
 
 		//Test that the distance of the computed route.
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1754,8 +1685,7 @@ public class ParamsTest extends ServiceTest {
 
 		//Test that the distance of the computed route.
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -1776,8 +1706,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("arrival", "2021-01-31T12:00");
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("profile"))
 				.body(body.toString())
 				.when()
@@ -1799,8 +1728,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("radiuses", 500);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()
@@ -1817,8 +1745,7 @@ public class ParamsTest extends ServiceTest {
 		body.put("radiuses", radii);
 
 		given()
-				.header("Accept", "application/json")
-				.header("Content-Type", "application/json")
+				.headers(jsonContent)
 				.pathParam("profile", getParameter("carProfile"))
 				.body(body.toString())
 				.when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -50,6 +50,7 @@ import static io.restassured.config.JsonConfig.jsonConfig;
 import io.restassured.RestAssured;
 import io.restassured.path.json.config.JsonPathConfig;
 import static org.hamcrest.Matchers.*;
+import static org.heigit.ors.v2.services.utils.CommonHeaders.*;
 import static org.heigit.ors.v2.services.utils.HelperFunctions.constructCoords;
 
 @EndPointAnnotation(name = "directions")
@@ -141,8 +142,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", true);
 
         Response response = given()
-                .header("Accept", "application/gpx+xml")
-                .header("Content-Type", "application/json")
+                .headers(gpxContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -160,8 +160,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("instructions", false);
         Response response_without_instructions = given()
-                .header("Accept", "application/gpx+xml")
-                .header("Content-Type", "application/json")
+                .headers(gpxContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -653,8 +652,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", getParameter("extra_info"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -689,8 +687,7 @@ public class ResultTest extends ServiceTest {
         body.put("id", "request123");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -705,8 +702,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -727,8 +723,7 @@ public class ResultTest extends ServiceTest {
         body.put("id", "request123");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -766,8 +761,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -789,8 +783,7 @@ public class ResultTest extends ServiceTest {
         body.put("elevation", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -816,8 +809,7 @@ public class ResultTest extends ServiceTest {
         body.put("elevation", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -844,8 +836,7 @@ public class ResultTest extends ServiceTest {
         body.put("elevation", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -868,8 +859,7 @@ public class ResultTest extends ServiceTest {
         body.put("elevation", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -890,8 +880,7 @@ public class ResultTest extends ServiceTest {
         body.put("elevation", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -913,8 +902,7 @@ public class ResultTest extends ServiceTest {
         body.put("maneuvers", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -941,8 +929,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", getParameter("extra_info"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -967,8 +954,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", getParameter("extra_info"));
 
         Response response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -996,8 +982,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", constructExtras("surface|suitability|steepness"));
 
         Response response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -1017,8 +1002,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", constructExtras("suitability|traildifficulty"));
 
         Response response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -1046,8 +1030,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", constructExtras("traildifficulty"));
 
         response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "foot-hiking")
                 .body(body.toString())
                 .when()
@@ -1083,8 +1066,7 @@ public class ResultTest extends ServiceTest {
         // Test that the response indicates that the whole route is tollway free. The first two tests check that the waypoint ids
         // in the extras.tollways.values match the final waypoint of the route
         Response response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car")
                 .body(body.toString())
                 .when()
@@ -1103,8 +1085,7 @@ public class ResultTest extends ServiceTest {
         checkExtraConsistency(response);
 
         response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1141,8 +1122,7 @@ public class ResultTest extends ServiceTest {
         body.put("continue_straight", false);
 
         response = given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -1174,8 +1154,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", constructExtras("green"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -1201,8 +1180,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", constructExtras("noise"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -1237,8 +1215,7 @@ public class ResultTest extends ServiceTest {
 
         given()
                 .config(JSON_CONFIG_DOUBLE_NUMBERS)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -1259,8 +1236,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", new JSONArray("[\"steepness\",\"suitability\",\"surface\",\"waycategory\",\"waytype\",\"tollways\",\"traildifficulty\",\"osmid\",\"roadaccessrestrictions\",\"countryinfo\",\"green\",\"noise\"]"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .body(body.toString())
                 .when()
                 .post(getEndPointPath() + "/foot-walking/json")
@@ -1292,8 +1268,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that the "right turn only" restriction at the junction is taken into account
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car")
                 .body(body.toString())
                 .when()
@@ -1314,8 +1289,7 @@ public class ResultTest extends ServiceTest {
 
         //Test against default maximum speed lower bound setting
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car")
                 .body(body.toString())
                 .when()
@@ -1330,8 +1304,7 @@ public class ResultTest extends ServiceTest {
         body.put("maximum_speed", 75);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1355,8 +1328,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that the "right turn only" restriction at the junction is taken into account
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car")
                 .body(body.toString())
                 .when()
@@ -1380,8 +1352,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that the "right turn only" restriction at the junction is taken into account
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-car")
                 .body(body.toString())
                 .when()
@@ -1401,8 +1372,7 @@ public class ResultTest extends ServiceTest {
         body.put("geometry", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -1423,8 +1393,7 @@ public class ResultTest extends ServiceTest {
         body.put("bearings", constructBearings("25,30|90,20"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "cycling-road")
                 .body(body.toString())
                 .when()
@@ -1445,8 +1414,7 @@ public class ResultTest extends ServiceTest {
         body.put("bearings", constructBearings("25,30"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "cycling-road")
                 .body(body.toString())
                 .when()
@@ -1467,8 +1435,7 @@ public class ResultTest extends ServiceTest {
         body.put("bearings", constructBearings("|90,20"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -1487,8 +1454,7 @@ public class ResultTest extends ServiceTest {
         body.put("continue_straight", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1508,8 +1474,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -1532,8 +1497,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -1614,8 +1578,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that buses are not allowed on Neue Schlossstraße (https://www.openstreetmap.org/way/150549948)
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1629,8 +1592,7 @@ public class ResultTest extends ServiceTest {
         options.put("vehicle_type", "bus");
         body.put("options", options);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1660,8 +1622,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1683,8 +1644,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1715,8 +1675,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1738,8 +1697,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -1761,8 +1719,7 @@ public class ResultTest extends ServiceTest {
 
         // Generic test to ensure that the distance and duration dont get changed
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1792,8 +1749,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that providing border control in avoid_features works
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1810,8 +1766,7 @@ public class ResultTest extends ServiceTest {
 
         // Option 1 signifies that the route should not cross any borders
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1837,8 +1792,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1854,8 +1808,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1869,8 +1822,7 @@ public class ResultTest extends ServiceTest {
         // Test avoid_countries with ISO 3166-1 Alpha-2 parameters
         options.put("avoid_countries", constructFromPipedList("AT|FR"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1884,8 +1836,7 @@ public class ResultTest extends ServiceTest {
         // Test avoid_countries with ISO 3166-1 Alpha-3 parameters
         options.put("avoid_countries", constructFromPipedList("AUT|FRA"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1913,8 +1864,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that routing avoids crossing into borders specified
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1935,8 +1885,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that a detourfactor is returned when requested
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1960,8 +1909,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -1992,8 +1940,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2014,8 +1961,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -2045,8 +1991,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2067,8 +2012,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2097,8 +2041,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2119,8 +2062,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2149,8 +2091,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2172,8 +2113,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2202,8 +2142,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2224,8 +2163,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2246,8 +2184,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2266,8 +2203,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2288,8 +2224,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2308,8 +2243,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2331,8 +2265,7 @@ public class ResultTest extends ServiceTest {
         body.put("extra_info", constructExtras("osmid"));
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "wheelchair")
                 .body(body.toString())
                 .when()
@@ -2363,8 +2296,7 @@ public class ResultTest extends ServiceTest {
         body.put("preference", "shortest");
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2380,8 +2312,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2408,8 +2339,7 @@ public class ResultTest extends ServiceTest {
         body.put("coordinates", getParameter("coordinatesLong"));
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2422,8 +2352,7 @@ public class ResultTest extends ServiceTest {
         body.put("geometry_simplify", true);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2445,8 +2374,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("skip_segments", skipSegments);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -2460,8 +2388,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2488,8 +2415,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("coordinates", getParameter("coordinatesShort"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -2527,8 +2453,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2581,8 +2506,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("coordinates", getParameter("coordinatesLong"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -2627,8 +2551,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2704,8 +2627,7 @@ public class ResultTest extends ServiceTest {
         coordsTooLong.put(coordLong5);
         body.put("coordinates", coordsTooLong);
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -2734,8 +2656,7 @@ public class ResultTest extends ServiceTest {
         body.put("attributes", attributes);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2750,8 +2671,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("units", "km");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2766,8 +2686,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("units", "m");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2782,8 +2701,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("units", "mi");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2804,8 +2722,7 @@ public class ResultTest extends ServiceTest {
 
         given()
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -2828,8 +2745,7 @@ public class ResultTest extends ServiceTest {
 
         given()
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -2849,8 +2765,7 @@ public class ResultTest extends ServiceTest {
 
         given()
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -2873,8 +2788,7 @@ public class ResultTest extends ServiceTest {
 
         given()
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -2895,8 +2809,7 @@ public class ResultTest extends ServiceTest {
 
         given()
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -2919,8 +2832,7 @@ public class ResultTest extends ServiceTest {
 
         given()
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -2942,8 +2854,7 @@ public class ResultTest extends ServiceTest {
 
         // ensure indexing of merged routes waypoints dont get messed up
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2971,8 +2882,7 @@ public class ResultTest extends ServiceTest {
         body.put("preference", getParameter("preference"));
         body.put("instructions", true);
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -2994,8 +2904,7 @@ public class ResultTest extends ServiceTest {
 
         // ensure indexing of merged routes waypoints dont get messed up
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3036,8 +2945,7 @@ public class ResultTest extends ServiceTest {
 
         // No border crossing
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3077,8 +2985,7 @@ public class ResultTest extends ServiceTest {
 
         // Outside of any borders
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3113,8 +3020,7 @@ public class ResultTest extends ServiceTest {
 
         // Close to a border crossing
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3154,8 +3060,7 @@ public class ResultTest extends ServiceTest {
 
         // With Border crossing
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3203,8 +3108,7 @@ public class ResultTest extends ServiceTest {
         body.put("alternative_routes", ar);
         body.put("extra_info", getParameter("extra_info"));
         given()
-            .header("Accept", "application/json")
-            .header("Content-Type", "application/json")
+            .headers(jsonContent)
             .pathParam("profile", getParameter("carProfile"))
             .body(body.toString())
             .when()
@@ -3229,8 +3133,7 @@ public class ResultTest extends ServiceTest {
         body.put("options", options);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3266,8 +3169,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", false);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -3285,8 +3187,7 @@ public class ResultTest extends ServiceTest {
         options.put("avoid_polygons", avoidGeom);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -3303,8 +3204,7 @@ public class ResultTest extends ServiceTest {
         roundTripOptions.put("points", 3);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -3319,8 +3219,7 @@ public class ResultTest extends ServiceTest {
 
         body.put("bearings", constructBearings("25,30"));
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -3354,8 +3253,7 @@ public class ResultTest extends ServiceTest {
         body.put("instructions", false);
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -3374,8 +3272,7 @@ public class ResultTest extends ServiceTest {
         body.put("preference", "shortest");
 
         given()
-                .header("Accept", "application/geo+json")
-                .header("Content-Type", "application/json")
+                .headers(geoJsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when().log().ifValidationFails()
@@ -3394,8 +3291,7 @@ public class ResultTest extends ServiceTest {
         body.put("elevation", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("footProfile"))
                 .body(body.toString())
                 .when()
@@ -3417,8 +3313,7 @@ public class ResultTest extends ServiceTest {
         body.put("elevation", true);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "foot-hiking")
                 .body(body.toString())
                 .when()
@@ -3441,8 +3336,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that if the request specifies departure time then the response contains both departure and arrival time
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("bikeProfile"))
                 .body(body.toString())
                 .when()
@@ -3474,8 +3368,7 @@ public class ResultTest extends ServiceTest {
         // Tag "motor_vehicle:conditional = no @ Mo-Fr 12:45-13:30" on way 27884831
         // Test that way is accessible if no time is specified
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3490,8 +3383,7 @@ public class ResultTest extends ServiceTest {
         // Test that way is accessible on weekends
         body.put("departure", "2021-01-31T13:00");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3506,8 +3398,7 @@ public class ResultTest extends ServiceTest {
         // Test that way is closed at certain times throughout the week
         body.put("departure", "2021-12-31T13:00");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3522,8 +3413,7 @@ public class ResultTest extends ServiceTest {
         // Test that a shorter route around closed edge exists
         body.put("preference", "shortest");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3555,8 +3445,7 @@ public class ResultTest extends ServiceTest {
         // Tag "maxspeed:conditional = 30 @ (22:00-06:00)" along Rohrbacher Strasse
         // Test that the speed limit is not taken into account if no time is specified
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3571,8 +3460,7 @@ public class ResultTest extends ServiceTest {
         // Test that the speed limit does not apply throughout the day
         body.put("arrival", "2021-01-31T22:00");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3588,8 +3476,7 @@ public class ResultTest extends ServiceTest {
         body.remove("arrival");
         body.put("departure", "2021-01-31T22:00");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3604,8 +3491,7 @@ public class ResultTest extends ServiceTest {
         // Test that the speed limit applies for shortest weighting as well
         body.put("preference", "shortest");
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3636,8 +3522,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that "zone:maxspeed = DE:urban" overrides default "highway = residential" speed for both car and hgv
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3650,8 +3535,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()
@@ -3682,8 +3566,7 @@ public class ResultTest extends ServiceTest {
 
         // Test that "maxspeed:hgv:forward = 30" when going downhill on Am Götzenberg is taken into account for hgv profile
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", getParameter("carProfile"))
                 .body(body.toString())
                 .when()
@@ -3696,8 +3579,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
 
         given()
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
+                .headers(jsonContent)
                 .pathParam("profile", "driving-hgv")
                 .body(body.toString())
                 .when()

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/utils/CommonHeaders.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/utils/CommonHeaders.java
@@ -1,0 +1,15 @@
+package org.heigit.ors.v2.services.utils;
+
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+
+public class CommonHeaders {
+    public static Header contentTypeJson = new Header("Content-Type", "application/json");
+    public static Header acceptApplicationGeoJson = new Header("Accept", "application/geo+json");
+    public static Header acceptApplicationJson = new Header("Accept", "application/json");
+    public static Header acceptApplicationGpx = new Header("Accept", "application/gpx+xml");
+
+    public static Headers jsonContent = new Headers(contentTypeJson, acceptApplicationJson);
+    public static Headers geoJsonContent = new Headers(contentTypeJson, acceptApplicationGeoJson);
+    public static Headers gpxContent = new Headers(contentTypeJson, acceptApplicationGpx);
+}


### PR DESCRIPTION
use single 'Headers' object instead of two separate 'Header' objects to avoid duplication.

- Add CommonHeaders class for exposing static header and header collections
- Add 'Headers' objects for each used combination

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Reason for change: refactoring

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
