### PR TITLE
make docker build multistage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+.metadata/
+.git
+.gitignore
+**/*.pbf
+
+.idea/
+*.iml
+.DS_Store
+nohup.out
+.python-version
+.project
+
+# Ignore all ors and app config files except for the sample ones
+openrouteservice/WebContent/WEB-INF/app.config*
+!openrouteservice/WebContent/WEB-INF/app.config.sample
+openrouteservice/src/main/resources/app.config*
+!openrouteservice/src/main/resources/app.config.sample
+openrouteservice/WebContent/WEB-INF/ors-config*
+!openrouteservice/WebContent/WEB-INF/ors-config-sample.json
+openrouteservice/src/main/resources/ors-config*
+!openrouteservice/src/main/resources/ors-config-sample.json
+
+# no tests
+openrouteservice/src/test
+
+# Ignore folders generated from docker
+docker/elevation_cache
+docker/conf
+
+# Ignore ors.run file
+*ors.run
+
+cgiar_provider/
+graphs/
+target/
+.python-version
+nohup.out
+build/
+logs/
+cgiar_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ RELEASING:
 - fix minor spelling errors in Places.md ([#1196](https://github.com/GIScience/openrouteservice/issues/1196))
 - address matrix failures for HGV profile ([#1198](https://github.com/GIScience/openrouteservice/issues/1198))
 
+### Changed
+- docker image is multistage now ([#1234](https://github.com/GIScience/openrouteservice/issues/1234))
+
 ## [6.7.1] - 2022-10-05
 ### Added
 - optional routing profile parameter `force_turn_costs` ([#1220](https://github.com/GIScience/openrouteservice/pull/1220))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk
+FROM maven:3.8-jdk-11-slim as build
 
 ENV MAVEN_OPTS="-Dmaven.repo.local=.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
 ENV MAVEN_CLI_OPTS="--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
@@ -6,55 +6,49 @@ ENV MAVEN_CLI_OPTS="--batch-mode --errors --fail-at-end --show-version -Dinstall
 ARG ORS_CONFIG=./openrouteservice/src/main/resources/ors-config-sample.json
 ARG OSM_FILE=./openrouteservice/src/main/files/heidelberg.osm.gz
 ENV BUILD_GRAPHS="False"
-ARG UID=1000
 ARG TOMCAT_VERSION=8.5.69
 
-# Create user
-RUN useradd -u $UID -md /ors-core ors
-
-# Create directories
-RUN mkdir -p /usr/local/tomcat /ors-conf /var/log/ors && \
-    chown ors:ors /usr/local/tomcat /ors-conf /var/log/ors
+WORKDIR /ors-core
 
 # Install dependencies and locales
 RUN apt-get update -qq && \
-    apt-get install -qq -y locales nano maven moreutils jq && \
-    rm -rf /var/lib/apt/lists/* && \
-    locale-gen en_US.UTF-8
+    apt-get install -qq -y nano moreutils jq wget
 
-USER ors:ors
-WORKDIR /ors-core
-
-COPY --chown=ors:ors openrouteservice /ors-core/openrouteservice
-COPY --chown=ors:ors $OSM_FILE /ors-core/data/osm_file.pbf
-COPY --chown=ors:ors $ORS_CONFIG /ors-core/openrouteservice/src/main/resources/ors-config-sample.json
-COPY --chown=ors:ors ./docker-entrypoint.sh /ors-core/docker-entrypoint.sh
+COPY openrouteservice /ors-core/openrouteservice
+COPY $OSM_FILE /ors-core/data/osm_file.pbf
+COPY $ORS_CONFIG /ors-core/openrouteservice/src/main/resources/ors-config-sample.json
 
 # Install tomcat
 RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -O /tmp/tomcat.tar.gz && \
     cd /tmp && \
     tar xvfz tomcat.tar.gz && \
+    mkdir /usr/local/tomcat && \
     cp -R /tmp/apache-tomcat-${TOMCAT_VERSION}/* /usr/local/tomcat/ && \
     rm -r /tmp/tomcat.tar.gz /tmp/apache-tomcat-${TOMCAT_VERSION}
 
-# Configure ors config
+# Configure ors config:
+# - Replace paths in ors-config.json to match docker setup
+# - init_threads = 1, > 1 been reported some issues
+# - Delete all profiles but car
 RUN cp /ors-core/openrouteservice/src/main/resources/ors-config-sample.json /ors-core/openrouteservice/src/main/resources/ors-config.json && \
-    # Replace paths in ors-config.json to match docker setup
     jq '.ors.services.routing.sources[0] = "data/osm_file.pbf"' /ors-core/openrouteservice/src/main/resources/ors-config.json |sponge /ors-core/openrouteservice/src/main/resources/ors-config.json && \
     jq '.ors.services.routing.profiles.default_params.elevation_cache_path = "data/elevation_cache"' /ors-core/openrouteservice/src/main/resources/ors-config.json |sponge /ors-core/openrouteservice/src/main/resources/ors-config.json && \
     jq '.ors.services.routing.profiles.default_params.graphs_root_path = "data/graphs"' /ors-core/openrouteservice/src/main/resources/ors-config.json |sponge /ors-core/openrouteservice/src/main/resources/ors-config.json && \
-    # init_threads = 1, > 1 been reported some issues
     jq '.ors.services.routing.init_threads = 1' /ors-core/openrouteservice/src/main/resources/ors-config.json |sponge /ors-core/openrouteservice/src/main/resources/ors-config.json && \
-
-    # Delete all profiles but car
     jq 'del(.ors.services.routing.profiles.active[1,2,3,4,5,6,7,8])' /ors-core/openrouteservice/src/main/resources/ors-config.json |sponge /ors-core/openrouteservice/src/main/resources/ors-config.json
 
-# Make all directories writable, to allow the usage of other uids via "docker run -u"
-RUN chmod -R go+rwX /ors-core /ors-conf /usr/local/tomcat /var/log/ors
+RUN mvn -f /ors-core/openrouteservice/pom.xml package -DskipTests
 
-# Define volumes
-VOLUME ["/ors-core/data/graphs", "/ors-core/data/elevation_cache", "/ors-conf", "/usr/local/tomcat/logs", "/var/log/ors"]
+# build final image, just copying stuff inside
+FROM openjdk:11.0-jre-slim
+
+WORKDIR /ors-core
+
+COPY --from=build /ors-core/openrouteservice/target/ors.war .
+COPY --from=build /ors-core/openrouteservice/src/main/resources/ors-config.json .
+COPY --from=build /usr/local/tomcat /usr/local/tomcat
+COPY ./docker-entrypoint.sh .
 
 # Start the container
 EXPOSE 8080
-ENTRYPOINT ["/bin/bash", "/ors-core/docker-entrypoint.sh"]
+CMD ["bash", "-c", "/ors-core/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ COPY ./docker-entrypoint.sh .
 
 # Start the container
 EXPOSE 8080
-CMD ["bash", "-c", "/ors-core/docker-entrypoint.sh"]
+CMD ["/bin/bash", "/ors-core/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+echo "Running container as user $(whoami) with id $(id -u)"
+
 graphs=/ors-core/data/graphs
 tomcat_ors_config=/usr/local/tomcat/webapps/ors/WEB-INF/classes/ors-config.json
-source_ors_config=/ors-core/openrouteservice/src/main/resources/ors-config.json
+source_ors_config=/ors-core/ors-config.json
+public_ors_config=/ors-conf/ors-config.json
 
 if [ -z "${CATALINA_OPTS}" ]; then
 	export CATALINA_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9001 -Dcom.sun.management.jmxremote.rmi.port=9001 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost"
@@ -12,8 +15,8 @@ if [ -z "${JAVA_OPTS}" ]; then
 	export JAVA_OPTS="-Djava.awt.headless=true -server -XX:TargetSurvivorRatio=75 -XX:SurvivorRatio=64 -XX:MaxTenuringThreshold=3 -XX:+UseG1GC -XX:+ScavengeBeforeFullGC -XX:ParallelGCThreads=4 -Xms1g -Xmx2g"
 fi
 
-echo "CATALINA_OPTS=\"$CATALINA_OPTS\"" > /usr/local/tomcat/bin/setenv.sh
-echo "JAVA_OPTS=\"$JAVA_OPTS\"" >> /usr/local/tomcat/bin/setenv.sh
+echo "CATALINA_OPTS=\"${CATALINA_OPTS}\"" > /usr/local/tomcat/bin/setenv.sh
+echo "JAVA_OPTS=\"${JAVA_OPTS}\"" >> /usr/local/tomcat/bin/setenv.sh
 
 if [ "${BUILD_GRAPHS}" = "True" ]; then
   rm -rf ${graphs}/*
@@ -22,21 +25,18 @@ echo "### openrouteservice configuration ###"
 # if Tomcat built before, copy the mounted ors-config.json to the Tomcat webapp ors-config.json, else copy it from the source
 if [ -d "/usr/local/tomcat/webapps/ors" ]; then
   echo "Tomcat already built: Copying /ors-conf/ors-config.json to tomcat webapp folder"
-	cp -f /ors-conf/ors-config.json $tomcat_ors_config
+	cp -f ${public_ors_config} ${tomcat_ors_config}
 else
-	if [ ! -f /ors-conf/ors-config.json ]; then
-	  echo "No ors-config.json in ors-conf folder. Copy config from ${source_ors_config}"
-		cp -f $source_ors_config /ors-conf/ors-config.json
+	if [ ! -f $public_ors_config ]; then
+	  echo "No ors-config.json in ors-conf folder. Copying config from ${source_ors_config}"
+		cp -f ${source_ors_config} ${public_ors_config}
 	else
-	  echo "ors-config.json exists in ors-conf folder. Copy config to ${source_ors_config}"
-		cp -f /ors-conf/ors-config.json $source_ors_config
+	  echo "ors-config.json exists in ors-conf folder. Copying config to ${source_ors_config}"
+		cp -f ${public_ors_config} ${source_ors_config}
 	fi
 	echo "### Package openrouteservice and deploy to Tomcat ###"
-	mvn -q -f /ors-core/openrouteservice/pom.xml package -DskipTests && \
-	cp -f /ors-core/openrouteservice/target/*.war /usr/local/tomcat/webapps/ors.war
+	cp -f /ors-core/ors.war /usr/local/tomcat/webapps/ors.war
 fi
 
-/usr/local/tomcat/bin/catalina.sh run
-
-# Keep docker running easy
-exec "$@"
+# so docker can stop the process gracefully
+exec /usr/local/tomcat/bin/catalina.sh run

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,6 @@ services:
 #      args:
 #        ORS_CONFIG: ./openrouteservice/src/main/resources/ors-config-sample.json
 #        OSM_FILE: ./openrouteservice/src/main/files/heidelberg.osm.gz
-    user: "${ORS_UID:-0}:${ORS_GID:-0}"
     volumes:
       - ./graphs:/ors-core/data/graphs
       - ./elevation_cache:/ors-core/data/elevation_cache


### PR DESCRIPTION
Fixes #1232 

Multistaging the ORS image brings down the uncompressed size from 1.06 GB to 365 GB.

EDIT: actually the most important improvement I forgot😅. Before, the Java code was compiled for _every_ container. Now it’s compiled in the image, and a container starts building a graph instantly, instead of first compiling the project for 10 mins.

I also tried for along time to keep the logic with `USER` etc, but eventually it seems rather like it was more redundant and didn't really do what I'd have expected it to do, even before the change. So I removed most of that which makes it a bit easier to maintain I guess.

Basically, before this change, the paths which are mounted as volumes in the docker-compose, were never really owned by whatever the UID was. They were always owned by `root`. If I actually provided a user ID in docker-compose.yml that matched my host one (1000), it wasn't able to create any files in those directories. AFAIU it's happening because after the image is created, those paths are mounted on the host machine, which makes them `root`. I tried fixing that as well, but couldn't in any reasonable time. TBH, I do that exact thing on our [Valhalla image](https://github.com/gis-ops/docker-valhalla) and it works. I tried replicating exactly that for 2 hours with this image and I couldn't get it to work. In the end the effect is that nothing changes compared to before, other than having 1/3 of the image size and a MUCH quicker container startup time.

More comments in the changes.