### PR TITLE
Consistent use of maximum visited nodes limit in matrix algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ RELEASING:
 ## [Unreleased]
 ### Added
 - API documentation on coordinate CRS
+### Changed
+- Consistent use of maximum number of visited nodes limit across different matrix algorithms ([#1246](https://github.com/GIScience/openrouteservice/issues/1246))
 ### Fixed
 - Way access for walking profiles ([#1227](https://github.com/GIScience/openrouteservice/issues/1227))
 

--- a/openrouteservice/src/main/java/org/heigit/ors/exceptions/MaxVisitedNodesExceededException.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/exceptions/MaxVisitedNodesExceededException.java
@@ -1,0 +1,9 @@
+package org.heigit.ors.exceptions;
+
+public class MaxVisitedNodesExceededException extends Exception {
+
+    public MaxVisitedNodesExceededException() {
+        super("Search exceeds the limit of visited nodes.");
+    }
+
+}

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractMatrixAlgorithm.java
@@ -18,12 +18,14 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import org.heigit.ors.matrix.MatrixRequest;
+import org.heigit.ors.services.matrix.MatrixServiceSettings;
 
 public abstract class AbstractMatrixAlgorithm implements MatrixAlgorithm {
   protected GraphHopper graphHopper;
   protected Graph graph;
   protected FlagEncoder encoder;
   protected Weighting weighting;
+  protected int maxVisitedNodes = Integer.MAX_VALUE;
   
   public void init(MatrixRequest req, GraphHopper gh, Graph graph, FlagEncoder encoder, Weighting weighting)
   {
@@ -31,5 +33,6 @@ public abstract class AbstractMatrixAlgorithm implements MatrixAlgorithm {
 	  this.graph = graph;
 	  this.encoder = encoder;
 	  this.weighting = weighting;
+	  this.maxVisitedNodes = MatrixServiceSettings.getMaximumVisitedNodes();
   }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
@@ -30,6 +30,7 @@ import com.graphhopper.storage.CHGraph;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.*;
 import org.heigit.ors.matrix.algorithms.AbstractMatrixAlgorithm;
 import org.heigit.ors.matrix.algorithms.dijkstra.DijkstraManyToMany;
@@ -156,7 +157,7 @@ public class CoreMatrixAlgorithm extends AbstractMatrixAlgorithm {
             runPhaseInsideCore();
 
             if (visitedNodes > maxVisitedNodes)
-                throw new Exception("Search exceeds the limit of visited nodes.");
+                throw new MaxVisitedNodesExceededException();
 
             extractMetrics(srcData, dstData, times, distances, weights);
         }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
@@ -38,7 +38,6 @@ import org.heigit.ors.routing.graphhopper.extensions.core.CoreDijkstraFilter;
 import org.heigit.ors.routing.graphhopper.extensions.core.CoreMatrixFilter;
 import org.heigit.ors.routing.graphhopper.extensions.storages.AveragedMultiTreeSPEntry;
 import org.heigit.ors.routing.graphhopper.extensions.storages.MultiTreeSPEntryItem;
-import org.heigit.ors.services.matrix.MatrixServiceSettings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +55,6 @@ import static org.heigit.ors.routing.graphhopper.extensions.util.TurnWeightingHe
 public class CoreMatrixAlgorithm extends AbstractMatrixAlgorithm {
     protected int coreNodeLevel;
     protected int nodeCount;
-    protected int maxVisitedNodes = Integer.MAX_VALUE;
     protected int visitedNodes;
     private int treeEntrySize;
     private boolean hasTurnWeighting = false;
@@ -93,7 +91,6 @@ public class CoreMatrixAlgorithm extends AbstractMatrixAlgorithm {
         pathMetricsExtractor = new MultiTreeMetricsExtractor(req.getMetrics(), graph, this.encoder, weighting, req.getUnits());
         additionalCoreEdgeFilter = new CoreMatrixFilter(chGraph);
         initCollections(10);
-        setMaxVisitedNodes(MatrixServiceSettings.getMaximumVisitedNodes());
     }
 
     public void init(MatrixRequest req, GraphHopper gh, Graph graph, FlagEncoder encoder, Weighting weighting, EdgeFilter additionalEdgeFilter) {
@@ -157,6 +154,9 @@ public class CoreMatrixAlgorithm extends AbstractMatrixAlgorithm {
 
             this.additionalCoreEdgeFilter.setInCore(true);
             runPhaseInsideCore();
+
+            if (visitedNodes > maxVisitedNodes)
+                throw new Exception("Search exceeds the limit of visited nodes.");
 
             extractMetrics(srcData, dstData, times, distances, weights);
         }
@@ -410,6 +410,7 @@ public class CoreMatrixAlgorithm extends AbstractMatrixAlgorithm {
         int[] entryPoints = coreEntryPoints.toArray();
         int[] exitPoints = coreExitPoints.toArray();
         algorithm.calcPaths(entryPoints, exitPoints);
+        visitedNodes = algorithm.getVisitedNodes();
     }
 
     /**

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
@@ -20,6 +20,7 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.SPTEntry;
 
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.MatrixMetricsType;
 import org.heigit.ors.matrix.MatrixRequest;
 import org.heigit.ors.matrix.MatrixResult;
@@ -74,7 +75,7 @@ public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
 					SPTEntry[] targets = algorithm.calcPaths(sourceId, dstData.getNodeIds());
 
 					if (algorithm.getFoundTargets() != algorithm.getTargetsCount())
-						throw new Exception("Search exceeds the limit of visited nodes.");
+						throw new MaxVisitedNodesExceededException();
 
 					if (targets != null) {
 						pathMetricsExtractor.calcValues(srcIndex, targets, dstData, times, distances, weights);

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
@@ -27,7 +27,6 @@ import org.heigit.ors.matrix.MatrixLocations;
 import org.heigit.ors.matrix.PathMetricsExtractor;
 import org.heigit.ors.matrix.algorithms.AbstractMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.DijkstraOneToManyAlgorithm;
-import org.heigit.ors.services.matrix.MatrixServiceSettings;
 
 public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
 	private PathMetricsExtractor pathMetricsExtractor;
@@ -61,7 +60,7 @@ public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
 		} else {
 			DijkstraOneToManyAlgorithm algorithm = new DijkstraOneToManyAlgorithm(graph, weighting, TraversalMode.NODE_BASED);
 			algorithm.prepare(srcData.getNodeIds(),  dstData.getNodeIds());
-			algorithm.setMaxVisitedNodes(MatrixServiceSettings.getMaximumVisitedNodes());
+			algorithm.setMaxVisitedNodes(this.maxVisitedNodes);
 			
 			int sourceId = -1;
 

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
@@ -67,15 +67,19 @@ public class RPHASTMatrixAlgorithm extends AbstractMatrixAlgorithm {
 		} else {
 			RPHASTAlgorithm algorithm = new RPHASTAlgorithm(graph, prepareCH.getPrepareWeighting(),
 					TraversalMode.NODE_BASED);
+			algorithm.setMaxVisitedNodes(this.maxVisitedNodes);
 			
 			int[] srcIds = getValidNodeIds(srcData.getNodeIds());
 			int[] destIds = getValidNodeIds(dstData.getNodeIds());
 
 			mtxResult.setGraphDate(graphHopper.getGraphHopperStorage().getProperties().get("datareader.import.date"));
-			
+
 			algorithm.prepare(srcIds, destIds);
 
 			MultiTreeSPEntry[] destTrees = algorithm.calcPaths(srcIds, destIds);
+
+			if (algorithm.getVisitedNodes() > maxVisitedNodes)
+				throw new Exception("Search exceeds the limit of visited nodes.");
 
 			MultiTreeSPEntry[] originalDestTrees = new MultiTreeSPEntry[dstData.size()];
 			

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
@@ -23,6 +23,7 @@ import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.MatrixLocations;
 import org.heigit.ors.matrix.MatrixMetricsType;
 import org.heigit.ors.matrix.MatrixRequest;
@@ -79,7 +80,7 @@ public class RPHASTMatrixAlgorithm extends AbstractMatrixAlgorithm {
 			MultiTreeSPEntry[] destTrees = algorithm.calcPaths(srcIds, destIds);
 
 			if (algorithm.getVisitedNodes() > maxVisitedNodes)
-				throw new Exception("Search exceeds the limit of visited nodes.");
+				throw new MaxVisitedNodesExceededException();
 
 			MultiTreeSPEntry[] originalDestTrees = new MultiTreeSPEntry[dstData.size()];
 			

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
@@ -66,7 +66,6 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
 			chGraph = (CHGraph) qGraph.getMainGraph();
 		}
 
-		setMaxVisitedNodes(Integer.MAX_VALUE);
 		FlagEncoder encoder = weighting.getFlagEncoder();
 
 		upwardEdgeFilter = new UpwardSearchEdgeFilter(chGraph, encoder);
@@ -133,7 +132,7 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
 	}
 
 	protected void runDownwardSearch() {
-		while (!finishedTo) {
+		while (!isMaxVisitedNodesExceeded() && !finishedTo) {
 			finishedTo = !downwardSearch();
 		}
 	}


### PR DESCRIPTION
Apply the limit on the number of visited nodes which is specified in the config file to all matrix algorithms.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1246.

### Information about the changes
- Key functionality added: Enforce `maximum_visited_nodes` limit specified in the config file.

- Reason for change: The limit was not respected at all by **RPHAST** matrix algorithm, and not handled properly by **CoreMatrix** either.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request

Some more complex long-distance matrix queries computed with either RPHAST or CoreMatrix which have been working before might start failinmg with the following error:

```
Unable to compute a distance/duration matrix: Search exceeds the limit of visited nodes.
```

This can be circumvented by increasing the `maximum_visited_nodes` limit if server resources allow it.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
