### PR TITLE
fix: Fix failing glibc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ RELEASING:
 - visibility of csv_factor and csv_column API parameters ([PR #1279](https://github.com/GIScience/openrouteservice/pull/1279))
 - update org.apache.kafka:kafka_2.13 and related packages from 3.3.2 to 3.4.0
 - update outdated dockerfile dependencies ([PR #1284](https://github.com/GIScience/openrouteservice/pull/1284))
+- fix the dockerbuild by reducing the glibc version to 2.29-r0 ([PR #1287](https://github.com/GIScience/openrouteservice/pull/1287))
 
 ## [6.8.1] - 2023-02-08
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3019,SC2086
 RUN ln -svf /usr/glibc-compat/lib/ld-2.31.so /usr/glibc-compat/lib/ld-linux-x86-64.so.2 && \
     apk add --no-cache --virtual .build-deps curl='7.79.1-r5' binutils='2.35.2-r2' && \
-    GLIBC_VER="2.35-r0" && \
+    GLIBC_VER="2.29-r0" && \
     ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
     GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" && \
     GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" && \


### PR DESCRIPTION
The latest glibc version has some bugs that cause musl to not properly find required symbols.

### Information about the changes
- Reason for change: The current glibc version leads to musl failing to retrieve system symbols. It's a known incompatibility and can be addressed later.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
