### PR TITLE
Re-introduce the actual distance calculation for ferry ways

### DIFF
--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -440,7 +440,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>v4.0-RC10</version>
+            <version>v4.0-RC11</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -452,7 +452,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>v4.0-RC10</version>
+            <version>v4.0-RC11</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
@@ -375,8 +375,8 @@ public class ORSOSMReader extends OSMReader {
     }
 
     @Override
-	protected void recordWayDistance(ReaderWay way, LongArrayList osmNodeIds) {
-		super.recordWayDistance(way, osmNodeIds);
+	protected void recordExactWayDistance(ReaderWay way, LongArrayList osmNodeIds) {
+		super.recordExactWayDistance(way, osmNodeIds);
 
 		// compute exact way distance for ferries in order to improve travel time estimate, see #1037
 		if (way.hasTag("route", "ferry", "shuttle_train")) {


### PR DESCRIPTION
updated to a newer GH version which has the recordExactWayDistance method. The original method (recordWayDistance) was removed as the GH code changed how they used the estimated centre point so it cannot be done inside a separate method any more (the point is needed in later code)