### PR TITLE
fix tomcat config overwrite

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,9 @@ echo "Catalina Path: ${catalina_base}"
 graphs=${ors_base}/ors-core/data/graphs
 tomcat_ors_config=${catalina_base}/webapps/ors/WEB-INF/classes/ors-config.json
 source_ors_config=${ors_base}/ors-core/ors-config.json
-public_ors_config=${ors_base}/ors-conf/ors-config.json
+public_ors_config_folder=${ors_base}/ors-conf
+public_ors_config=${public_ors_config_folder}/ors-config.json
+ors_war_path=${ors_base}/ors-core/ors.war
 
 if [ -z "${CATALINA_OPTS}" ]; then
   export CATALINA_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9001 -Dcom.sun.management.jmxremote.rmi.port=9001 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost"
@@ -31,23 +33,22 @@ fi
 if [ "${BUILD_GRAPHS}" = "True" ]; then
   rm -rf "${graphs:?}"/*
 fi
+
 echo "### openrouteservice configuration ###"
-# if Tomcat built before, copy the mounted ors-config.json to the Tomcat webapp ors-config.json, else copy it from the source
-if [ -d "${catalina_base}/webapps/ors" ]; then
-  echo "Tomcat already built: Copying ${ors_base}/ors-conf/ors-config.json to tomcat webapp folder"
-  cp -f "${public_ors_config}" "${tomcat_ors_config}"
-else
-  if [ ! -f "$public_ors_config" ]; then
-    echo "No ors-config.json in ors-conf folder. Copying config from ${source_ors_config}"
-    mkdir -p "${ors_base}"/ors-conf
-    cp -f "${source_ors_config}" "${public_ors_config}"
-  else
-    echo "ors-config.json exists in ors-conf folder. Copying config to ${source_ors_config}"
-    cp -f "${public_ors_config}" "${source_ors_config}"
-  fi
-  echo "### Package openrouteservice and deploy to Tomcat ###"
-  cp -f "${ors_base}"/ors-core/ors.war "${catalina_base}"/webapps/ors.war
+if [ ! -d "${catalina_base}/webapps/ors" ]; then
+  echo "Extract war file to ${catalina_base}/webapps/ors"
+  cp -f "${ors_war_path}" "${catalina_base}"/webapps/ors.war
+  unzip -qq "${catalina_base}"/webapps/ors.war -d "${catalina_base}/webapps/ors"
 fi
+
+if [ ! -f "$public_ors_config" ]; then
+  echo "No ors-config.json in ors-conf folder. Copying original config from ${source_ors_config}"
+  mkdir -p "${public_ors_config_folder}"
+  cp -f "${source_ors_config}" "${public_ors_config}"
+fi
+
+echo "Deploy ors with config from ${public_ors_config}"
+cp -f "${public_ors_config}" "${tomcat_ors_config}"
 
 # so docker can stop the process gracefully
 exec "${catalina_base}"/bin/catalina.sh run

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,13 @@
 
 echo "Running container as user $(whoami) with id $(id -u)"
 
+if [[ -d /ors-core ]] || [[ -d /ors-conf ]]; then
+  echo "You're mounting old paths. Remove them and migrate to the new docker setup: https://github.com/GIScience/openrouteservice/blob/master/docker/docker-compose.yml"
+  echo "Exit setup due to old folders /ors-core or /ors-conf being mounted"
+  sleep 5
+  exit 1
+fi
+
 ors_base=${1}
 catalina_base=${ors_base}/tomcat
 echo "ORS Path: ${ors_base}"


### PR DESCRIPTION
The user config file is now used when the container is restarted or recreated.

Fixes #1300 

### Information about the changes
- Reason for change: The recent docker setup ignored custom config files.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
