### PR TITLE
fix: changes to make `expectDepartureAndArrival` API test passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ RELEASING:
 
 ## [Unreleased]
 ### Fixed
-- support for API time parameters
+- support for API time parameters  ([#1315](https://github.com/GIScience/openrouteservice/pull/1315))
+
 
 ## [7.0.1] - 2023-03-08
 - fix tomcat config overwrite ([#1311](https://github.com/GIScience/openrouteservice/issues/1311))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ RELEASING:
  -->
 
 ## [Unreleased]
+### Fixed
+- support for API time parameters
 
 ## [7.0.1] - 2023-03-08
 - fix tomcat config overwrite ([#1311](https://github.com/GIScience/openrouteservice/issues/1311))

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -3380,8 +3380,7 @@ public class ResultTest extends ServiceTest {
                 .statusCode(200);
     }
 
-    // TODO (refactoring): implement TD routing. As this was postponed until the update is done, this test is to be ignored for now.
-    @Test @Ignore
+    @Test
     public void expectDepartureAndArrival() { // TD routing not implemented yet
         JSONObject body = new JSONObject();
         body.put("coordinates", getParameter("coordinatesShort"));

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResult.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResult.java
@@ -38,6 +38,7 @@ public class RouteResult {
 	private ZonedDateTime arrival;
 	public static final String KEY_TIMEZONE_DEPARTURE = "timezone.departure";
 	public static final String KEY_TIMEZONE_ARRIVAL = "timezone.arrival";
+	public static final String DEFAULT_TIMEZONE = "Europe/Berlin";
 
 	public RouteResult(int routeExtras) {
 		segments = new ArrayList<>();

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResultBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RouteResultBuilder.java
@@ -97,8 +97,8 @@ class RouteResultBuilder
         result.calculateRouteSummary(request);
 
         if (request.getSearchParameters().isTimeDependent()) {
-            String timezoneDeparture = responses.get(0).getHints().getString(KEY_TIMEZONE_DEPARTURE, "");
-            String timezoneArrival = responses.get(responses.size()-1).getHints().getString(KEY_TIMEZONE_ARRIVAL, "");
+            String timezoneDeparture = responses.get(0).getHints().getString(KEY_TIMEZONE_DEPARTURE, DEFAULT_TIMEZONE);
+            String timezoneArrival = responses.get(responses.size()-1).getHints().getString(KEY_TIMEZONE_ARRIVAL, DEFAULT_TIMEZONE);
 
             setDepartureArrivalTimes(timezoneDeparture, timezoneArrival, request, result);
         }
@@ -143,8 +143,8 @@ class RouteResultBuilder
             resultSet[response.getAll().indexOf(path)] = result;
 
             if (request.getSearchParameters().isTimeDependent()) {
-                String timezoneDeparture = response.getHints().getString(KEY_TIMEZONE_DEPARTURE, "");
-                String timezoneArrival = response.getHints().getString(KEY_TIMEZONE_ARRIVAL, "");
+                String timezoneDeparture = response.getHints().getString(KEY_TIMEZONE_DEPARTURE, DEFAULT_TIMEZONE);
+                String timezoneArrival = response.getHints().getString(KEY_TIMEZONE_ARRIVAL, DEFAULT_TIMEZONE);
 
                 setDepartureArrivalTimes(timezoneDeparture, timezoneArrival, request, result);
             }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [X] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

### Information about the changes

Post-release fix: compatibility for API time parameters as the first step in re-introducing functionality of time-dependent routing.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
