### PR TITLE
Set java compile version to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,11 @@ RELEASING:
  -->
 
 ## [Unreleased]
-### Fixed
+### Added
 - support for API time parameters  ([#1315](https://github.com/GIScience/openrouteservice/pull/1315))
-
+- migration from Junit4 to Junit5  ([#1320](https://github.com/GIScience/openrouteservice/pull/1320))
+### Fixed
+- change compile mode from Java 8 to Java 11 and remove old Java 8 API usages ([#1321](https://github.com/GIScience/openrouteservice/pull/1321))
 
 ## [7.0.1] - 2023-03-08
 - fix tomcat config overwrite ([#1311](https://github.com/GIScience/openrouteservice/issues/1311))

--- a/openrouteservice-api-tests/pom.xml
+++ b/openrouteservice-api-tests/pom.xml
@@ -12,7 +12,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <slf4j.version>2.0.6</slf4j.version>
         <log4j.version>2.19.0</log4j.version>
     </properties>
@@ -20,15 +22,29 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <!--compilerArgs>
-                      <arg>add-modules=java.xml.bind</arg>
-                   </compilerArgs-->
-                </configuration>
+                <version>3.10.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -116,14 +132,20 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
             <version>1.4.2</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.4.0-b180830.0359</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ParamsTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ParamsTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
@@ -1020,7 +1019,7 @@ class ParamsTest extends ServiceTest {
         JSONObject body = new JSONObject();
         body.put("coordinates", getParameter("coordinatesShort"));
         body.put("preference", getParameter("preference"));
-        body.put("attributes", Collections.singletonList("blah"));
+        body.put("attributes", List.of("blah"));
 
         given()
                 .headers(jsonContent)

--- a/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
+++ b/openrouteservice-api-tests/src/test/java/org/heigit/ors/v2/services/routing/ResultTest.java
@@ -3380,7 +3380,7 @@ public class ResultTest extends ServiceTest {
     }
 
     @Test
-    public void expectDepartureAndArrival() { // TD routing not implemented yet
+    void expectDepartureAndArrival() { // TD routing not implemented yet
         JSONObject body = new JSONObject();
         body.put("coordinates", getParameter("coordinatesShort"));
         body.put("preference", getParameter("preference"));

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -27,10 +27,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <prerequisites>
-        <!-- Java 11 upgrade -->
-        <maven>3.0</maven>
-    </prerequisites>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.heigit.ors</groupId>
     <artifactId>openrouteservice</artifactId>
@@ -44,11 +40,13 @@
         <url>https://github.com/GIScience/openrouteservice/issues</url>
     </issueManagement>
     <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.timestamp>${maven.build.timestamp}</project.timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
-        <maven.compiler.target>11</maven.compiler.target>
         <geotools.version>27.2</geotools.version>
         <slf4j.version>2.0.6</slf4j.version>
         <log4j.version>2.19.0</log4j.version>
@@ -99,8 +97,27 @@
                 <filtering>true</filtering>
             </testResource>
         </testResources>
-
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <!-- Java 11 upgrade -->
                 <groupId>org.codehaus.mojo</groupId>
@@ -122,23 +139,22 @@
                         <configuration>
                             <target>
                                 <echo>Creating version file</echo>
-                                <copy file="${basedir}/target/${project.build.finalName}/WEB-INF/classes/resources/version.properties" tofile="${basedir}/target/version.properties"/>
+                                <copy file="${basedir}/target/${project.build.finalName}/WEB-INF/classes/resources/version.properties"
+                                      tofile="${basedir}/target/version.properties"/>
                             </target>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+                <version>3.10.1</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.3.2</version>
                 <configuration>
                     <warSourceDirectory>WebContent</warSourceDirectory>
                     <webXml>WebContent/WEB-INF/web.xml</webXml>
@@ -220,8 +236,6 @@
             <plugin><!-- clean up from war:inplace  -->
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.1.0</version>
-                <configuration>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -243,11 +257,10 @@
                     <argLine>-Duser.language=en -Duser.region=US -Dillegal-access=permit ${surefireArgLine}</argLine>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <!-- prepare agent for measuring unit tests -->
                     <execution>
@@ -271,7 +284,6 @@
             </plugin>
         </plugins>
     </build>
-
     <repositories>
         <repository>
             <!--This will resolve special artifact through our own reopository (https://www.jfrog.com/confluence/display/RTF/Maven+Repository#MavenRepository-ResolvingArtifactsthroughArtifactory).-->
@@ -298,22 +310,18 @@
     </repositories>
     <dependencies>
         <dependency>
-            <!-- Java 11 upgrade -->
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
+
         <dependency>
-            <!-- Java 11 upgrade -->
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
+
         <dependency>
-            <!-- Java 11 upgrade -->
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.8</version>
         </dependency>
 
         <dependency>
@@ -392,6 +400,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <version>${slf4j.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -400,16 +409,14 @@
             <version>0.9.5</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
-            <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -472,7 +479,6 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.4.5</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
@@ -559,25 +565,24 @@
             </exclusions>
         </dependency>
         <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-actuator</artifactId>
-          <exclusions>
-            <exclusion>
-              <groupId>org.springframework.boot</groupId>
-              <artifactId>spring-boot-starter-logging</artifactId>
-            </exclusion>
-          </exclusions>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-registry-prometheus</artifactId>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>3.0.0</version>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
@@ -599,8 +604,6 @@
             <version>${fasterxml.jackson.version}</version>
         </dependency>
     </dependencies>
-
-    <!-- mvn deploy -DperformRelease=true -->
     <profiles>
         <profile>
             <id>release-sign-artifacts</id>

--- a/openrouteservice/src/main/java/org/heigit/ors/api/util/SystemMessage.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/api/util/SystemMessage.java
@@ -92,7 +92,7 @@ public class SystemMessage {
         params.setApiFormat("json");
         params.setRequestService("matrix");
         params.setRequestProfiles(req.getProfile() != null ? req.getProfile().toString() : "driving-car");
-        params.setRequestPreference(req.getMetricsStrings().isEmpty() ? new HashSet<>(Collections.singletonList("duration")) : req.getMetricsStrings());
+        params.setRequestPreference(req.getMetricsStrings().isEmpty() ? new HashSet<>(List.of("duration")) : req.getMetricsStrings());
     }
 
     private static void extractParams(IsochronesRequest req, RequestParams params) {

--- a/openrouteservice/src/main/java/org/heigit/ors/kafka/ORSKafkaConsumerRunner.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/kafka/ORSKafkaConsumerRunner.java
@@ -26,9 +26,8 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.log4j.Logger;
 import org.heigit.ors.routing.RoutingProfileManager;
 
-import java.io.IOException;
 import java.time.Duration;
-import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 public class ORSKafkaConsumerRunner implements Runnable {
@@ -46,7 +45,7 @@ public class ORSKafkaConsumerRunner implements Runnable {
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class.getName());
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumer = new KafkaConsumer<>(props);
-        consumer.subscribe(Collections.singletonList(config.getTopic()));
+        consumer.subscribe(List.of(config.getTopic()));
         this.profile = config.getProfile();
         this.pollTimeout = config.hasTimeout() ? config.getTimeout() : POLL_TIMEOUT_DEFAULT;
         this.active = true;

--- a/openrouteservice/src/main/java/org/heigit/ors/mapmatching/hmm/HiddenMarkovMapMatcher.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/mapmatching/hmm/HiddenMarkovMapMatcher.java
@@ -21,7 +21,6 @@ import com.graphhopper.routing.querygraph.EdgeIteratorStateHelper;
 import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.DistanceCalc;
@@ -32,7 +31,6 @@ import org.heigit.ors.routing.graphhopper.extensions.ORSGraphHopper;
 import org.locationtech.jts.geom.Coordinate;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /*
@@ -325,7 +323,8 @@ public class HiddenMarkovMapMatcher extends AbstractMapMatcher {
 	private MatchPoint[] findNearestPoints(double lat, double lon, int measuredPointIndex, EdgeFilter edgeFilter, List<MatchPoint> matchPoints,
 			List<Integer> roadSegments) {
 		// TODO Postponed: find out how to do this now: List<Snap> qResults = locationIndex.findNClosest(lat, lon, edgeFilter);
-		List<Snap> qResults = Collections.singletonList(locationIndex.findClosest(lat, lon, edgeFilter)); // TODO: this is just a temporary work-around for the previous line
+        // TODO: this is just a temporary work-around for the previous line
+		List<Snap> qResults = List.of(locationIndex.findClosest(lat, lon, edgeFilter));
 		if (qResults.isEmpty())
 			return new MatchPoint[] {};
 

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/MatrixMetricsType.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/MatrixMetricsType.java
@@ -16,8 +16,8 @@ package org.heigit.ors.matrix;
 import com.graphhopper.util.Helper;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class MatrixMetricsType {
@@ -83,15 +83,15 @@ public class MatrixMetricsType {
 	public static Set<String> getMetricsNamesFromInt(int metric) {
 		switch (metric) {
 			case MatrixMetricsType.DURATION:
-				return new HashSet<>(Collections.singletonList(KEY_DURATION)) ;
+				return new HashSet<>(List.of(KEY_DURATION)) ;
 			case MatrixMetricsType.DISTANCE:
-				return new HashSet<>(Collections.singletonList(KEY_DISTANCE)) ;
+				return new HashSet<>(List.of(KEY_DISTANCE)) ;
 			case MatrixMetricsType.WEIGHT:
-				return new HashSet<>(Collections.singletonList(KEY_WEIGHT)) ;
+				return new HashSet<>(List.of(KEY_WEIGHT)) ;
 			case MatrixMetricsType.DURATION | MatrixMetricsType.DISTANCE:
 				return new HashSet<>(Arrays.asList(KEY_DURATION, KEY_DISTANCE)) ;
 			default:
-				return new HashSet<>(Collections.singletonList(KEY_UNKNOWN)) ;
+				return new HashSet<>(List.of(KEY_UNKNOWN)) ;
 		}
 	}
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/util/SteepnessUtil.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/util/SteepnessUtil.java
@@ -12,7 +12,7 @@ public class SteepnessUtil {
     private SteepnessUtil() {
         throw new IllegalStateException("Utility class should not be instantiated.");
     }
-    
+
     public static int getCategory(double value) {
         if (Double.isNaN(value))
             return 0;
@@ -112,10 +112,8 @@ public class SteepnessUtil {
                         double elevGap = length/30;
                         if (
                             (
-                                elevSign > 0 /* && Math.Abs(prevSplit.gradient - gradient) < gradientDiff)//*/ && prevGC > 0
-                                || 
-                                /*Math.Abs(prevSplit.gradient - gradient) < gradientDiff)//*/prevGC < 0
-                            ) 
+                                elevSign > 0 && prevGC > 0 || prevGC < 0
+                            )
                             && Math.abs(zn - z1) < elevGap) {
                                 bApply = false;
                         }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/util/extrainfobuilders/SteepnessExtraInfoBuilder.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/util/extrainfobuilders/SteepnessExtraInfoBuilder.java
@@ -14,10 +14,7 @@
 package org.heigit.ors.routing.util.extrainfobuilders;
 
 import com.graphhopper.util.DistanceCalc3D;
-import com.graphhopper.util.DistanceCalcEarth;
-import com.graphhopper.util.Helper;
 import com.graphhopper.util.PointList;
-
 import org.heigit.ors.routing.RouteExtraInfo;
 import org.heigit.ors.routing.RouteSegmentItem;
 import org.heigit.ors.routing.util.SteepnessUtil;
@@ -102,8 +99,7 @@ public class SteepnessExtraInfoBuilder extends RouteExtraInfoBuilder {
 					if (zn != Double.MIN_VALUE) {
 						double elevGap = segLength/30;
 						if ((
-								elevSign > 0 /* && Math.Abs(prevSplit.Gradient - gradient) < gradientDiff)//*/ && prevGradientCat > 0
-								|| /*Math.Abs(prevSplit.Gradient - gradient) < gradientDiff)//*/prevGradientCat < 0
+								elevSign > 0 && prevGradientCat > 0 || prevGradientCat < 0
 							)
 							&& Math.abs(zn - z1) < elevGap)
 							bApply = false;

--- a/openrouteservice/src/main/java/org/json/JSONArray.java
+++ b/openrouteservice/src/main/java/org/json/JSONArray.java
@@ -30,11 +30,7 @@ import java.io.Writer;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A JSONArray is an ordered sequence of values. Its external text form is a
@@ -769,7 +765,7 @@ public class JSONArray implements Iterable<Object> {
      * @return this.
      */
     public JSONArray put(double value) throws JSONException {
-        Double d = new Double(value);
+        Double d = Double.valueOf(value);
         JSONObject.testValidity(d);
         this.put(d);
         return this;
@@ -783,7 +779,7 @@ public class JSONArray implements Iterable<Object> {
      * @return this.
      */
     public JSONArray put(int value) {
-        this.put(new Integer(value));
+        this.put(Integer.valueOf(value));
         return this;
     }
 
@@ -795,7 +791,7 @@ public class JSONArray implements Iterable<Object> {
      * @return this.
      */
     public JSONArray put(long value) {
-        this.put(new Long(value));
+        this.put(Long.valueOf(value));
         return this;
     }
 
@@ -875,7 +871,7 @@ public class JSONArray implements Iterable<Object> {
      *             If the index is negative or if the value is not finite.
      */
     public JSONArray put(int index, double value) throws JSONException {
-        this.put(index, new Double(value));
+        this.put(index, Double.valueOf(value));
         return this;
     }
 
@@ -893,7 +889,7 @@ public class JSONArray implements Iterable<Object> {
      *             If the index is negative.
      */
     public JSONArray put(int index, int value) throws JSONException {
-        this.put(index, new Integer(value));
+        this.put(index, Integer.valueOf(value));
         return this;
     }
 
@@ -911,7 +907,7 @@ public class JSONArray implements Iterable<Object> {
      *             If the index is negative.
      */
     public JSONArray put(int index, long value) throws JSONException {
-        this.put(index, new Long(value));
+        this.put(index, Long.valueOf(value));
         return this;
     }
 

--- a/openrouteservice/src/main/java/org/json/JSONObject.java
+++ b/openrouteservice/src/main/java/org/json/JSONObject.java
@@ -32,16 +32,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.ResourceBundle;
-import java.util.Set;
 
 /**
  * A JSONObject is an unordered collection of name/value pairs. Its external
@@ -1273,7 +1265,7 @@ public class JSONObject {
      *             If the key is null or if the number is invalid.
      */
     public JSONObject put(String key, double value) throws JSONException {
-        this.put(key, new Double(value));
+        this.put(key, Double.valueOf(value));
         return this;
     }
 
@@ -1289,7 +1281,7 @@ public class JSONObject {
      *             If the key is null.
      */
     public JSONObject put(String key, int value) throws JSONException {
-        this.put(key, new Integer(value));
+        this.put(key, Integer.valueOf(value));
         return this;
     }
 
@@ -1305,7 +1297,7 @@ public class JSONObject {
      *             If the key is null.
      */
     public JSONObject put(String key, long value) throws JSONException {
-        this.put(key, new Long(value));
+        this.put(key, Long.valueOf(value));
         return this;
     }
 
@@ -1638,7 +1630,7 @@ public class JSONObject {
                         return d;
                     }
                 } else {
-                    Long myLong = new Long(string);
+                    Long myLong = Long.valueOf(string);
                     if (string.equals(myLong.toString())) {
                         if (myLong.longValue() == myLong.intValue()) {
                             return Integer.valueOf(myLong.intValue());

--- a/openrouteservice/src/main/java/org/json/JSONWriter.java
+++ b/openrouteservice/src/main/java/org/json/JSONWriter.java
@@ -299,7 +299,7 @@ public class JSONWriter {
      * @throws JSONException If the number is not finite.
      */
     public JSONWriter value(double d) throws JSONException {
-        return this.value(new Double(d));
+        return this.value(Double.valueOf(d));
     }
 
     /**

--- a/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/corelm/CoreLMPreparationHandlerTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/corelm/CoreLMPreparationHandlerTest.java
@@ -69,8 +69,8 @@ class CoreLMPreparationHandlerTest {
     @Test
     void testPrepareWeightingNo() {
         GraphHopperConfig ghConfig = new GraphHopperConfig();
-        ghConfig.setProfiles(Collections.singletonList(new Profile("profile")));
-        ghConfig.setLMProfiles(Collections.singletonList(new LMProfile("profile")));
+        ghConfig.setProfiles(List.of(new Profile("profile")));
+        ghConfig.setLMProfiles(List.of(new LMProfile("profile")));
         CoreLMPreparationHandler handler = new CoreLMPreparationHandler();
         handler.init(ghConfig);
         assertTrue(handler.isEnabled());


### PR DESCRIPTION
Closes #1319 

### Information about the changes
- Key functionality added: Java was still compiling in Java 8 compatibility mode.
- Reason for change: Use new Java 11 version.
