### PR TITLE
comment out the build from source settings

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,11 +7,11 @@ services:
       - "9001:9001"
     image: openrouteservice/openrouteservice:latest
     user: "${UID:-0}:${GID:-0}"
-    build:
-      context: ../
-      args:
-        ORS_CONFIG: ./openrouteservice/src/main/resources/ors-config-sample.json
-        OSM_FILE: ./openrouteservice/src/main/files/heidelberg.osm.gz
+#    build:
+#      context: ../
+#      args:
+#        ORS_CONFIG: ./openrouteservice/src/main/resources/ors-config-sample.json
+#        OSM_FILE: ./openrouteservice/src/main/files/heidelberg.osm.gz
     volumes:
       - ./graphs:/home/ors/ors-core/data/graphs
       - ./elevation_cache:/home/ors/ors-core/data/elevation_cache


### PR DESCRIPTION
Users are now building from nightly automatically. This is not desired!

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.

Touches #1331

### Information about the changes
- Key functionality added: Right now, when users start the docker-compose stack, they will build from nightly source.
