### PR TITLE
fix(docker): deactivate public transport in ors-config-sample.json

### DIFF
--- a/openrouteservice/src/main/resources/ors-config-sample.json
+++ b/openrouteservice/src/main/resources/ors-config-sample.json
@@ -100,8 +100,7 @@
             "bike-electric",
             "walking",
             "hiking",
-            "wheelchair",
-            "public-transport"
+            "wheelchair"
           ],
           "default_params": {
             "encoder_flags_size": 8,


### PR DESCRIPTION
- Reason for change:
`ors-config-sample.json` is used in the docker setup, GTFS support is not required there.