### PR TITLE
migrate ors to java 17

### DIFF
--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Cache SonarCloud packages
       uses: actions/cache@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ RELEASING:
 - support for API time parameters  ([#1315](https://github.com/GIScience/openrouteservice/pull/1315))
 - upgrade to spring-boot 2.7.9 and dependency alignment for the api-tests [#1310](https://github.com/GIScience/openrouteservice/pull/1310)
 - moved all api tests into `openrouteservice` module [#1352](https://github.com/GIScience/openrouteservice/pull/1352)
+- migrate java from 11 to 17 [#1353](https://github.com/GIScience/openrouteservice/pull/1353)
 
 ### Fixed
 - update docker setup description ([#1326](https://github.com/GIScience/openrouteservice/pull/1326))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image is reused in the workflow builds for master and the latest version
-FROM maven:3.8-jdk-11-slim as base
+FROM maven:3.8-openjdk-17-slim as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -8,8 +8,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 USER root
 
 # Install dependencies and locales
+# hadolint ignore=DL3008
 RUN apt-get update -qq && \
-    apt-get install -qq -y --no-install-recommends nano=5.4-2+deb11u2 moreutils=0.65-1 jq=1.6-2.1 wget=1.21-1+deb11u1 && \
+    apt-get install -qq -y --no-install-recommends nano moreutils jq wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -60,7 +61,7 @@ RUN cp /ors-core/openrouteservice/src/main/resources/ors-config-sample.json /ors
 RUN mvn -f /ors-core/openrouteservice/pom.xml package -DskipTests
 
 # build final image, just copying stuff inside
-FROM adoptopenjdk/openjdk11:jre-11.0.18_10-alpine as publish
+FROM eclipse-temurin:17.0.6_10-jre-alpine as publish
 
 # Build ARGS
 ARG UID=1000
@@ -73,53 +74,19 @@ ENV CATALINA_BASE=${BASE_FOLDER}/tomcat
 ENV CATALINA_HOME=${BASE_FOLDER}/tomcat
 ENV CATALINA_PID=${BASE_FOLDER}/tomcat/temp/tomcat.pid
 
+# Set the default language
+ENV LANG='en_US' LANGUAGE='en_US' LC_ALL='en_US'
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-
-RUN apk add --no-cache bash=~'5.1' openssl=~'1.1'
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# Compile en_US.UTF-8 for alpine
-# hadolint ignore=DL3019,SC2086
-RUN ln -svf /usr/glibc-compat/lib/ld-2.31.so /usr/glibc-compat/lib/ld-linux-x86-64.so.2 && \
-    apk add --no-cache --virtual .build-deps curl binutils && \
-    GLIBC_VER="2.29-r0" && \
-    ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
-    GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" && \
-    GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" && \
-    ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" && \
-    ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 && \
-    curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub && \
-    SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" && \
-    echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - && \
-    curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk && \
-    apk add /tmp/glibc-${GLIBC_VER}.apk && \
-    curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk && \
-    apk add /tmp/glibc-bin-${GLIBC_VER}.apk && \
-    curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk && \
-    apk add /tmp/glibc-i18n-${GLIBC_VER}.apk && \
-    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true && \
-    echo "export LANG=$LANG" > /etc/profile.d/locale.sh && \
-    curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz && \
-    echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - && \
-    mkdir /tmp/gcc && \
-    tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc && \
-    mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib && \
-    strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* && \
-    curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz && \
-    echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - && \
-    mkdir /tmp/libz && \
-    tar -xf /tmp/libz.tar.xz -C /tmp/libz && \
-    mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib && \
-    apk del --purge .build-deps glibc-i18n && \
-    rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/* && \
+# Setup the target system with the right user and folders.
+RUN apk add --no-cache bash=~'5.2' openssl=~'3.0' && \
     addgroup -g ${GID} ors && \
     adduser -D -h ${BASE_FOLDER} -u ${UID} -G ors ors &&  \
     mkdir -p ${BASE_FOLDER}/ors-core/logs/ors ${BASE_FOLDER}/ors-conf ${BASE_FOLDER}/tomcat/logs &&  \
     chown -R ors ${BASE_FOLDER}/tomcat ${BASE_FOLDER}/ors-core/logs/ors ${BASE_FOLDER}/ors-conf ${BASE_FOLDER}/tomcat/logs
+
 WORKDIR ${BASE_FOLDER}
 
+# Copy over the needed bits and pieces from the other stages.
 COPY --chown=ors:ors --from=build /ors-core/openrouteservice/target/ors.war ${BASE_FOLDER}/ors-core/ors.war
 COPY --chown=ors:ors --from=build /ors-core/openrouteservice/src/main/resources/ors-config.json ${BASE_FOLDER}/ors-core/ors-config.json
 COPY --chown=ors:ors --from=tomcat /tmp/tomcat ${BASE_FOLDER}/tomcat

--- a/docs/installation/Building-from-Source.md
+++ b/docs/installation/Building-from-Source.md
@@ -22,7 +22,7 @@ If you need to install without Docker, on an Ubuntu 20.04 system (also generally
       cd openrouteservice
       ```
 
-  2. Make sure that you have java 1.11 set as the default Java environment.
+  2. Make sure that you have java 17 set as the default Java environment.
   3. Make sure that you have Maven installed.
   4. Download/create an OpenStreetMap pbf file on the machine.
   5. Copy the `openrouteservice/src/main/resources/ors-config-sample.json` file to

--- a/docs/installation/Opening-Project-in-IntelliJ.md
+++ b/docs/installation/Opening-Project-in-IntelliJ.md
@@ -14,7 +14,7 @@ Though IntelliJ provides functionality to directly clone a repository, the steps
 5. When you reach a page asking to "choose directories that will be added as project roots", deselect all items and then click Next
 6. When the project has been loaded, you should only see the files that are contained in the root openrouteservice folder and no subdirectories.
 7. Click File -> Project Structure
-8. In the Project tab, select 11 as the Java SDK
+8. In the Project tab, select 17 as the Java SDK
 9. Go to the Modules tab and click the "+" button and then select "Import Module"
 10. Select the openrouteservice folder (not the root one, but the one containing the src folder) and click Next
 11. Select to "Import module from external model" and choose Maven.

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -40,7 +40,7 @@
         <url>https://github.com/GIScience/openrouteservice/issues</url>
     </issueManagement>
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -110,7 +110,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- Java 11 upgrade -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Rewrite some old Java 11 API calls in the ors backend code, migrating them to Java 17 standards.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.

Closes #1347 

### Information about the changes
- Key functionality added: Migration from Java 11 to 17.
- Reason for change: Move to a faster and more recent Java version. Additionally, the first end-of-life for Java 11 was already reached for OpenJDK. Others will follow in the subsequent years.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
