### PR TITLE
Add war deployment check

### DIFF
--- a/.github/utils/health_check.sh
+++ b/.github/utils/health_check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+host=${1}
+port=${2}
+base_path=${3}
+
+wait_for_url() {
+    echo "Waiting for status code 200: $1"
+    # shellcheck disable=SC2016
+    timeout --foreground -s TERM 240s bash -c \
+        'while [[ "$(curl -s -o /dev/null -m 3 -L -w ''%{http_code}'' ${0})" != "200" ]];\
+        do echo "Waiting for ${0}" && sleep 2;\
+        done' "${1}"
+    local TIMEOUT_RETURN="$?"
+    if [[ "${TIMEOUT_RETURN}" == 0 ]]; then
+        echo "OK: ${1}"
+        return
+    elif [[ "${TIMEOUT_RETURN}" == 124 ]]; then
+        echo "TIMEOUT: ${1} -> EXIT"
+        exit "${TIMEOUT_RETURN}"
+    else
+        echo "Other error with code ${TIMEOUT_RETURN}: ${1} -> EXIT"
+        exit "${TIMEOUT_RETURN}"
+    fi
+}
+
+wait_for_url "$host:$port$base_path/v2/health"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   # This way the env variables are accessible in the individual jobs
   prepare_environment:
+    name: Prepare the environment variables
     runs-on: ubuntu-latest
     outputs:
       test_image_name: ${{ env.TEST_IMAGE_NAME }}
@@ -55,6 +56,7 @@ jobs:
           docker run -it -d -p 8080:8080 ${{ needs.prepare_environment.outputs.test_image_name }}
           ./.github/utils/health_check.sh 127.0.0.1 8080 /ors/
   publish_docker:
+    name: Publish the docker image to docker hub
     runs-on: ubuntu-latest
     needs:
       - prepare_environment

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,10 +6,28 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+env:
+  TEST_IMAGE_NAME: 'local/openrouteservice:test'
+  PRODUCTION_IMAGE_NAME: 'openrouteservice/openrouteservice:nightly'
+  BUILD_PLATFORMS: 'linux/amd64'
+
+
 jobs:
-  build_and_publish_docker:
-    name: Build and push the image to docker hub
+  # This way the env variables are accessible in the individual jobs
+  prepare_environment:
     runs-on: ubuntu-latest
+    outputs:
+      test_image_name: ${{ env.TEST_IMAGE_NAME }}
+      production_image_name: ${{ env.PRODUCTION_IMAGE_NAME }}
+      build_platforms: ${{ env.BUILD_PLATFORMS }}
+    steps:
+      - run: |
+          echo "Publish enironment variables"
+  build_docker_and_test_war_deployment:
+    name: Build and check the war deployment stage
+    runs-on: ubuntu-latest
+    needs:
+      - prepare_environment
     steps:
       - name: Checkout
         uses: actions/checkout@v2.2.0
@@ -22,23 +40,37 @@ jobs:
         id: buildx
         with:
           install: true
-      - name: Prepare
-        id: prepare
-        run: |
-          DOCKER_IMAGE=openrouteservice/openrouteservice
-          DOCKER_PLATFORMS=linux/amd64
-          TAGS_NIGHTLY="${DOCKER_IMAGE}:nightly"
-          echo ::set-output name=build_args::--platform ${DOCKER_PLATFORMS}
-          echo ::set-output name=buildx_tags_nightly::${TAGS_NIGHTLY}
-      - name: Build nightly
+      - name: Build image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: false
-          tags: ${{ steps.prepare.outputs.buildx_tags_nightly }}
-          build-args: ${{ steps.prepare.outputs.build_args }}
+          load: true
+          tags: ${{ needs.prepare_environment.outputs.test_image_name }}
+          build-args: "--platform ${{ needs.prepare_environment.outputs.build_platforms }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Start container from image and wait for successful war deployment
+        run: |
+          docker run -it -d -p 8080:8080 ${{ needs.prepare_environment.outputs.test_image_name }}
+          ./.github/utils/health_check.sh 127.0.0.1 8080 /ors/
+  publish_docker:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare_environment
+      - build_docker_and_test_war_deployment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
       - name: Login to DockerHub
         if: ${{ success() && github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v2
@@ -51,7 +83,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.prepare.outputs.buildx_tags_nightly }}
-          build-args: ${{ steps.prepare.outputs.build_args }}
+          tags: ${{ needs.prepare_environment.outputs.production_image_name }}
+          build-args: "--platform ${{ needs.prepare_environment.outputs.build_platforms }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   run_tests:
+    name: Run unit and integration tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Currently, the war deployment is not checked. This starts the container and waits for the health API to indicate the default graph is built and ready.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.

Closes #1355 

### Information about the changes
- Key functionality added: Test for correct war deployment.
