### PR TITLE
Bump spring-boot to 2.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ RELEASING:
 - time-dependent routing with Dijkstra ([#1322](https://github.com/GIScience/openrouteservice/pull/1322))
 - change compile mode from Java 8 to Java 11 and remove old Java 8 API usages ([#1321](https://github.com/GIScience/openrouteservice/pull/1321))
 - support for API time parameters  ([#1315](https://github.com/GIScience/openrouteservice/pull/1315))
+- upgrade spring-boot from 2.7.9 to 2.7.10  ([#1372](https://github.com/GIScience/openrouteservice/pull/1372))
 
 ## [7.0.1] - 2023-03-08
 ### Fixed

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -66,7 +66,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.9</version>
+        <version>2.7.10</version>
     </parent>
     <build>
         <finalName>ors</finalName>


### PR DESCRIPTION
Version 2.7.10 has the option to push snakeyaml to a version that isn't affected by SNYK-JAVA-ORGYAML-2806360.
Fixes #1367  .
