### PR TITLE
build(CI): run tests with pre-built graphs

### DIFF
--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -35,7 +35,9 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Test, build, run API tests
-      run: mvn -B -f openrouteservice/pom.xml verify -Papitests -DCI=true jacoco:report
+      run: mvn -B -f openrouteservice/pom.xml verify -Papitests -DCI=true
+    - name: Run tests with pre-built graphs from previous run
+      run: mvn -B -f openrouteservice/pom.xml verify -Papitests jacoco:report
     - name: run SonarLint checks
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ RELEASING:
 - change compile mode from Java 8 to Java 11 and remove old Java 8 API usages ([#1321](https://github.com/GIScience/openrouteservice/pull/1321))
 - support for API time parameters  ([#1315](https://github.com/GIScience/openrouteservice/pull/1315))
 - upgrade spring-boot from 2.7.9 to 2.7.10  ([#1372](https://github.com/GIScience/openrouteservice/pull/1372))
+- upgrade graphhopper version to v4.4 for correct flushing of graph storages [#1378](https://github.com/GIScience/openrouteservice/pull/1378)
 
 ## [7.0.1] - 2023-03-08
 ### Fixed

--- a/openrouteservice/pom.xml
+++ b/openrouteservice/pom.xml
@@ -367,7 +367,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>v4.3.1</version>
+            <version>v4.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -379,7 +379,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>v4.3.1</version>
+            <version>v4.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -391,7 +391,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>v4.3.1</version>
+            <version>v4.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Currently, tests are only run on the in-memory version of the initial graph building. Correct function after writing graphs to disk and re-loading them is now being tested as well.

### Information about the changes
- Key functionality added: Run the API tests twice to catch errors that only occur on flushing/reloading of the graphs

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
