### PR TITLE
build(ci): suppress kafka related logs

### DIFF
--- a/openrouteservice/src/test/resources/logs/TEST_LOGGING.json
+++ b/openrouteservice/src/test/resources/logs/TEST_LOGGING.json
@@ -7,7 +7,7 @@
       "Console": {
         "name": "stdout",
         "PatternLayout": {
-          "pattern": "%d{dd MMM HH:mm:ss} %p [%c{2}] - %m%n"
+          "pattern": "%d{dd MMM HH:mm:ss} %p [%c{5}] - %m%n"
         }
       },
       "RollingFile": {
@@ -38,6 +38,30 @@
         {
           "name": "org.springframework",
           "level": "warn",
+          "additivity": "false",
+          "AppenderRef": {
+            "ref": "stdout"
+          }
+        },
+        {
+          "name": "org.apache",
+          "level": "error",
+          "additivity": "false",
+          "AppenderRef": {
+            "ref": "stdout"
+          }
+        },
+        {
+          "name": "state.change.logger",
+          "level": "warn",
+          "additivity": "false",
+          "AppenderRef": {
+            "ref": "stdout"
+          }
+        },
+        {
+          "name": "kafka",
+          "level": "error",
           "additivity": "false",
           "AppenderRef": {
             "ref": "stdout"


### PR DESCRIPTION
to unclutter output during ci tests. 

