### PR TITLE
fix (unit tests): Make CountryBordersReaderTest reset state

### DIFF
--- a/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/reader/borders/CountryBordersReader.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/graphhopper/extensions/reader/borders/CountryBordersReader.java
@@ -47,7 +47,8 @@ public class CountryBordersReader {
 
     private final HashMap<Long, CountryBordersHierarchy> hierarchies = new HashMap<>();
 
-    private static CountryBordersReader currentInstance = null;
+    // Package scoped for testing purposes
+    static CountryBordersReader currentInstance = null;
 
     /**
      * Empty constructor which does not read any data - the user must explicitly pass information

--- a/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/reader/borders/CountryBordersReaderTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/routing/graphhopper/extensions/reader/borders/CountryBordersReaderTest.java
@@ -13,6 +13,8 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions.reader.borders;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -20,6 +22,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CountryBordersReaderTest {
+    CountryBordersReader _oldReaderSingleton;
     CountryBordersReader _reader;
 
     CountryBordersHierarchy[] hierarchies;
@@ -54,8 +57,10 @@ class CountryBordersReaderTest {
 
     GeometryFactory gf = new GeometryFactory();
 
-    public CountryBordersReaderTest() {
+    @BeforeEach
+    void prepareCountryBordersReader() {
 
+        _oldReaderSingleton = CountryBordersReader.currentInstance;
         // Construct the objects
         _reader = new CountryBordersReader();
         hierarchies = new CountryBordersHierarchy[2];
@@ -65,19 +70,24 @@ class CountryBordersReaderTest {
             hierarchies[0].add(new CountryBordersPolygon("country1", gf.createPolygon(country1Geom)));
             hierarchies[0].add(new CountryBordersPolygon("country2", gf.createPolygon(country2Geom)));
 
-            _reader.addHierarchy(1l, hierarchies[0]);
+            _reader.addHierarchy(1L, hierarchies[0]);
 
             hierarchies[1] = new CountryBordersHierarchy();
             hierarchies[1].add(new CountryBordersPolygon("country3", gf.createPolygon(country3Geom)));
             hierarchies[1].add(new CountryBordersPolygon("country4", gf.createPolygon(country4Geom)));
 
-            _reader.addHierarchy(2l, hierarchies[1]);
+            _reader.addHierarchy(2L, hierarchies[1]);
         } catch (Exception e) {
             System.out.println(e);
         }
 
         _reader.addOpenBorder("country1", "country2");
         _reader.addId("1", "country1", "country1 English", "CT", "CTR");
+    }
+
+    @AfterEach
+    void resetCountryBordersReader() {
+        CountryBordersReader.currentInstance = _oldReaderSingleton;
     }
 
     /**


### PR DESCRIPTION
## Fixes failure of routing.ResultTest.testCountryExclusion when run in full test suite - and only then.

The root cause is that CountryBordersReader internally uses a singleton.
Never do that! Never do that! Never do that! Never do that! Never do that!
Singletons are bad! Singletons are bad! Singletons are bad! Singletons are bad! Singletons are bad!

The fix does not get rid of the singleton, which would be quite a refactoring. It just resets it to its previous state in the unit test that changes it.