### PR TITLE
fix(github,action): Add missing multiplatform features

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -119,8 +119,12 @@ jobs:
     name: Publish the docker image to docker hub
     runs-on: ubuntu-latest
     needs:
+      - prepare_environment
+      - build_docker_images
       - run_docker_image_tests
     steps:
+      - run: |
+          echo "Publish image ${{ needs.prepare_environment.outputs.production_image_name }}"
       - name: Checkout
         uses: actions/checkout@v2.2.0
         with:

--- a/.github/workflows/publish-tagged-release.yml
+++ b/.github/workflows/publish-tagged-release.yml
@@ -44,7 +44,7 @@ jobs:
           CURRENT_VERSIONS=$(test_version)
           LATEST_IMAGE_VERSION=${{ steps.previoustag.outputs.tag }}
           HIGHEST_IMAGE_VERSION=${{ steps.semvers.outputs.v_mayor }}
-          DOCKER_PLATFORMS=linux/amd64
+          DOCKER_PLATFORMS=linux/amd64,linux/arm64
           BUILD_VERSION=true
 
           TAGS_LATEST_VERSION="${DOCKER_IMAGE}:${LATEST_IMAGE_VERSION}"


### PR DESCRIPTION
When the "prepare_environment" step is not set, the task cannot access the environment variables.
Also the version is not published for all platforms.

Fixes #1408 .

### Information about the changes
- Key functionality added: Add arm64 to tagged docker image releases and fix an enviroment variable bug.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
