### PR TITLE
ci(workflow): Add conventional commit checks

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+#    authors:
+#      - octocat
+  categories:
+    - title: API Breaking Changes 🛠
+      labels:
+        - api-breaking
+    - title: Graph-Building Breaking Changes 🌐
+      labels:
+        - graph-breaking
+    - title: New Features 🎉
+      labels:
+        - feature
+    - title: Fixes 🔧
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/commit-style.yml
+++ b/.github/workflows/commit-style.yml
@@ -1,0 +1,44 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Conventional commit checks
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, reopened, edited, synchronize ]
+
+
+jobs:
+  convention_commit_check:
+    name: Run conventional commit style check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the commit style against the 'conventional commit styling'
+        uses: MichaelsJP/action-conventional-commits@master
+        with:
+          VALID_LABELS: '["feat","fix","docs","style","refactor","test","build","perf","ci","chore","revert","merge","wip"]'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  conventional_commit_pr_title_check:
+    name: Check the PR title against the 'conventional commit styling'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  add_conventional_release_labels:
+    needs:
+      - conventional_commit_pr_title_check
+    name: Add PR title conventional type to PR labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add conventional release labels
+        uses: bcoe/conventional-release-labels@v1.3.0
+        with:
+          type_labels: '{"feat": "feature", "fix": "fix", "docs": "documentation", "style": "style", "refactor": "refactor", "test": "test", "build": "build", "perf": "performance", "ci": "ci", "chore": "chore", "revert": "revert", "merge": "merge", "wip": "wip"}'
+          ignored_types: '["chore"]'
+          ignore_label: 'ignore-for-release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -10,29 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  run_pre_checks:
-    name: Run style and lint checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Check the commit style against the 'conventional commit styling'
-        uses: MichaelsJP/action-conventional-commits@master
-        with:
-          VALID_LABELS: '["feat","fix","docs","style","refactor","test","build","perf","ci","chore","revert","merge","wip","graphbreak", "apigreak"]'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add conventional release labels
-        uses: bcoe/conventional-release-labels@v1.3.0
-        with:
-          type_labels: '{"feat": "feature", "fix": "fix", "graphbreak": "graph-breaking", "apibreak": "api-breaking"}'
-          ignored_types: '["chore"]'
-          ignore_label: 'ignore-for-release'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run_tests:
-    needs:
-      - run_pre_checks
     name: Run unit and integration tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -10,7 +10,29 @@ on:
     branches: [ master ]
 
 jobs:
+  run_pre_checks:
+    name: Run style and lint checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check the commit style against the 'conventional commit styling'
+        uses: MichaelsJP/action-conventional-commits@master
+        with:
+          VALID_LABELS: '["feat","fix","docs","style","refactor","test","build","perf","ci","chore","revert","merge","wip","graphbreak", "apigreak"]'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add conventional release labels
+        uses: bcoe/conventional-release-labels@v1.3.0
+        with:
+          type_labels: '{"feat": "feature", "fix": "fix", "graphbreak": "graph-breaking", "apibreak": "api-breaking"}'
+          ignored_types: '["chore"]'
+          ignore_label: 'ignore-for-release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run_tests:
+    needs:
+      - run_pre_checks
     name: Run unit and integration tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
```yml
- name: Check the commit style against the 'conventional commit styling'
      uses: MichaelsJP/action-conventional-commits@master
      with:
        VALID_LABELS: '["feat","fix","docs","style","refactor","test","build","perf","ci","chore","revert","merge","wip","graphbreak", "apigreak"]'
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
`action-conventional-commits` checks the conventional commit structure and if the used type is in the list of valid labels.
If a commit doesn't qualify for the conventional commit standards, the action will fail and a pretty clear log will show which commit failed.


```yml
- name: Add conventional release labels
  uses: bcoe/conventional-release-labels@v1.3.0
  with:
    type_labels: '{"feat": "feature", "fix": "fix", "graphbreak": "graph-breaking", "apibreak": "api-breaking"}'
    ignored_types: '["chore"]'
    ignore_label: 'ignore-for-release'
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
`conventional-release-labels` additionally checks the title of the PR and if it's in a conventional commit style. If a type is used such as `feat` the PR also gets the label `feature` etc. If a title doesn't fit to the commit style, the action fails.

This action can in the future also be used to create auto-changelogs.