### PR TITLE
fix(matrix-algorithms): Consistent use of maximum visited nodes limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ RELEASING:
 - moved all api tests into `openrouteservice` module [#1352](https://github.com/GIScience/openrouteservice/pull/1352)
 - migrate java from 11 to 17 [#1353](https://github.com/GIScience/openrouteservice/pull/1353)
 - time-dependent core routing algorithms ([#1388](https://github.com/GIScience/openrouteservice/pull/1388))
+### Changed
+- Consistent use of maximum number of visited nodes limit across different matrix algorithms ([#1246](https://github.com/GIScience/openrouteservice/issues/1246))
 ### Fixed
 - certain cases of OSM ways with invalid node refs causing crashes during graph building [#1351](https://github.com/GIScience/openrouteservice/issues/1351)
 - update docker setup description ([#1326](https://github.com/GIScience/openrouteservice/pull/1326))

--- a/openrouteservice/src/main/java/org/heigit/ors/exceptions/MaxVisitedNodesExceededException.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/exceptions/MaxVisitedNodesExceededException.java
@@ -1,0 +1,22 @@
+/*  This file is part of Openrouteservice.
+ *
+ *  Openrouteservice is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+
+ *  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+
+ *  You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, see <https://www.gnu.org/licenses/>.
+ */
+package org.heigit.ors.exceptions;
+
+public class MaxVisitedNodesExceededException extends Exception {
+
+    public MaxVisitedNodesExceededException() {
+        super("Search exceeds the limit of visited nodes.");
+    }
+
+}

--- a/openrouteservice/src/main/java/org/heigit/ors/exceptions/MaxVisitedNodesExceededException.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/exceptions/MaxVisitedNodesExceededException.java
@@ -13,7 +13,7 @@
  */
 package org.heigit.ors.exceptions;
 
-public class MaxVisitedNodesExceededException extends Exception {
+public class MaxVisitedNodesExceededException extends RuntimeException {
 
     public MaxVisitedNodesExceededException() {
         super("Search exceeds the limit of visited nodes.");

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/MatrixErrorCodes.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/MatrixErrorCodes.java
@@ -31,6 +31,7 @@ public class MatrixErrorCodes {
     public static final int EMPTY_ELEMENT = 6008;
     public static final int POINT_NOT_FOUND = 6010;
     public static final int UNKNOWN_PARAMETER = 6011;
+    public static final int MAX_VISITED_NODES_EXCEEDED = 6020;
     public static final int UNKNOWN = 6099;
     private MatrixErrorCodes() {}
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractContractedMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractContractedMatrixAlgorithm.java
@@ -17,6 +17,7 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.RoutingCHGraph;
+import org.heigit.ors.config.MatrixServiceSettings;
 import org.heigit.ors.matrix.MatrixRequest;
 
 public abstract class AbstractContractedMatrixAlgorithm implements ContractedMatrixAlgorithm {
@@ -24,11 +25,13 @@ public abstract class AbstractContractedMatrixAlgorithm implements ContractedMat
     protected RoutingCHGraph chGraph;
     protected FlagEncoder encoder;
     protected Weighting weighting;
+    protected int maxVisitedNodes = Integer.MAX_VALUE;
 
     public void init(MatrixRequest req, GraphHopper gh, RoutingCHGraph chGraph, FlagEncoder encoder, Weighting weighting) {
         graphHopper = gh;
         this.chGraph = chGraph;
         this.encoder = encoder;
         this.weighting = weighting;
+        this.maxVisitedNodes = MatrixServiceSettings.getMaximumVisitedNodes();
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractContractedMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractContractedMatrixAlgorithm.java
@@ -17,21 +17,13 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.RoutingCHGraph;
-import org.heigit.ors.config.MatrixServiceSettings;
 import org.heigit.ors.matrix.MatrixRequest;
 
-public abstract class AbstractContractedMatrixAlgorithm implements ContractedMatrixAlgorithm {
-    protected GraphHopper graphHopper;
+public abstract class AbstractContractedMatrixAlgorithm extends AbstractMatrixAlgorithm {
     protected RoutingCHGraph chGraph;
-    protected FlagEncoder encoder;
-    protected Weighting weighting;
-    protected int maxVisitedNodes = Integer.MAX_VALUE;
 
     public void init(MatrixRequest req, GraphHopper gh, RoutingCHGraph chGraph, FlagEncoder encoder, Weighting weighting) {
-        graphHopper = gh;
+        super.init(req, gh, chGraph.getBaseGraph(), encoder, weighting);
         this.chGraph = chGraph;
-        this.encoder = encoder;
-        this.weighting = weighting;
-        this.maxVisitedNodes = MatrixServiceSettings.getMaximumVisitedNodes();
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractMatrixAlgorithm.java
@@ -18,21 +18,28 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import org.heigit.ors.config.MatrixServiceSettings;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.MatrixRequest;
 
 public abstract class AbstractMatrixAlgorithm implements MatrixAlgorithm {
-  protected GraphHopper graphHopper;
-  protected Graph graph;
-  protected FlagEncoder encoder;
-  protected Weighting weighting;
-  protected int maxVisitedNodes = Integer.MAX_VALUE;
-  
-  public void init(MatrixRequest req, GraphHopper gh, Graph graph, FlagEncoder encoder, Weighting weighting)
-  {
-	  graphHopper = gh;
-	  this.graph = graph;
-	  this.encoder = encoder;
-	  this.weighting = weighting;
-      this.maxVisitedNodes = MatrixServiceSettings.getMaximumVisitedNodes();
-  }
+    protected GraphHopper graphHopper;
+    protected Graph graph;
+    protected FlagEncoder encoder;
+    protected Weighting weighting;
+    protected int visitedNodes = 0;
+    protected int maxVisitedNodes = Integer.MAX_VALUE;
+
+    public void init(MatrixRequest req, GraphHopper gh, Graph graph, FlagEncoder encoder, Weighting weighting) {
+        graphHopper = gh;
+        this.graph = graph;
+        this.encoder = encoder;
+        this.weighting = weighting;
+        this.maxVisitedNodes = MatrixServiceSettings.getMaximumVisitedNodes();
+    }
+
+    protected boolean isMaxVisitedNodesExceeded() {
+        if (visitedNodes > maxVisitedNodes)
+            throw new MaxVisitedNodesExceededException();
+        return false;
+    }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/AbstractMatrixAlgorithm.java
@@ -17,6 +17,7 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
+import org.heigit.ors.config.MatrixServiceSettings;
 import org.heigit.ors.matrix.MatrixRequest;
 
 public abstract class AbstractMatrixAlgorithm implements MatrixAlgorithm {
@@ -24,6 +25,7 @@ public abstract class AbstractMatrixAlgorithm implements MatrixAlgorithm {
   protected Graph graph;
   protected FlagEncoder encoder;
   protected Weighting weighting;
+  protected int maxVisitedNodes = Integer.MAX_VALUE;
   
   public void init(MatrixRequest req, GraphHopper gh, Graph graph, FlagEncoder encoder, Weighting weighting)
   {
@@ -31,5 +33,6 @@ public abstract class AbstractMatrixAlgorithm implements MatrixAlgorithm {
 	  this.graph = graph;
 	  this.encoder = encoder;
 	  this.weighting = weighting;
+      this.maxVisitedNodes = MatrixServiceSettings.getMaximumVisitedNodes();
   }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
@@ -27,7 +27,6 @@ import com.graphhopper.storage.RoutingCHEdgeIterator;
 import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 import com.graphhopper.util.EdgeIterator;
-import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.*;
 import org.heigit.ors.matrix.algorithms.AbstractContractedMatrixAlgorithm;
 import org.heigit.ors.matrix.algorithms.dijkstra.DijkstraManyToMany;
@@ -53,7 +52,6 @@ import static org.heigit.ors.matrix.util.GraphUtils.isCoreNode;
 public class CoreMatrixAlgorithm extends AbstractContractedMatrixAlgorithm {
     protected int coreNodeLevel;
     protected int nodeCount;
-    protected int visitedNodes;
     private int treeEntrySize;
     private boolean hasTurnWeighting = false;
     private boolean swap = false;
@@ -143,9 +141,6 @@ public class CoreMatrixAlgorithm extends AbstractContractedMatrixAlgorithm {
 
             this.additionalCoreEdgeFilter.setInCore(true);
             runPhaseInsideCore();
-
-            if (visitedNodes > maxVisitedNodes)
-                throw new MaxVisitedNodesExceededException();
 
             extractMetrics(srcData, dstData, times, distances, weights);
         }
@@ -493,10 +488,6 @@ public class CoreMatrixAlgorithm extends AbstractContractedMatrixAlgorithm {
 
     public void setMaxVisitedNodes(int numberOfNodes) {
         this.maxVisitedNodes = numberOfNodes;
-    }
-
-    protected boolean isMaxVisitedNodesExceeded() {
-        return this.maxVisitedNodes < this.visitedNodes;
     }
 
     double calcPathWeight(RoutingCHEdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraManyToMany.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraManyToMany.java
@@ -524,11 +524,6 @@ public class DijkstraManyToMany extends AbstractManyToManyRoutingAlgorithm {
     }
 
     @Override
-    protected boolean isMaxVisitedNodesExceeded() {
-        return this.maxVisitedNodes < this.visitedNodes;
-    }
-
-    @Override
     public String getName() {
         return Parameters.Algorithms.DIJKSTRA;
     }

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
@@ -20,7 +20,6 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
-import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.*;
 import org.heigit.ors.matrix.algorithms.AbstractMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.DijkstraOneToManyAlgorithm;
@@ -74,7 +73,7 @@ public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
                     SPTEntry[] targets = algorithm.calcPaths(sourceId, dstData.getNodeIds());
 
                     if (algorithm.getFoundTargets() != algorithm.getTargetsCount())
-                        throw new MaxVisitedNodesExceededException();
+                        throw new Exception("Some target nodes could not be found.");
 
                     if (targets != null) {
                         pathMetricsExtractor.calcValues(srcIndex, targets, dstData, times, distances, weights);

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
@@ -20,7 +20,7 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
-import org.heigit.ors.config.MatrixServiceSettings;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.*;
 import org.heigit.ors.matrix.algorithms.AbstractMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.DijkstraOneToManyAlgorithm;
@@ -60,7 +60,7 @@ public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
             //TODO Refactoring : Check whether this access filter is unnecessary
             algorithm.setEdgeFilter(AccessFilter.allEdges(this.encoder.getAccessEnc()));
             algorithm.prepare(srcData.getNodeIds(), dstData.getNodeIds());
-            algorithm.setMaxVisitedNodes(MatrixServiceSettings.getMaximumVisitedNodes());
+            algorithm.setMaxVisitedNodes(this.maxVisitedNodes);
 
             int sourceId = -1;
 
@@ -74,7 +74,7 @@ public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
                     SPTEntry[] targets = algorithm.calcPaths(sourceId, dstData.getNodeIds());
 
                     if (algorithm.getFoundTargets() != algorithm.getTargetsCount())
-                        throw new Exception("Search exceeds the limit of visited nodes.");
+                        throw new MaxVisitedNodesExceededException();
 
                     if (targets != null) {
                         pathMetricsExtractor.calcValues(srcIndex, targets, dstData, times, distances, weights);

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
@@ -18,6 +18,7 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.RoutingCHGraph;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.*;
 import org.heigit.ors.matrix.algorithms.AbstractMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.RPHASTAlgorithm;
@@ -61,6 +62,7 @@ public class RPHASTMatrixAlgorithm extends AbstractMatrixAlgorithm {
                 pathMetricsExtractor.setEmptyValues(srcIndex, dstData, times, distances, weights);
         } else {
             RPHASTAlgorithm algorithm = new RPHASTAlgorithm(chGraph, chGraph.getWeighting(), TraversalMode.NODE_BASED);
+            algorithm.setMaxVisitedNodes(this.maxVisitedNodes);
 
             int[] srcIds = getValidNodeIds(srcData.getNodeIds());
             int[] destIds = getValidNodeIds(dstData.getNodeIds());
@@ -71,6 +73,9 @@ public class RPHASTMatrixAlgorithm extends AbstractMatrixAlgorithm {
             algorithm.prepare(srcIds, destIds);
 
             MultiTreeSPEntry[] destTrees = algorithm.calcPaths(srcIds, destIds);
+
+            if (algorithm.getVisitedNodes() > maxVisitedNodes)
+                throw new MaxVisitedNodesExceededException();
 
             MultiTreeSPEntry[] originalDestTrees = new MultiTreeSPEntry[dstData.size()];
 

--- a/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
@@ -18,7 +18,6 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.RoutingCHGraph;
-import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.matrix.*;
 import org.heigit.ors.matrix.algorithms.AbstractMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.RPHASTAlgorithm;
@@ -73,9 +72,6 @@ public class RPHASTMatrixAlgorithm extends AbstractMatrixAlgorithm {
             algorithm.prepare(srcIds, destIds);
 
             MultiTreeSPEntry[] destTrees = algorithm.calcPaths(srcIds, destIds);
-
-            if (algorithm.getVisitedNodes() > maxVisitedNodes)
-                throw new MaxVisitedNodesExceededException();
 
             MultiTreeSPEntry[] originalDestTrees = new MultiTreeSPEntry[dstData.size()];
 

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -31,6 +31,7 @@ import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
 import com.typesafe.config.Config;
+import org.heigit.ors.exceptions.*;
 import org.locationtech.jts.geom.Coordinate;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -44,9 +45,6 @@ import org.heigit.ors.common.Pair;
 import org.heigit.ors.config.AppConfig;
 import org.heigit.ors.config.IsochronesServiceSettings;
 import org.heigit.ors.config.MatrixServiceSettings;
-import org.heigit.ors.exceptions.IncompatibleParameterException;
-import org.heigit.ors.exceptions.InternalServerException;
-import org.heigit.ors.exceptions.PointNotFoundException;
 import org.heigit.ors.export.ExportRequest;
 import org.heigit.ors.export.ExportResult;
 import org.heigit.ors.export.ExportWarning;
@@ -715,6 +713,8 @@ public class RoutingProfile {
             }
         } catch (PointNotFoundException e) {
             throw e;
+        } catch (MaxVisitedNodesExceededException e) {
+            throw new InternalServerException(MatrixErrorCodes.MAX_VISITED_NODES_EXCEEDED, "Unable to compute a distance/duration matrix: " + e.getMessage());
         } catch (Exception ex) {
             throw new InternalServerException(MatrixErrorCodes.UNKNOWN, "Unable to compute a distance/duration matrix: " + ex.getMessage());
         }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/AbstractManyToManyRoutingAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/AbstractManyToManyRoutingAlgorithm.java
@@ -18,6 +18,7 @@ import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import org.heigit.ors.config.MatrixServiceSettings;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 
 public abstract class AbstractManyToManyRoutingAlgorithm implements ManyToManyRoutingAlgorithm {
     protected final RoutingCHGraph graph;
@@ -91,6 +92,8 @@ public abstract class AbstractManyToManyRoutingAlgorithm implements ManyToManyRo
     }
 
     protected boolean isMaxVisitedNodesExceeded() {
-        return maxVisitedNodes < getVisitedNodes();
+        if (getVisitedNodes() > maxVisitedNodes)
+            throw new MaxVisitedNodesExceededException();
+        return false;
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/AbstractOneToManyRoutingAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/AbstractOneToManyRoutingAlgorithm.java
@@ -23,6 +23,7 @@ import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.routing.SPTEntry;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 
 public abstract class AbstractOneToManyRoutingAlgorithm implements OneToManyRoutingAlgorithm {
     protected final Graph graph;
@@ -79,6 +80,8 @@ public abstract class AbstractOneToManyRoutingAlgorithm implements OneToManyRout
     }
 
     protected boolean isMaxVisitedNodesExceeded() {
-        return maxVisitedNodes < getVisitedNodes();
+        if (getVisitedNodes() > maxVisitedNodes)
+            throw new MaxVisitedNodesExceededException();
+        return false;
     }
 }

--- a/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
+++ b/openrouteservice/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
@@ -54,7 +54,6 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
         int size = Math.min(Math.max(200, graph.getNodes() / 10), 2000);
 
         initCollections(size);
-        setMaxVisitedNodes(Integer.MAX_VALUE);
         FlagEncoder encoder = weighting.getFlagEncoder();
 
         upwardEdgeFilter = new UpwardSearchEdgeFilter(graph, encoder);
@@ -119,7 +118,7 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
     }
 
     protected void runDownwardSearch() {
-        while (!finishedTo) {
+        while (!isMaxVisitedNodesExceeded() && !finishedTo) {
             finishedTo = !downwardSearch();
         }
     }

--- a/openrouteservice/src/test/java/org/heigit/ors/apitests/matrix/ResultTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/apitests/matrix/ResultTest.java
@@ -28,100 +28,97 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.config.JsonConfig.jsonConfig;
 import static org.hamcrest.Matchers.*;
 import static org.heigit.ors.apitests.utils.CommonHeaders.jsonContent;
+import static org.heigit.ors.matrix.MatrixErrorCodes.*;
 
 @EndPointAnnotation(name = "matrix")
 @VersionAnnotation(version = "v2")
 class ResultTest extends ServiceTest {
     public static final RestAssuredConfig JSON_CONFIG_DOUBLE_NUMBERS = RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE));
     public ResultTest() {
-        // Locations
-        JSONArray coordsShort = new JSONArray();
+        // Three locations
+        JSONArray locations3 = new JSONArray();
         JSONArray coord1 = new JSONArray();
         coord1.put(8.681495);
         coord1.put(49.41461);
-        coordsShort.put(coord1);
+        locations3.put(coord1);
         JSONArray coord2 = new JSONArray();
         coord2.put(8.686507);
         coord2.put(49.41943);
-        coordsShort.put(coord2);
+        locations3.put(coord2);
         JSONArray coord3 = new JSONArray();
         coord3.put(8.687872);
         coord3.put(49.420318);
-        coordsShort.put(coord3);
-        addParameter("locations", coordsShort);
-        JSONArray locationsLong = new JSONArray();
-        coord1 = new JSONArray();
-        coord1.put(8.681495);
-        coord1.put(49.41461);
-        locationsLong.put(coord1);
-        coord2 = new JSONArray();
-        coord2.put(8.686507);
-        coord2.put(49.41943);
-        locationsLong.put(coord2);
-        coord3 = new JSONArray();
-        coord3.put(8.687872);
-        coord3.put(49.420318);
-        locationsLong.put(coord3);
-        JSONArray coord4 = new JSONArray();
-        coord4.put(8.787872);
-        coord4.put(49.620318);
-        locationsLong.put(coord3);
-        addParameter("locationsLong", locationsLong);
+        locations3.put(coord3);
+        addParameter("locations", locations3);
 
+        // Four locations: the three original ones with the last one repeated (?)
+        JSONArray locations4 = new JSONArray();
+        locations4.put(coord1);
+        locations4.put(coord2);
+        locations4.put(coord3);
+        locations4.put(coord3);
+        addParameter("locationsLong", locations4);
+
+        // Just two locations
+        JSONArray locations2 = new JSONArray();
+        JSONArray coord10 = new JSONArray();
+        coord10.put(8.684081);
+        coord10.put(49.398155);
+        locations2.put(coord10);
+        JSONArray coord11 = new JSONArray();
+        coord11.put(8.684703);
+        coord11.put(49.397359);
+        locations2.put(coord11);
+        addParameter("locations2", locations2);
+
+        // Five new locations + all of the above ones
         JSONArray locations5 = new JSONArray();
-        coord1 = new JSONArray();
-        coord1.put(8.684682);
-        coord1.put(49.401961);
-        locations5.put(coord1);
-        coord2 = new JSONArray();
-        coord2.put(8.690518);
-        coord2.put(49.405326);
-        locations5.put(coord2);
-        coord3 = new JSONArray();
-        coord3.put(8.690915);
-        coord3.put(49.430117);
-        locations5.put(coord3);
-        coord4 = new JSONArray();
-        coord4.put(8.68834);
-        coord4.put(49.427758);
-        locations5.put(coord4);
         JSONArray coord5 = new JSONArray();
-        coord5.put(8.687525);
-        coord5.put(49.405437);
+        coord5.put(8.684682);
+        coord5.put(49.401961);
         locations5.put(coord5);
-
+        JSONArray coord6 = new JSONArray();
+        coord6.put(8.690518);
+        coord6.put(49.405326);
+        locations5.put(coord6);
+        JSONArray coord7 = new JSONArray();
+        coord7.put(8.690915);
+        coord7.put(49.430117);
+        locations5.put(coord7);
+        JSONArray coord8 = new JSONArray();
+        coord8.put(8.68834);
+        coord8.put(49.427758);
+        locations5.put(coord8);
+        JSONArray coord9 = new JSONArray();
+        coord9.put(8.687525);
+        coord9.put(49.405437);
+        locations5.put(coord9);
+        locations5.put(coord1);
+        locations5.put(coord2);
+        locations5.put(coord3);
+        locations5.put(coord10);
+        locations5.put(coord11);
         addParameter("locations5", locations5);
 
-        JSONArray locations6 = new JSONArray();
-        coord1 = new JSONArray();
-        coord1.put(8.684081);
-        coord1.put(49.398155);
-        locations6.put(coord1);
-        coord2 = new JSONArray();
-        coord2.put(8.684703);
-        coord2.put(49.397359);
-        locations6.put(coord2);
-
-        addParameter("locations6", locations6);
-
-        JSONArray locations7 = new JSONArray();
-        coord1 = new JSONArray();
-        coord1.put(8.703320316580971);
-        coord1.put(49.43318333640056);
-        locations7.put(coord1);
-        coord2 = new JSONArray();
-        coord2.put(8.687654576684464);
-        coord2.put(49.424556390630144);
-        locations7.put(coord2);
-        coord3 = new JSONArray();
-        coord3.put(8.720827102661133);
-        coord3.put(49.450717967273356);
-        locations7.put(coord3);
-        coord4 = new JSONArray();
-        coord4.put(8.708810806274414);
-        coord4.put(49.45122015291216);
-        locations7.put(coord4);
-        addParameter("locations7", locations7);
+        // Locations for testing core matrix
+        JSONArray locationsCore = new JSONArray();
+        JSONArray coord1c = new JSONArray();
+        coord1c.put(8.703320316580971);
+        coord1c.put(49.43318333640056);
+        locationsCore.put(coord1c);
+        JSONArray coord2c = new JSONArray();
+        coord2c.put(8.687654576684464);
+        coord2c.put(49.424556390630144);
+        locationsCore.put(coord2c);
+        JSONArray coord3c = new JSONArray();
+        coord3c.put(8.720827102661133);
+        coord3c.put(49.450717967273356);
+        locationsCore.put(coord3c);
+        JSONArray coord4c = new JSONArray();
+        coord4c.put(8.708810806274414);
+        coord4c.put(49.45122015291216);
+        locationsCore.put(coord4c);
+        addParameter("locationsCore", locationsCore);
 
         // Fake array to test maximum exceedings
         JSONArray maximumLocations = HelperFunctions.fakeJSONLocations(101);
@@ -880,7 +877,7 @@ class ResultTest extends ServiceTest {
     void expectTurnRestrictionDurations() {
         JSONObject body = new JSONObject();
         JSONObject options = new JSONObject();
-        body.put("locations", getParameter("locations6"));
+        body.put("locations", getParameter("locations2"));
         body.put("resolve_locations", true);
         body.put("metrics", getParameter("metricsDuration"));
         body.put("options", options.put("dynamic_speeds", true));// enforce use of CALT over CH
@@ -909,7 +906,7 @@ class ResultTest extends ServiceTest {
     void testCrossVirtualNode() {
         JSONObject body = new JSONObject();
         JSONObject options = new JSONObject();
-        body.put("locations", getParameter("locations7"));
+        body.put("locations", getParameter("locationsCore"));
         body.put("resolve_locations", true);
         body.put("metrics", getParameter("metricsDuration"));
         body.put("options", options.put("dynamic_speeds", true));// enforce use of CALT over CH
@@ -944,5 +941,21 @@ class ResultTest extends ServiceTest {
                 .body("durations[3][2]", is(closeTo(210.8f, 1.0f)))
                 .body("durations[3][3]", is(closeTo(0.0f, 1.0f)))
                 .statusCode(200);
+    }
+
+    @Test
+    void expectMaxVisitedNodesExceededError() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations5"));
+        given()
+                .headers(jsonContent)
+                .pathParam("profile", getParameter("cyclingProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then()
+                .assertThat()
+                .body("error.code", is(MAX_VISITED_NODES_EXCEEDED))
+                .statusCode(500);
     }
 }

--- a/openrouteservice/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
+++ b/openrouteservice/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
@@ -8,6 +8,7 @@ import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 import org.heigit.ors.routing.algorithms.RPHASTAlgorithm;
 import org.heigit.ors.routing.graphhopper.extensions.storages.MultiTreeSPEntry;
 import org.heigit.ors.util.DebugUtility;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RPHASTMatrixTest {
     private final CarFlagEncoder carEncoder = new CarFlagEncoder().setSpeedTwoDirections(true);
@@ -139,6 +141,19 @@ class RPHASTMatrixTest {
                 assertEquals(expected[i * 9 + j], destTrees[j].getItem(i).getWeight(), 1e-6);
             }
         }
+    }
+
+    @Test
+    void testMaxVisitedNodesExceededException() {
+        ToyGraphCreationUtil.createMediumGraph(g, encodingManager);
+        PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
+        prepare.doWork();
+        RPHASTAlgorithm algorithm = new RPHASTAlgorithm(routingCHGraph, weighting, TraversalMode.NODE_BASED);
+        int[] srcIds = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8};
+        int[] dstIds = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8};
+        algorithm.prepare(srcIds, dstIds);
+        algorithm.setMaxVisitedNodes(33);
+        assertThrows(MaxVisitedNodesExceededException.class, () -> algorithm.calcPaths(srcIds, dstIds));
     }
 
 

--- a/openrouteservice/src/test/resources/ors-config.json
+++ b/openrouteservice/src/test/resources/ors-config.json
@@ -38,7 +38,7 @@
       "matrix": {
         "enabled": true,
         "maximum_routes": 200,
-        "maximum_visited_nodes": 100000,
+        "maximum_visited_nodes": 50000,
         "allow_resolve_locations": true,
         "attribution": "openrouteservice.org, OpenStreetMap contributors"
       },


### PR DESCRIPTION
Apply the limit on the number of visited nodes which is specified in the config file to all matrix algorithms.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1246.

### Information about the changes
- Key functionality added: Enforce `maximum_visited_nodes` limit specified in the config file.

- Reason for change: The limit was not respected at all by **RPHAST** matrix algorithm, and not handled properly by **CoreMatrix** either.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request

Some more complex long-distance matrix queries computed with either RPHAST or CoreMatrix which have been working before might start failing with the following error:
```
Unable to compute a distance/duration matrix: Search exceeds the limit of visited nodes.
```

This can be circumvented by increasing the `maximum_visited_nodes` limit if server resources allow it.

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
