### PR TITLE
ci(cve): Scan the war and docker images with grype

### DIFF
--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -1,0 +1,110 @@
+name: "Vulnerability scan"
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    branches: [ "master", "main" ]
+  schedule:
+    - cron: '0 0 * * MON'
+
+permissions:
+  contents: read
+
+jobs:
+  Anchore-War-Build-Scan:
+    name: Analyze maven war file with Grype
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build war file
+        run: |
+          mvn -B -f openrouteservice/pom.xml package -DskipTests -DCI=true
+          # Copy the .war file to a custom location where grype can find it
+          mkdir -p openrouteservice/target/grype
+          cp openrouteservice/target/ors.war openrouteservice/target/grype/ors.war
+      - name: Run the Anchore Grype scan action to console
+        uses: anchore/scan-action@v3
+        with:
+          path: "openrouteservice/target/grype/"
+          fail-build: false
+          output-format: table
+      - name: Run the Anchore Grype scan action to SARIF
+        uses: anchore/scan-action@v3
+        id: scan
+        with:
+          path: "openrouteservice/target/grype/"
+          fail-build: false
+          output-format: sarif
+      - name: Upload vulnerability report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: Grype-War-Scan
+  Anchore-Docker-Image-Scan:
+    name: Analyze Docker Image for Vulnerabilities with Grype
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+      - name: Build image for platforms linux/amd64,linux/arm64
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          load: true
+          tags: local/openrouteservice:test
+          build-args: "--platform linux/amd64,linux/arm64"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run the Anchore Grype scan action to console
+        uses: anchore/scan-action@v3
+        with:
+          image: local/openrouteservice:test
+          fail-build: false
+          output-format: table
+      - name: Run the Anchore Grype scan action to SARIF
+        uses: anchore/scan-action@v3
+        id: scan
+        with:
+          image: local/openrouteservice:test
+          fail-build: false
+          output-format: sarif
+      - name: Upload vulnerability report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: Grype-Docker-Image


### PR DESCRIPTION
This PR introduces grype as another vulnerability check, next to Snyk. It's being implemented as an informational action right now. It's not as convenient as Snyk, but it seems as it's used frequently in the corporate world. Part of the reasons are, it's open source and way more picky in terms of what is being reported and what not.

The check is executed as the following action:

```yml
- name: Run the Anchore Grype scan action to SARIF
  uses: anchore/scan-action@v3
  id: scan
  with:
    fail-build: false
    output-format: sarif
```
There are two checks now with that action that check for the _docker image_ as well as for the _war file_.

The results are first printed to the runner's log and as well uploaded as a SARIF file with `github/codeql-action`. The results of the SARIF file can then be viewed in the code scanning GitHub overview:

https://github.com/GIScience/openrouteservice/security/code-scanning?query=pr%3A1432+tool%3AGrype+is%3Aopen

Additionally, it runs each Sunday at 00:00 am. 

The goal for now is to just inform us of detected vulnerabilities to be able to react in time.
