### PR TITLE
ci(docker): Fix the docker build github workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,6 +2,7 @@ name: Build and publish the nightly Docker image
 on:
   pull_request:
     branches: [ master ]
+    types: [ opened, synchronize, ready_for_review ]
   push:
     branches: [ master ]
   workflow_dispatch:
@@ -9,7 +10,7 @@ on:
 env:
   TEST_IMAGE_NAME: 'local/openrouteservice:test'
   PRODUCTION_IMAGE_NAME: 'openrouteservice/openrouteservice:nightly'
-  BUILD_PLATFORMS: 'linux/amd64,linux/arm64'
+  BUILD_PLATFORMS: 'linux/amd64,linux/arm64/v8'
 
 
 jobs:
@@ -47,33 +48,45 @@ jobs:
           context: .
           push: false
           load: false
-          tags: ${{ needs.prepare_environment.outputs.test_image_name }}
-          build-args: "--platform ${{ needs.prepare_environment.outputs.build_platforms }}"
+          tags: ${{ needs.prepare_environment.outputs.test_image_name }}, ${{ needs.prepare_environment.outputs.production_image_name }}
+          platforms: "${{ needs.prepare_environment.outputs.build_platforms }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
   run_docker_image_tests:
-    name: Run & test ${{ matrix.arch }}
-    runs-on: ubuntu-latest
+    name: Run & test ${{ matrix.platform }}
+    runs-on: ${{ matrix.image }}
     needs:
       - prepare_environment
       - build_docker_images
     strategy:
       matrix:
-        include:
-          - arch: amd64
-            platform: linux/amd64
-            image: ubuntu-latest
-          - arch: arm64
-            platform: linux/arm64
-            image: ubuntu-latest
+        platform: [ linux/amd64,linux/arm64/v8 ]
+        image: [ ubuntu-latest ]
+        # linux/arm64/v8 is emulated with qemu and takes ages to build the graph.
+        # Only run linux/arm64/v8 tests on ready PR and master.
+        isDraftPR:
+          - ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
+        exclude:
+          - isDraftPR: true
+            platform: linux/arm64/v8
     steps:
       - run: |
-          echo "Run docker test for platform ${{ matrix.arch }}"
+          echo "Run docker test for platform ${{ matrix.platform }}"
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up QEMU for ${{ matrix.arch }}
+      - name: Set the wait time for arm64
+        run: |
+          if [[ "${{ matrix.platform }}" == 'linux/arm64/v8' ]]; then
+            # arm64 is emulated and takes longer to build the graph
+            echo "Set HEALTH_WAIT_TIME to 600 for arm64"
+            echo "HEALTH_WAIT_TIME=600" >> $GITHUB_ENV
+          else
+            echo "Set HEALTH_WAIT_TIME to 260 for non-arm64"
+            echo "HEALTH_WAIT_TIME=260" >> $GITHUB_ENV
+          fi
+      - name: Set up QEMU for ${{ matrix.platform }}
         uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.platform }}
@@ -94,16 +107,15 @@ jobs:
           push: false
           load: true
           tags: ${{ needs.prepare_environment.outputs.test_image_name }}
-          build-args: "--platform ${{ matrix.platform }}"
+          platforms: "${{ matrix.platform }}"
           cache-from: type=gha
-          cache-to: type=gha,mode=max
       - name: Start container from previously build image and wait for successful checks
         run: |
           mkdir $(pwd)/graphs $(pwd)/conf
           sudo chown 1000:1000 $(pwd)/graphs $(pwd)/conf
           docker run -it -d -p 8080:8080 -v $(pwd)/graphs:/home/ors/ors-core/data/graphs -v $(pwd)/conf:/home/ors/ors-conf --name ors-instance ${{ needs.prepare_environment.outputs.test_image_name }}
-          # Check for health to turn 200 after the graphs are build and spring-boot completely started         
-          ./.github/utils/url_check.sh 127.0.0.1 8080 /ors/v2/health 200 240
+          # Check for health to turn 200 after the graphs are build and spring-boot completely started
+          ./.github/utils/url_check.sh 127.0.0.1 8080 /ors/v2/health 200 ${{ env.HEALTH_WAIT_TIME }}
           # Check for correct preflight settings to avoid CORS issues with ORIGIN wildcard from the example config
           ./.github/utils/cors_check.sh 127.0.0.1 8080 /ors/v2/isochrones/geojson "https://example.org" 200 10
           ./.github/utils/cors_check.sh 127.0.0.1 8080 /ors/v2/isochrones/geojson "https://example.com" 200 10
@@ -149,6 +161,5 @@ jobs:
           context: .
           push: true
           tags: ${{ needs.prepare_environment.outputs.production_image_name }}
-          build-args: "--platform ${{ needs.prepare_environment.outputs.build_platforms }}"
+          platforms: "${{ needs.prepare_environment.outputs.build_platforms }}"
           cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-tagged-release.yml
+++ b/.github/workflows/publish-tagged-release.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
           echo ::set-output name=build_version::${BUILD_VERSION}
-          echo ::set-output name=build_args::--platform ${DOCKER_PLATFORMS}
+          echo ::set-output name=build_platforms::${DOCKER_PLATFORMS}
             echo ::set-output name=buildx_tags_version::${TAGS_LATEST_VERSION}
           echo ::set-output name=buildx_tags_latest::${TAGS_LATEST}
       - name: Login to DockerHub
@@ -80,6 +80,6 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.prepare.outputs.buildx_tags_version }},${{ steps.prepare.outputs.buildx_tags_latest }}
-          build-args: ${{ steps.prepare.outputs.build_args }}
+          platforms: ${{ steps.prepare.outputs.build_platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -5,7 +5,10 @@ on:
     branches: [ "master", "main" ]
   pull_request:
     branches: [ "master", "main" ]
-    types: [ opened, synchronize, ready_for_review ]
+    paths:
+      - pom.xml
+      - '**/pom.xml'
+      - Dockerfile
   schedule:
     - cron: '0 0 * * MON'
 

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -5,15 +5,27 @@ on:
     branches: [ "master", "main" ]
   pull_request:
     branches: [ "master", "main" ]
+    types: [ opened, synchronize, ready_for_review ]
   schedule:
     - cron: '0 0 * * MON'
 
 permissions:
   contents: read
 
+env:
+  TEST_IMAGE_NAME: 'local/openrouteservice:test'
+
 jobs:
+  prepare_environment:
+    name: Prepare the environment variables
+    runs-on: ubuntu-latest
+    outputs:
+      test_image_name: ${{ env.TEST_IMAGE_NAME }}
+    steps:
+      - run: |
+          echo "Publish environment variables"
   Anchore-War-Build-Scan:
-    name: Analyze maven war file with Grype
+    name: Grype scan war file
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -61,50 +73,61 @@ jobs:
           sarif_file: ${{ steps.scan.outputs.sarif }}
           category: Grype-War-Scan
   Anchore-Docker-Image-Scan:
-    name: Analyze Docker Image for Vulnerabilities with Grype
-    runs-on: ubuntu-latest
+    name: Grype scan ${{ matrix.platform }} image
+    runs-on: ${{ matrix.image }}
+    needs:
+      - prepare_environment
     permissions:
       actions: read
       contents: read
       security-events: write
+    strategy:
+      matrix:
+        platform: [ linux/amd64,linux/arm64/v8 ]
+        image: [ ubuntu-latest ]
+        # linux/arm64/v8 is emulated with qemu and takes ages to build the graph.
+        # Only run linux/arm64/v8 tests on ready PR and master.
+        isDraftPR:
+          - ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
+        exclude:
+          - isDraftPR: true
+            platform: linux/arm64/v8
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up QEMU
+      - name: Set up QEMU for ${{ matrix.platform }}
         uses: docker/setup-qemu-action@v2
+        with:
+          platforms: ${{ matrix.platform }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         id: buildx
         with:
           install: true
-      - name: Build image for platforms linux/amd64,linux/arm64
+      - name: Build image for ${{ matrix.platform }}
         uses: docker/build-push-action@v4
         with:
           context: .
           push: false
           load: true
-          tags: local/openrouteservice:test
-          build-args: "--platform linux/amd64,linux/arm64"
+          tags: ${{ needs.prepare_environment.outputs.test_image_name }}
+          platforms: ${{ matrix.platform }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
       - name: Run the Anchore Grype scan action to console
         uses: anchore/scan-action@v3
         with:
-          image: local/openrouteservice:test
+          image: ${{ needs.prepare_environment.outputs.test_image_name }}
           fail-build: false
           output-format: table
       - name: Run the Anchore Grype scan action to SARIF
         uses: anchore/scan-action@v3
         id: scan
         with:
-          image: local/openrouteservice:test
+          image: ${{ needs.prepare_environment.outputs.test_image_name }}
           fail-build: false
           output-format: sarif
       - name: Upload vulnerability report
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-          category: Grype-Docker-Image
+          category: Grype-Docker-Image-${{ matrix.platform }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN cp /ors-core/openrouteservice/src/main/resources/ors-config-sample.json /ors
 RUN mvn -f /ors-core/openrouteservice/pom.xml package -DskipTests
 
 # build final image, just copying stuff inside
-FROM eclipse-temurin:17.0.7_7-jre-alpine as publish
+FROM amazoncorretto:17.0.7-alpine3.17 as publish
 
 # Build ARGS
 ARG UID=1000


### PR DESCRIPTION
Currently, the workflow doesn't seem to correctly build for arm64 platforms.

The current base image doesn't support arm64 so we need to take another one.
`amazoncorretto:17.0.7-alpine3.17` is the only major java build that supports alpine and arm64. To keep vulnerabilities low we should stick to this. Any debian/ubuntu-based images are just full to the top with CVEs.

Partially fixes #1338  .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
