### PR TITLE
ci: disable rpm build on pull

### DIFF
--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -5,8 +5,6 @@ on:
  #   types:
   #    - created
   workflow_dispatch:
-  pull_request:
-    branches: [ master ]
 
 env:
   HEALTH_WAIT_TIME: 200


### PR DESCRIPTION
### Information about the changes
- Reason for change:
workflow accidentally contained "on pull_request" 