### PR TITLE
perf(isochrones): Increase edge splitting threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ RELEASING:
 - cleanup StatusCodeCaptureWrapper class ([#1504](https://github.com/GIScience/openrouteservice/pull/1504))
 - spring-boot-starter-parent to v3.1.1 ([#1504](https://github.com/GIScience/openrouteservice/pull/1504))
 - from springdoc-openapi-ui package to springdoc-openapi-starter-webmvc-ui ([#1504](https://github.com/GIScience/openrouteservice/pull/1504))
+- increase edge splitting threshold for generating isochrones ([#1508](https://github.com/GIScience/openrouteservice/pull/1508))
 
 ### Removed
 - dependency on apache-curator ([#1496](https://github.com/GIScience/openrouteservice/issues/1496))

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ResultTest.java
@@ -393,7 +393,7 @@ class ResultTest extends ServiceTest {
                 .body("features[2].type", is("Feature"))
                 .body("features[2].geometry.type", is("Polygon"))
                 //.body("features[2].geometry.coordinates[0].size()", is(26))
-                .body("features[2].geometry.coordinates[0].size()", is(both(greaterThan(38)).and(lessThan(40))))
+                .body("features[2].geometry.coordinates[0].size()", is(both(greaterThan(39)).and(lessThan(41))))
                 .body("features[2].properties.contours.size()", is(2))
                 .body("features[2].properties.containsKey('area')", is(true))
                 //.body("features[2].properties.area", is(5824280.5f))

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -384,7 +384,7 @@ public class ConcaveBallsIsochroneMapBuilder implements IsochroneMapBuilder {
         int nodeId;
         int edgeId;
 
-        int minSplitLength = 20;
+        int minSplitLength = 200;
         int maxSplitLength = 20000;
         StopWatch sw = new StopWatch();
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- **Key functionality added:** 2x speedup of isochrone generation time.

- **Reason for change:** Setting the threshold for edge splitting to a low value slows down isochrone generation because of the increased amount of points which need to be processed when calculating the geometry. Initial benchmarks have revealed that increasing the current threshold of 20m to 200m yields acceptable results while drastically improving performance.

The edge splitting threshold has been verified by running some benchmark and assessing the results both in terms of performance and visual aspects of the generated geometries. All files are available on [GitLab](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/benchmarks/-/tree/master/isochrones), while the resulting report can be viewed at [RPubs](https://rpubs.com/aoles/isochrones_edge_splitting).

The benchmark consisted of performing 10 isochrone queries for the car profile at 10 random locations within the DACH region. Each query requested a 60min isochrone split into 20min ranges. First, the cumulative distribution of edge distances have been gathered. This revealed that for the original threshold of 20m almost 70% of edges get split. Increasing this value 10-fold reduces the amount of splitted edges to 5% as illustrated by the following figure.
![image](https://github.com/GIScience/openrouteservice/assets/6545356/810274e7-0e41-4179-ba1c-2efd177c2a03)

Then three scenarios have been evaluated: the original splitting of edges into 20m segments, splitting into 200m segments, and not doing any splitting at all. While the original 20m splitting introduces a significant 2-3x performance penalty, splitting based on 200m threshold is only 20% slower compared to no splitting. 
![image](https://github.com/GIScience/openrouteservice/assets/6545356/962c4b5c-a33d-4e60-b431-663e2a27e3ec)

Not splitting long edges may occasionally introduce weird geometrical artifacts. The following figure compares an isochrone without edge splitting (red) to one calculated with 20m splitting.
![image](https://github.com/GIScience/openrouteservice/assets/6545356/9949010e-29fa-4716-8fb8-be7595f01815)

These issues are mostly resolved with the 200m threshold while keeping the computation time low.


### Examples and reasons for differences between live ORS routes, and those generated from this pull request

Blue is the original isochrone geometry while the red one was generated with this PR.

![image](https://github.com/GIScience/openrouteservice/assets/6545356/c1e81131-c601-496e-838f-f7d92ed9ab9c)


[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
