### PR TITLE
fix: remove visited nodes limit from fast isochrones preparations

### DIFF
--- a/ors-engine/src/main/java/org/heigit/ors/fastisochrones/Eccentricity.java
+++ b/ors-engine/src/main/java/org/heigit/ors/fastisochrones/Eccentricity.java
@@ -171,7 +171,6 @@ public class Eccentricity extends AbstractEccentricity {
             DijkstraOneToManyAlgorithm algorithm = new DijkstraOneToManyAlgorithm(graph, weighting, TraversalMode.NODE_BASED);
             algorithm.setEdgeFilter(edgeFilterSequence);
             algorithm.prepare(new int[]{borderNode}, cellBorderNodes);
-            algorithm.setMaxVisitedNodes(getMaxCellNodesNumber() * 20);
             SPTEntry[] targets = algorithm.calcPaths(borderNode, cellBorderNodes);
             int[] ids = new int[targets.length - 1];
             double[] distances = new double[targets.length - 1];


### PR DESCRIPTION
### Pull Request Checklist
- Reason for change:
Remove hard-coded limit to maximum nodes visited during fast isochrones preparations. 
Profiles with fast isochrones activated need to be double-checked for OOM problems, and potentially have `maxcellnodes` settings adjusted.