### PR TITLE
fix: maxcellnodes parameter

### DIFF
--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -272,7 +272,7 @@ public class RoutingProfile {
                 if (fastisochroneOpts.hasPath(KEY_THREADS))
                     ghConfig.putObject("prepare.fastisochrone.threads", fastisochroneOpts.getInt(KEY_THREADS));
                 if (fastisochroneOpts.hasPath(KEY_MAXCELLNODES))
-                    ghConfig.putObject("prepare.fastisochrone.maxcellnodes", StringUtility.trimQuotes(fastisochroneOpts.getString(KEY_MAXCELLNODES)));
+                    ghConfig.putObject("prepare.fastisochrone.maxcellnodes", fastisochroneOpts.getInt(KEY_MAXCELLNODES));
                 if (fastisochroneOpts.hasPath(KEY_WEIGHTINGS)) {
                     List<Profile> fastisochronesProfiles = new ArrayList<>();
                     String fastisochronesWeightingsString = StringUtility.trimQuotes(fastisochroneOpts.getString(KEY_WEIGHTINGS));


### PR DESCRIPTION
### Information about the changes
- Reason for change:
The fast-isochrones parameter `maxcellnodes` was never taken into account, since it was inserted as string but read as int, causing the algo to always fall back to the default value of 5000.