### PR TITLE
fix(fastisochrones): Fix the max visited nodes bug for fast-isochrones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ RELEASING:
 - update spring-boot from 2.7.10 to 2.7.12 ([#1474](https://github.com/GIScience/openrouteservice/issues/1474))
 - Upgrade org.geotools.gt-epsg-hsql to version 29.1. ([#1479](https://github.com/GIScience/openrouteservice/issues/1479))
 - various style and low level code problems ([#1489](https://github.com/GIScience/openrouteservice/pull/1489))
+- Fix the max visited nodes bug for fast-isochrones ([#1538](https://github.com/GIScience/openrouteservice/pull/1538))
 
 ## [7.1.0] - 2023-06-13
 ### Added

--- a/ors-engine/src/main/java/org/heigit/ors/fastisochrones/Eccentricity.java
+++ b/ors-engine/src/main/java/org/heigit/ors/fastisochrones/Eccentricity.java
@@ -171,6 +171,7 @@ public class Eccentricity extends AbstractEccentricity {
             DijkstraOneToManyAlgorithm algorithm = new DijkstraOneToManyAlgorithm(graph, weighting, TraversalMode.NODE_BASED);
             algorithm.setEdgeFilter(edgeFilterSequence);
             algorithm.prepare(new int[]{borderNode}, cellBorderNodes);
+            algorithm.setMaxVisitedNodes(getMaxCellNodesNumber() * 20);
             SPTEntry[] targets = algorithm.calcPaths(borderNode, cellBorderNodes);
             int[] ids = new int[targets.length - 1];
             double[] distances = new double[targets.length - 1];

--- a/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
@@ -55,7 +55,7 @@ public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
             for (int srcIndex = 0; srcIndex < srcData.size(); srcIndex++)
                 pathMetricsExtractor.setEmptyValues(srcIndex, dstData, times, distances, weights);
         } else {
-            DijkstraOneToManyAlgorithm algorithm = new DijkstraOneToManyAlgorithm(graph, weighting, TraversalMode.NODE_BASED);
+            DijkstraOneToManyAlgorithm algorithm = new DijkstraOneToManyAlgorithm(graph, weighting, TraversalMode.NODE_BASED, true);
             //TODO Refactoring : Check whether this access filter is unnecessary
             algorithm.setEdgeFilter(AccessFilter.allEdges(this.encoder.getAccessEnc()));
             algorithm.prepare(srcData.getNodeIds(), dstData.getNodeIds());

--- a/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/AbstractOneToManyRoutingAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/AbstractOneToManyRoutingAlgorithm.java
@@ -80,8 +80,6 @@ public abstract class AbstractOneToManyRoutingAlgorithm implements OneToManyRout
     }
 
     protected boolean isMaxVisitedNodesExceeded() {
-        if (getVisitedNodes() > maxVisitedNodes)
-            throw new MaxVisitedNodesExceededException();
-        return false;
+        return maxVisitedNodes < getVisitedNodes();
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/DijkstraOneToManyAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/DijkstraOneToManyAlgorithm.java
@@ -1,15 +1,15 @@
 /*  This file is part of Openrouteservice.
  *
- *  Openrouteservice is free software; you can redistribute it and/or modify it under the terms of the 
- *  GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 
+ *  Openrouteservice is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1
  *  of the License, or (at your option) any later version.
 
- *  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
- *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ *  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU Lesser General Public License for more details.
 
- *  You should have received a copy of the GNU Lesser General Public License along with this library; 
- *  if not, see <https://www.gnu.org/licenses/>.  
+ *  You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, see <https://www.gnu.org/licenses/>.
  */
 package org.heigit.ors.routing.algorithms;
 
@@ -22,6 +22,7 @@ import com.graphhopper.storage.Graph;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.Parameters;
+import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
 
 import java.util.PriorityQueue;
 
@@ -35,10 +36,17 @@ public class DijkstraOneToManyAlgorithm extends AbstractOneToManyRoutingAlgorith
     private IntObjectMap<SPTEntry> targets;
     private int targetsCount = 0;
 
+    private boolean failOnMaxVisitedNodesExceeded = false;
+
     public DijkstraOneToManyAlgorithm(Graph graph, Weighting weighting, TraversalMode tMode) {
+        this(graph, weighting, tMode, false);
+    }
+
+    public DijkstraOneToManyAlgorithm(Graph graph, Weighting weighting, TraversalMode tMode, boolean failOnMaxVisitedNodesExceeded) {
         super(graph, weighting, tMode);
         int size = Math.min(Math.max(200, graph.getNodes() / 10), 2000);
         initCollections(size);
+        this.failOnMaxVisitedNodesExceeded = failOnMaxVisitedNodesExceeded;
     }
 
     protected void initCollections(int size) {
@@ -106,7 +114,12 @@ public class DijkstraOneToManyAlgorithm extends AbstractOneToManyRoutingAlgorith
         EdgeExplorer explorer = outEdgeExplorer;
         while (true) {
             visitedNodes++;
-            if (isMaxVisitedNodesExceeded() || finished())
+            if (this.failOnMaxVisitedNodesExceeded && isMaxVisitedNodesExceeded())
+                // Fail only if necessary for the matrix api endpoint
+                throw new MaxVisitedNodesExceededException();
+            else if (isMaxVisitedNodesExceeded() || finished())
+                // Do not fail but quit the search if the max visited nodes are exceeded
+                // Important for the fast-isochrones cell nodes calculation
                 break;
 
             int startNode = currEdge.adjNode;


### PR DESCRIPTION
The new max visited nodes check for the matrix api introduced an error which works well when querying via the api. When the fast-algorithm quries the matrix code, it needs a true or false feedback and not an error to abort a search. That logic works now again.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
