### PR TITLE
fix(fastisochrones): Fix the max visited nodes break for fast-isochrones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ RELEASING:
 - Java17 style issues ([#1504](https://github.com/GIScience/openrouteservice/pull/1504))
 - defaultValue for matrix 'metrics' parameter ([#1504](https://github.com/GIScience/openrouteservice/pull/1504))
 - schema type for parameters of type Duration ([#1504](https://github.com/GIScience/openrouteservice/pull/1504))
+- Fix the max visited nodes bug for fast-isochrones ([#1538](https://github.com/GIScience/openrouteservice/pull/1538))
 
 ## [7.1.0] - 2023-06-13
 ### Added

--- a/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/dijkstra/DijkstraMatrixAlgorithm.java
@@ -55,7 +55,7 @@ public class DijkstraMatrixAlgorithm extends AbstractMatrixAlgorithm {
             for (int srcIndex = 0; srcIndex < srcData.size(); srcIndex++)
                 pathMetricsExtractor.setEmptyValues(srcIndex, dstData, times, distances, weights);
         } else {
-            DijkstraOneToManyAlgorithm algorithm = new DijkstraOneToManyAlgorithm(graph, weighting, TraversalMode.NODE_BASED);
+            DijkstraOneToManyAlgorithm algorithm = new DijkstraOneToManyAlgorithm(graph, weighting, TraversalMode.NODE_BASED, true);
             //TODO Refactoring : Check whether this access filter is unnecessary
             algorithm.setEdgeFilter(AccessFilter.allEdges(this.encoder.getAccessEnc()));
             algorithm.prepare(srcData.getNodeIds(), dstData.getNodeIds());

--- a/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/AbstractOneToManyRoutingAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/AbstractOneToManyRoutingAlgorithm.java
@@ -80,8 +80,6 @@ public abstract class AbstractOneToManyRoutingAlgorithm implements OneToManyRout
     }
 
     protected boolean isMaxVisitedNodesExceeded() {
-        if (getVisitedNodes() > maxVisitedNodes)
-            throw new MaxVisitedNodesExceededException();
-        return false;
+        return maxVisitedNodes < getVisitedNodes();
     }
 }


### PR DESCRIPTION
The new max visited nodes check for the matrix api introduced an error which works well when querying via the api. When the fast-algorithm quries the matrix code, it needs a true or false feedback and not an error to abort a search. That logic works now again.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
