### PR TITLE
fix: RPM adjustments

### DIFF
--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -269,13 +269,8 @@ jobs:
           # Copy the /opt/openrouteservice/config/example-config.json to /opt/openrouteservice/config/ors-config.json
           podman exec -u openrouteservice ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
           
-          # Restart the container to load the new configuration
-          podman stop ${{ env.CONTAINER_NAME }}
-          
-          # Sleep to wait for the container to stop and release the port
-          sleep 5
-          
-          podman start ${{ env.CONTAINER_NAME }}
+          # Restart the systemd service
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'systemctl restart jws5-tomcat.service'
           
           # echo "Waiting for the podman container to build graphs and return 200"
           .github/utils/url_check.sh '127.0.0.1:8080/ors/v2/health' 200 ${{ env.HEALTH_WAIT_TIME }}

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker_file: [ dockerfile-jboss-java17-rhel8 ]
+        docker_file: [ dockerfile-ubi8-java17-jws57 ]
     env:
       CONTAINER_NAME: ${{ matrix.docker_file }}
       IMAGE_NAME: local/${{ matrix.docker_file }}:latest
@@ -175,39 +175,38 @@ jobs:
           .github/utils/upload_rpm_package.sh '${{ secrets.NEXUS_USERNAME }}' '${{ secrets.NEXUS_PASSWORD }}' '${{ env.RPM_PATH }}' '${{ steps.job_environment_variables.outputs.rpm_repo_testing_url }}/noarch/${{ env.RPM_NAME }}'
 
       - name: Login to RedHat Container Registry
-        uses: docker/login-action@v2
+        uses: redhat-actions/podman-login@v1
         with:
           registry: registry.redhat.io
           username: ${{ secrets.REDHAT_REGISTRY_LOGIN }}
           password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
 
-      - name: Build and load the rpm image for dockerfile ${{ matrix.docker_file }}
-        uses: docker/build-push-action@v4
+      - name: Build the docker image with podman
+        uses: redhat-actions/buildah-build@v2
         with:
-          context: .
-          file: .rpm-packaging/${{ matrix.docker_file }}
-          push: false
-          load: true
+          containerfile: .rpm-packaging/${{ matrix.docker_file }}
           tags: ${{ env.IMAGE_NAME }}
           build-args: |
             REDHAT_ORG=${{ secrets.REDHAT_ORG }}
             REDHAT_ACTIVATION_KEY_NAME=${{ secrets.REDHAT_ACTIVATION_KEY_NAME }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          layers: true
+#          extra-args:
+#            cache-from: type=gha
+#            cache-to: type=gha,mode=max
 
       - name: Prepare the example.repo file
         run: |
           # Replace the baseurl line with the testing repository url
           sed -i "s|baseurl=.*|baseurl=${{ steps.job_environment_variables.outputs.rpm_repo_testing_url }}|g" .rpm-packaging/example.repo
 
-      - name: Setup the docker container
+      - name: Run the container with podman
         shell: bash
         run: |
-          echo "Waiting for the docker container to start"
+          echo "Waiting for the container to start"
           # Run the pre-build docker image and mount the needed files
           # Mount the elevation file to avoid downloading it
           # Mount the osm pbf file for the graph build
-          docker run -it -d -p 8080:8080 --name ${{ env.CONTAINER_NAME }} \
+          podman run -it -d -p 8080:8080 --systemd true --name ${{ env.CONTAINER_NAME }} \
             -v $(pwd)/ors-api/src/test/files/elevation/srtm_38_03.gh:/opt/openrouteservice/.elevation-cache/srtm_38_03.gh \
             -v $(pwd)/ors-api/src/test/files/heidelberg.osm.gz:/opt/openrouteservice/files/osm-file.osm.gz  \
             -v $(pwd)/.rpm-packaging/example.repo:/etc/yum.repos.d/ors.repo \
@@ -232,21 +231,21 @@ jobs:
         shell: bash
         run: |
           ##### Import the GPG key #####
-          echo "Importing the GPG key inside the docker container"
-          # docker exec -u root ${{ env.CONTAINER_NAME }} rpm --import /tmp/public_key.asc
+          echo "Importing the GPG key inside the container"
+          # podman exec -u root ${{ env.CONTAINER_NAME }} rpm --import /tmp/public_key.asc
 
           ##### Install the rpm package #####
           # Update the yum repository
-          docker exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum update -y'
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum update -y'
 
           echo "Installing the rpm package"
           # Create the missing jws5* rpm packages with fakeprovide
-          docker exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-runtime
-          docker exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat
-          docker exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat-native
-          docker exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat-selinux
+          podman exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-runtime
+          podman exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat
+          podman exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat-native
+          podman exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat-selinux
           # Install the rpm package as root with the fakeprovide packages
-          docker exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum install -y fakeprovide-jws5-* openrouteservice-jws5'
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum install -y fakeprovide-jws5-* openrouteservice-jws5'
           
           ##### Check the post install environment #####
           echo "Checking the post install environment"
@@ -257,20 +256,20 @@ jobs:
         run: |          
           ##### Start the graph building #####
           # Copy the /opt/openrouteservice/config/example-config.json to /opt/openrouteservice/config/ors-config.json
-          docker exec -u jboss ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
+          podman exec -u jboss ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
           
           # Restart the container to load the new configuration
-          docker restart ${{ env.CONTAINER_NAME }}
+          podman restart ${{ env.CONTAINER_NAME }}
           
-          # echo "Waiting for the docker container to build graphs and return 200"
+          # echo "Waiting for the podman container to build graphs and return 200"
           .github/utils/url_check.sh '127.0.0.1:8080/ors/v2/health' 200 ${{ env.HEALTH_WAIT_TIME }}
       - name: Print the container logs for debugging
         if: runner.debug == '1'
         shell: bash
         run: |
           ##### Print the container logs for debugging #####
-          echo "Print docker logs"
-          docker logs ${{ env.CONTAINER_NAME }}
+          echo "Print container logs"
+          podman logs ${{ env.CONTAINER_NAME }}
 
       - name: Uninstall the rpm package
         shell: bash
@@ -281,7 +280,7 @@ jobs:
 
           ##### Uninstall the rpm package #####
           echo "Uninstalling the rpm package"
-          docker exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum remove -y openrouteservice-jws5'
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum remove -y openrouteservice-jws5'
           
           ##### Check the post uninstall environment #####
           echo "Checking the post uninstall environment"

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -175,24 +175,29 @@ jobs:
           .github/utils/upload_rpm_package.sh '${{ secrets.NEXUS_USERNAME }}' '${{ secrets.NEXUS_PASSWORD }}' '${{ env.RPM_PATH }}' '${{ steps.job_environment_variables.outputs.rpm_repo_testing_url }}/noarch/${{ env.RPM_NAME }}'
 
       - name: Login to RedHat Container Registry
-        uses: redhat-actions/podman-login@v1
+        uses: docker/login-action@v2
         with:
           registry: registry.redhat.io
           username: ${{ secrets.REDHAT_REGISTRY_LOGIN }}
           password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
 
-      - name: Build the docker image with podman
-        uses: redhat-actions/buildah-build@v2
+      - name: Build and load the rpm image for dockerfile ${{ matrix.docker_file }}
+        uses: docker/build-push-action@v4
         with:
-          containerfiles: .rpm-packaging/${{ matrix.docker_file }}
+          context: .
+          file: .rpm-packaging/${{ matrix.docker_file }}
+          push: false
+          load: true
           tags: ${{ env.IMAGE_NAME }}
           build-args: |
-            REDHAT_ORG=${{ secrets.REDHAT_ORG }}
-            REDHAT_ACTIVATION_KEY_NAME=${{ secrets.REDHAT_ACTIVATION_KEY_NAME }}
-          layers: true
-#          extra-args:
-#            cache-from: type=gha
-#            cache-to: type=gha,mode=max
+#            REDHAT_ORG=${{ secrets.REDHAT_ORG }}
+#            REDHAT_ACTIVATION_KEY_NAME=${{ secrets.REDHAT_ACTIVATION_KEY_NAME }}
+            JWS57_APPLICATION_SERVER_URL=${{ secrets.PRIVATE_FILE_STORAGE_URL }}/jws57/jws-5.7.0-application-server.zip
+            JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL=${{ secrets.PRIVATE_FILE_STORAGE_URL }}/jws57/jws-5.7.0-application-server-RHEL8-x86_64.zip
+            USERNAME=${{ secrets.PRIVATE_FILE_STORAGE_USERNAME }}
+            PASSWORD=${{ secrets.PRIVATE_FILE_STORAGE_PASSWORD }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Prepare the example.repo file
         run: |
@@ -203,7 +208,8 @@ jobs:
         shell: bash
         run: |
           echo "Waiting for the container to start"
-          # Run the pre-build docker image and mount the needed files
+          # Pull the pre-build docker image into podman
+          podman pull docker-daemon:${{ env.IMAGE_NAME }}
           # Mount the elevation file to avoid downloading it
           # Mount the osm pbf file for the graph build
           podman run -it -d -p 8080:8080 --systemd true --name ${{ env.CONTAINER_NAME }} \

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -272,6 +272,9 @@ jobs:
           # Restart the container to load the new configuration
           podman restart ${{ env.CONTAINER_NAME }}
           
+          sleep 5
+          podman logs  ${{ env.CONTAINER_NAME }}
+          
           # echo "Waiting for the podman container to build graphs and return 200"
           .github/utils/url_check.sh '127.0.0.1:8080/ors/v2/health' 200 ${{ env.HEALTH_WAIT_TIME }}
       - name: Print the container logs for debugging

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -270,10 +270,12 @@ jobs:
           podman exec -u openrouteservice ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
           
           # Restart the container to load the new configuration
-          podman restart ${{ env.CONTAINER_NAME }}
+          podman stop ${{ env.CONTAINER_NAME }}
           
+          # Sleep to wait for the container to stop and release the port
           sleep 5
-          podman logs  ${{ env.CONTAINER_NAME }}
+          
+          podman start ${{ env.CONTAINER_NAME }}
           
           # echo "Waiting for the podman container to build graphs and return 200"
           .github/utils/url_check.sh '127.0.0.1:8080/ors/v2/health' 200 ${{ env.HEALTH_WAIT_TIME }}

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -214,7 +214,10 @@ jobs:
             -v $(pwd)/ors-api/src/test/files/elevation/srtm_38_03.gh:/opt/openrouteservice/.elevation-cache/srtm_38_03.gh \
             -v $(pwd)/ors-api/src/test/files/heidelberg.osm.gz:/opt/openrouteservice/files/osm-file.osm.gz  \
             -v $(pwd)/.rpm-packaging/example.repo:/etc/yum.repos.d/ors.repo \
+            -e ORS_HOME=/opt/openrouteservice \
             ${{ env.IMAGE_NAME }}
+#          podman exec -u root ${{ env.CONTAINER_NAME }} bash -c "echo 'ORS_HOME=/opt/openrouteservice' >> /etc/environment"
+ #         podman restart ${{ env.CONTAINER_NAME }}
 
       - name: Check the pre-install environment
         shell: bash
@@ -264,7 +267,7 @@ jobs:
         run: |
           ##### Start the graph building #####
           # Copy the /opt/openrouteservice/config/example-config.json to /opt/openrouteservice/config/ors-config.json
-          podman exec -u jboss ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
+          podman exec -u openrouteservice ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
           
           # Restart the container to load the new configuration
           podman restart ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Build the docker image with podman
         uses: redhat-actions/buildah-build@v2
         with:
-          containerfile: .rpm-packaging/${{ matrix.docker_file }}
+          containerfiles: .rpm-packaging/${{ matrix.docker_file }}
           tags: ${{ env.IMAGE_NAME }}
           build-args: |
             REDHAT_ORG=${{ secrets.REDHAT_ORG }}

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -244,6 +244,8 @@ jobs:
           ##### Install the rpm package #####
           # Update the yum repository
           podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'dnf update -y'
+          # Clean packages
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'dnf clean packages'
 
           echo "Installing the rpm package"
           # Create the missing jws5* rpm packages with fakeprovide

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -275,19 +275,7 @@ jobs:
           
           podman start ${{ env.CONTAINER_NAME }}
           
-          # Sleep and wait for the container to start
-          sleep 10
-          
-          # Check the container logs
-          podman logs ${{ env.CONTAINER_NAME }}
-          
-          # Check the ors logs
-          podman exec -u root ${{ env.CONTAINER_NAME }} bash -c 'ls -sahlS ${ORS_HOME}/**/**'
-          
-          # Check the catalina logs
-          podman exec -u root ${{ env.CONTAINER_NAME }} bash -c "ls -sahlS /var/opt/rh/jws5/tomcat/logs/**"
-          
-          # echo "Waiting for the podman container to build graphs and return 200"
+          echo "Waiting for the podman container to build graphs and return 200"
           .github/utils/url_check.sh '127.0.0.1:8080/ors/v2/health' 200 ${{ env.HEALTH_WAIT_TIME }}
       - name: Print the container logs for debugging
         if: runner.debug == '1'

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -190,8 +190,6 @@ jobs:
           load: true
           tags: ${{ env.IMAGE_NAME }}
           build-args: |
-#            REDHAT_ORG=${{ secrets.REDHAT_ORG }}
-#            REDHAT_ACTIVATION_KEY_NAME=${{ secrets.REDHAT_ACTIVATION_KEY_NAME }}
             JWS57_APPLICATION_SERVER_URL=${{ secrets.PRIVATE_FILE_STORAGE_URL }}/jws57/jws-5.7.0-application-server.zip
             JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL=${{ secrets.PRIVATE_FILE_STORAGE_URL }}/jws57/jws-5.7.0-application-server-RHEL8-x86_64.zip
             USERNAME=${{ secrets.PRIVATE_FILE_STORAGE_USERNAME }}

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -222,6 +222,8 @@ jobs:
           ##### Check the pre install environment #####
           echo "Checking the pre install environment"
           bash ${{ github.workspace }}/.rpm-packaging/rhel8_pre_install_check.sh
+        env:
+          CONTAINER_ENGINE: podman
 
       - name: Wait for the RPM repo to initialize the repodata folder
         shell: bash
@@ -254,10 +256,12 @@ jobs:
           ##### Check the post install environment #####
           echo "Checking the post install environment"
           bash ${{ github.workspace }}/.rpm-packaging/rhel8_post_install_check.sh
+        env:
+          CONTAINER_ENGINE: podman
 
       - name: Test the graph building
         shell: bash
-        run: |          
+        run: |
           ##### Start the graph building #####
           # Copy the /opt/openrouteservice/config/example-config.json to /opt/openrouteservice/config/ors-config.json
           podman exec -u jboss ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
@@ -289,6 +293,8 @@ jobs:
           ##### Check the post uninstall environment #####
           echo "Checking the post uninstall environment"
           bash ${{ github.workspace }}/.rpm-packaging/rhel8_post_uninstall_check.sh
+        env:
+          CONTAINER_ENGINE: podman
 
       - name: Clean the public GPG key
         run: |

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -243,7 +243,7 @@ jobs:
 
           ##### Install the rpm package #####
           # Update the yum repository
-          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum update -y'
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'dnf update -y'
 
           echo "Installing the rpm package"
           # Create the missing jws5* rpm packages with fakeprovide
@@ -252,7 +252,7 @@ jobs:
           podman exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat-native
           podman exec -u root ${{ env.CONTAINER_NAME }} fakeprovide jws5-tomcat-selinux
           # Install the rpm package as root with the fakeprovide packages
-          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum install -y fakeprovide-jws5-* openrouteservice-jws5'
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'dnf install -y fakeprovide-jws5-* openrouteservice-jws5'
           
           ##### Check the post install environment #####
           echo "Checking the post install environment"
@@ -294,7 +294,7 @@ jobs:
 
           ##### Uninstall the rpm package #####
           echo "Uninstalling the rpm package"
-          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'yum remove -y openrouteservice-jws5'
+          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'dnf remove -y openrouteservice-jws5'
           
           ##### Check the post uninstall environment #####
           echo "Checking the post uninstall environment"

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -210,14 +210,12 @@ jobs:
           podman pull docker-daemon:${{ env.IMAGE_NAME }}
           # Mount the elevation file to avoid downloading it
           # Mount the osm pbf file for the graph build
-          podman run -it -d -p 8080:8080 --systemd true --name ${{ env.CONTAINER_NAME }} \
+          podman run -it -d -p 8080:8080 -u root --systemd true --name ${{ env.CONTAINER_NAME }} \
             -v $(pwd)/ors-api/src/test/files/elevation/srtm_38_03.gh:/opt/openrouteservice/.elevation-cache/srtm_38_03.gh \
             -v $(pwd)/ors-api/src/test/files/heidelberg.osm.gz:/opt/openrouteservice/files/osm-file.osm.gz  \
             -v $(pwd)/.rpm-packaging/example.repo:/etc/yum.repos.d/ors.repo \
             -e ORS_HOME=/opt/openrouteservice \
             ${{ env.IMAGE_NAME }}
-#          podman exec -u root ${{ env.CONTAINER_NAME }} bash -c "echo 'ORS_HOME=/opt/openrouteservice' >> /etc/environment"
- #         podman restart ${{ env.CONTAINER_NAME }}
 
       - name: Check the pre-install environment
         shell: bash
@@ -269,8 +267,25 @@ jobs:
           # Copy the /opt/openrouteservice/config/example-config.json to /opt/openrouteservice/config/ors-config.json
           podman exec -u openrouteservice ${{ env.CONTAINER_NAME }} sh -c 'cp /opt/openrouteservice/config/example-config.json /opt/openrouteservice/config/ors-config.json'
           
-          # Restart the systemd service
-          podman exec -u root ${{ env.CONTAINER_NAME }} sh -c 'systemctl restart jws5-tomcat.service'
+          # Restart the container to load the new configuration
+          podman stop ${{ env.CONTAINER_NAME }}
+          
+          # Sleep to wait for the container to stop and release the port
+          sleep 5
+          
+          podman start ${{ env.CONTAINER_NAME }}
+          
+          # Sleep and wait for the container to start
+          sleep 10
+          
+          # Check the container logs
+          podman logs ${{ env.CONTAINER_NAME }}
+          
+          # Check the ors logs
+          podman exec -u root ${{ env.CONTAINER_NAME }} bash -c 'ls -sahlS ${ORS_HOME}/**/**'
+          
+          # Check the catalina logs
+          podman exec -u root ${{ env.CONTAINER_NAME }} bash -c "ls -sahlS /var/opt/rh/jws5/tomcat/logs/**"
           
           # echo "Waiting for the podman container to build graphs and return 200"
           .github/utils/url_check.sh '127.0.0.1:8080/ors/v2/health' 200 ${{ env.HEALTH_WAIT_TIME }}

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -30,12 +30,18 @@ FROM base
 # Copy /usr/bin/fakeprovide from the base image
 COPY --from=base /usr/bin/fakeprovide /usr/bin/fakeprovide
 
+# Download jws files from private repository
+ARG JWS57_APPLICATION_SERVER_URL
+ARG JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL
+ARG USERNAME
+ARG PASSWORD
+
 # Download and install tomcat
 RUN mkdir -p /var/opt/rh; cd /var/opt/rh/ && \
-    wget 'https://access.redhat.com/cspdownload/8f48cf7a8c897851a468eddbeef9d3fc/6509a054/JWS-5.7.0/jws-5.7.0-application-server.zip' && \
-    wget 'https://access.redhat.com/cspdownload/8ae72f3a4c9316eaba621855cc349d64/65099fab/JWS-5.7.0/jws-5.7.0-application-server-RHEL8-x86_64.zip' && \
-    unzip jws-5.7.0-application-server.zip -d /var/opt/rh/ && unzip jws-5.7.0-application-server-RHEL8-x86_64.zip -d /var/opt/rh/ && \
-    mv /var/opt/rh/jws-5.7 /var/opt/rh/jws5 && rm -f jws-5.7.0-application-server.zip jws-5.7.0-application-server-RHEL8-x86_64.zip && \
+    wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server.zip $JWS57_APPLICATION_SERVER_URL && \
+    wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server-RHEL8-x86_64.zip $JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL && \
+    unzip jws-5.7-application-server.zip -d /var/opt/rh/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d /var/opt/rh/ && \
+    mv /var/opt/rh/jws-5.7 /var/opt/rh/jws5 && rm -f *.zip && \
     cd /var/opt/rh/jws5/tomcat/ &&  \
     ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \
     chown -R tomcat:tomcat /var/opt/rh

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -15,7 +15,7 @@ RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*
     # Attach to the rhel8 repositories of the access key and unregister if it fails
     #subscription-manager attach || subscription-manager unregister && \
     # Update the system and unregister if it fails
-    yum update -y && yum install -y git make rpm-build java-17-openjdk-headless wget unzip systemd && \
+    yum update -y && yum install -y git make rpm-build java-17-openjdk-headless wget unzip systemd apr-util && \
     # give user root the passwort "root"
     echo "root:root" | chpasswd && \
     # Clone fakeprovide and install it \

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -30,7 +30,7 @@ FROM base
 # Copy /usr/bin/fakeprovide from the base image
 COPY --from=base /usr/bin/fakeprovide /usr/bin/fakeprovide
 
-ARG JWS57_INSTALLATION_DIRECTORY=/var/opt/rh/scls/
+ARG JWS57_INSTALLATION_DIRECTORY=/var/opt/rh/scls
 
 # Download jws files from private repository
 ARG JWS57_APPLICATION_SERVER_URL
@@ -39,14 +39,15 @@ ARG USERNAME
 ARG PASSWORD
 
 # Download and install tomcat
-RUN mkdir -p $JWS57_INSTALLATION_DIRECTORY; cd $JWS57_INSTALLATION_DIRECTORY/ && \
-    mkdir -p /etc/opt/rh/scls/jws5/tomcat/  && \
-    mkdir -p /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
+RUN mkdir -p $JWS57_INSTALLATION_DIRECTORY && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server.zip $JWS57_APPLICATION_SERVER_URL && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server-RHEL8-x86_64.zip $JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL && \
     unzip jws-5.7-application-server.zip -d $JWS57_INSTALLATION_DIRECTORY/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d $JWS57_INSTALLATION_DIRECTORY/ && \
     mv $JWS57_INSTALLATION_DIRECTORY/jws-5.7 $JWS57_INSTALLATION_DIRECTORY/jws5 && rm -f *.zip && \
     cd $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/ &&  \
+    mkdir -p /etc/opt/rh/scls/jws5/tomcat/  && \
+    mkdir -p /etc/opt/rh/jws5/tomcat/conf.d && \
+    mkdir -p /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
     ln -s /etc/opt/rh/jws5/tomcat/conf.d /etc/opt/rh/scls/jws5/tomcat/conf.d && \
     ln -s $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/webapps /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
     ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -38,13 +38,14 @@ ARG PASSWORD
 
 # Download and install tomcat
 RUN mkdir -p /var/opt/rh; cd /var/opt/rh/ && \
+    mkdir -p /etc/opt/rh/scls/jws5/tomcat/conf.d && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server.zip $JWS57_APPLICATION_SERVER_URL && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server-RHEL8-x86_64.zip $JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL && \
-    unzip jws-5.7-application-server.zip -d /var/opt/rh/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d /var/opt/rh/ && \
-    mv /var/opt/rh/jws-5.7 /var/opt/rh/jws5 && rm -f *.zip && \
-    cd /var/opt/rh/jws5/tomcat/ &&  \
+    unzip jws-5.7-application-server.zip -d /var/opt/rh/scls/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d /var/opt/rh/scls/ && \
+    mv /var/opt/rh/scls/jws-5.7 /var/opt/rh/scls/jws5 && rm -f *.zip && \
+    cd /var/opt/rh/scls/jws5/tomcat/ &&  \
     ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \
-    chown -R tomcat:tomcat /var/opt/rh
+    chown -R tomcat:tomcat /var/opt/rh/scls/
 
 EXPOSE 8080
 # Become tomcat that was created by the postinstall script

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -40,7 +40,8 @@ ARG PASSWORD
 
 # Download and install tomcat
 RUN mkdir -p $JWS57_INSTALLATION_DIRECTORY; cd $JWS57_INSTALLATION_DIRECTORY/ && \
-    mkdir -p /etc/opt/rh/scls/jws5/tomcat/conf.d && \
+    mkdir -p /etc/opt/rh/scls/jws5/tomcat/ && \
+    ln -s /etc/opt/rh/jws5/tomcat/conf.d /etc/opt/rh/scls/jws5/tomcat/conf.d && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server.zip $JWS57_APPLICATION_SERVER_URL && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server-RHEL8-x86_64.zip $JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL && \
     unzip jws-5.7-application-server.zip -d $JWS57_INSTALLATION_DIRECTORY/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d $JWS57_INSTALLATION_DIRECTORY/ && \

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -50,6 +50,7 @@ RUN mkdir -p $JWS57_INSTALLATION_DIRECTORY && \
     mkdir -p /var/opt/rh/scls/jws5/lib/tomcat/ && \
     ln -s /etc/opt/rh/jws5/tomcat/conf.d /etc/opt/rh/scls/jws5/tomcat/conf.d && \
     ln -s $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/webapps /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
+    sed -i '/EnvironmentFile=-/a \EnvironmentFile=-/etc/opt/rh/scls/jws5/tomcat/conf.d/*.conf\n ' services/jws5-tomcat.service.in && \
     ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \
     chown -R tomcat:tomcat $JWS57_INSTALLATION_DIRECTORY/
 
@@ -58,3 +59,4 @@ EXPOSE 8080
 USER tomcat
 CMD ["/usr/sbin/init"]
 
+#EnvironmentFile=/etc/opt/rh/scls/jws5/tomcat/conf.d/*.conf

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -30,6 +30,8 @@ FROM base
 # Copy /usr/bin/fakeprovide from the base image
 COPY --from=base /usr/bin/fakeprovide /usr/bin/fakeprovide
 
+ARG JWS57_INSTALLATION_DIRECTORY=/var/opt/rh/scls/
+
 # Download jws files from private repository
 ARG JWS57_APPLICATION_SERVER_URL
 ARG JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL
@@ -37,15 +39,15 @@ ARG USERNAME
 ARG PASSWORD
 
 # Download and install tomcat
-RUN mkdir -p /var/opt/rh; cd /var/opt/rh/ && \
+RUN mkdir -p $JWS57_INSTALLATION_DIRECTORY; cd $JWS57_INSTALLATION_DIRECTORY/ && \
     mkdir -p /etc/opt/rh/scls/jws5/tomcat/conf.d && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server.zip $JWS57_APPLICATION_SERVER_URL && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server-RHEL8-x86_64.zip $JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL && \
-    unzip jws-5.7-application-server.zip -d /var/opt/rh/scls/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d /var/opt/rh/scls/ && \
-    mv /var/opt/rh/scls/jws-5.7 /var/opt/rh/scls/jws5 && rm -f *.zip && \
-    cd /var/opt/rh/scls/jws5/tomcat/ &&  \
+    unzip jws-5.7-application-server.zip -d $JWS57_INSTALLATION_DIRECTORY/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d $JWS57_INSTALLATION_DIRECTORY/ && \
+    mv $JWS57_INSTALLATION_DIRECTORY/jws-5.7 $JWS57_INSTALLATION_DIRECTORY/jws5 && rm -f *.zip && \
+    cd $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/ &&  \
     ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \
-    chown -R tomcat:tomcat /var/opt/rh/scls/
+    chown -R tomcat:tomcat $JWS57_INSTALLATION_DIRECTORY/
 
 EXPOSE 8080
 # Become tomcat that was created by the postinstall script

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -47,7 +47,7 @@ RUN mkdir -p $JWS57_INSTALLATION_DIRECTORY && \
     cd $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/ &&  \
     mkdir -p /etc/opt/rh/scls/jws5/tomcat/  && \
     mkdir -p /etc/opt/rh/jws5/tomcat/conf.d && \
-    mkdir -p /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
+    mkdir -p /var/opt/rh/scls/jws5/lib/tomcat/ && \
     ln -s /etc/opt/rh/jws5/tomcat/conf.d /etc/opt/rh/scls/jws5/tomcat/conf.d && \
     ln -s $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/webapps /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
     ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/jboss-webserver-5/jws57-openjdk17-openshift-rhel8 as base
+FROM registry.access.redhat.com/ubi8/ubi:latest as base
 
 # Become root
 USER root
@@ -15,7 +15,9 @@ RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*
     # Attach to the rhel8 repositories of the access key and unregister if it fails
     #subscription-manager attach || subscription-manager unregister && \
     # Update the system and unregister if it fails
-    yum update -y && yum install -y git make && \
+    yum update -y && yum install -y git make rpm-build java-17-openjdk-headless wget unzip systemd && \
+    # give user root the passwort "root"
+    echo "root:root" | chpasswd && \
     # Clone fakeprovide and install it \
     git clone https://github.com/MichaelsJP/fakeprovide.git && cd fakeprovide && make install && \
     # Unregister from redhat in any case in the end to avoid too many registered systems
@@ -23,15 +25,23 @@ RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*
     echo "Done"
 
 
-from base as final
+FROM base
 
 # Copy /usr/bin/fakeprovide from the base image
 COPY --from=base /usr/bin/fakeprovide /usr/bin/fakeprovide
 
-# Install rpm-build with yum as needed for fakeprovide and remove the yum cache
-RUN yum install -y rpm-build && yum clean all && \
-    # give user root the passwort "root"
-    echo "root:root" | chpasswd
+# Download and install tomcat
+RUN mkdir -p /var/opt/rh; cd /var/opt/rh/ && \
+    wget 'https://access.redhat.com/cspdownload/8f48cf7a8c897851a468eddbeef9d3fc/6509a054/JWS-5.7.0/jws-5.7.0-application-server.zip' && \
+    wget 'https://access.redhat.com/cspdownload/8ae72f3a4c9316eaba621855cc349d64/65099fab/JWS-5.7.0/jws-5.7.0-application-server-RHEL8-x86_64.zip' && \
+    unzip jws-5.7.0-application-server.zip -d /var/opt/rh/ && unzip jws-5.7.0-application-server-RHEL8-x86_64.zip -d /var/opt/rh/ && \
+    mv /var/opt/rh/jws-5.7 /var/opt/rh/jws5 && rm -f jws-5.7.0-application-server.zip jws-5.7.0-application-server-RHEL8-x86_64.zip && \
+    cd /var/opt/rh/jws5/tomcat/ &&  \
+    ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \
+    chown -R tomcat:tomcat /var/opt/rh
 
-# Become the jboss user again
-USER jboss
+EXPOSE 8080
+# Become tomcat that was created by the postinstall script
+USER tomcat
+CMD ["/usr/sbin/init"]
+

--- a/.rpm-packaging/dockerfile-ubi8-java17-jws57
+++ b/.rpm-packaging/dockerfile-ubi8-java17-jws57
@@ -40,13 +40,15 @@ ARG PASSWORD
 
 # Download and install tomcat
 RUN mkdir -p $JWS57_INSTALLATION_DIRECTORY; cd $JWS57_INSTALLATION_DIRECTORY/ && \
-    mkdir -p /etc/opt/rh/scls/jws5/tomcat/ && \
-    ln -s /etc/opt/rh/jws5/tomcat/conf.d /etc/opt/rh/scls/jws5/tomcat/conf.d && \
+    mkdir -p /etc/opt/rh/scls/jws5/tomcat/  && \
+    mkdir -p /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server.zip $JWS57_APPLICATION_SERVER_URL && \
     wget --user=$USERNAME --password=$PASSWORD -O jws-5.7-application-server-RHEL8-x86_64.zip $JWS57_APPLICATION_SERVER_RHEL8_PLATTFORM_URL && \
     unzip jws-5.7-application-server.zip -d $JWS57_INSTALLATION_DIRECTORY/ && unzip jws-5.7-application-server-RHEL8-x86_64.zip -d $JWS57_INSTALLATION_DIRECTORY/ && \
     mv $JWS57_INSTALLATION_DIRECTORY/jws-5.7 $JWS57_INSTALLATION_DIRECTORY/jws5 && rm -f *.zip && \
     cd $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/ &&  \
+    ln -s /etc/opt/rh/jws5/tomcat/conf.d /etc/opt/rh/scls/jws5/tomcat/conf.d && \
+    ln -s $JWS57_INSTALLATION_DIRECTORY/jws5/tomcat/webapps /var/opt/rh/scls/jws5/lib/tomcat/webapps && \
     ./.postinstall.systemd && systemctl enable jws5-tomcat.service && \
     chown -R tomcat:tomcat $JWS57_INSTALLATION_DIRECTORY/
 

--- a/.rpm-packaging/example-config.json
+++ b/.rpm-packaging/example-config.json
@@ -1,5 +1,11 @@
 {
   "ors": {
+    "info": {
+      "base_url": "https://openrouteservice.org/",
+      "support_mail": "support@openrouteservice.heigit.org",
+      "author_tag": "openrouteservice",
+      "content_licence": "LGPL 3.0"
+    },
     "services": {
       "isochrones": {
         "enabled": true,

--- a/.rpm-packaging/example-config.json
+++ b/.rpm-packaging/example-config.json
@@ -69,7 +69,7 @@
         "routing_description": "This is a routing file from openrouteservice",
         "routing_name": "openrouteservice routing",
         "sources": [
-          "/opt/openrouteservice/files/osm-file.osm.gz"
+          "files/osm-file.osm.gz"
         ],
         "init_threads": 1,
         "attribution": "openrouteservice.org, OpenStreetMap contributors",
@@ -80,9 +80,9 @@
           ],
           "default_params": {
             "encoder_flags_size": 8,
-            "graphs_root_path": "/opt/openrouteservice/graphs",
+            "graphs_root_path": "graphs",
             "elevation_provider": "multi",
-            "elevation_cache_path": "/opt/openrouteservice/.elevation-cache",
+            "elevation_cache_path": ".elevation-cache",
             "elevation_cache_clear": false,
             "instructions": true,
             "maximum_distance": 100000,

--- a/.rpm-packaging/example-config.json
+++ b/.rpm-packaging/example-config.json
@@ -86,7 +86,7 @@
           ],
           "default_params": {
             "encoder_flags_size": 8,
-            "graphs_root_path": "graphs",
+            "graphs_root_path": ".graphs",
             "elevation_provider": "multi",
             "elevation_cache_path": ".elevation-cache",
             "elevation_cache_clear": false,
@@ -334,7 +334,7 @@
     "logging": {
       "enabled": true,
       "level_file": "DEFAULT_LOGGING.json",
-      "location": "/opt/openrouteservice/logs",
+      "location": "logs",
       "stdout": true
     }
   }

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -15,7 +15,7 @@ Requires:  jws5-runtime
 Requires:  jws5-tomcat
 Requires:  jws5-tomcat-native
 Requires:  jws5-tomcat-selinux
-Requires:  java-%{java_version}-openjdk
+Requires:  java-%{java_version}-openjdk-headless
 Vendor: HeiGIT gGmbH
 
 # For a detailed step explanation see: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -121,8 +121,8 @@ else
 fi
 
 # Set environment variable in Tomcat startup script to pick up the correct config file
-echo 'export ORS_CONFIG=%{ors_local_folder}/config/ors-config.json' >> ${JWS_HOME}/bin/setenv.sh
-echo 'export ORS_LOG_LOCATION=%{ors_local_folder}/logs/' >> ${JWS_HOME}/bin/setenv.sh
+echo 'export ORS_CONFIG=%{ors_local_folder}/config/ors-config.json' >> /etc/environment
+echo 'export ORS_LOG_LOCATION=%{ors_local_folder}/logs/' >> /etc/environment
 
 # Switch to the installed java version
 alternatives --set java $(readlink -f /etc/alternatives/jre_%{java_version})/bin/java
@@ -138,8 +138,8 @@ chmod -R 770 %{ors_local_folder}
 if [ "$1" = "0" ]; then
     echo "Uninstalling openrouteservice"
     # Remove environment variable from Tomcat startup script on uninstall
-    sed -i '/export ORS_CONFIG=/d' ${JWS_HOME}/bin/setenv.sh
-    sed -i '/export ORS_LOG_LOCATION=/d' ${JWS_HOME}/bin/setenv.sh
+    sed -i '/export ORS_CONFIG=/d' /etc/environment
+    sed -i '/export ORS_LOG_LOCATION=/d' /etc/environment
     # Remove the ors folder and war file from the webapps folder
     rm -rf ${JWS_HOME}/webapps/ors
     rm -rf ${JWS_HOME}/webapps/ors.war

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -170,6 +170,24 @@ if [ -z "${JWS_CONF_FOLDER}" ]; then
 else
     export jws_config_folder=${JWS_CONF_FOLDER}
 fi
+export jws_config_location=${jws_config_folder}/openrouteservice.conf
+
+# Do the same for the JWS_WEBAPPS_FOLDER
+if [ -z "${JWS_WEBAPPS_FOLDER}" ]; then
+    echo "JWS_WEBAPPS_FOLDER is not set. Setting default value of %{jws_webapps_folder}."
+    export jws_webapps_folder=%{jws_webapps_folder}
+else
+    export jws_webapps_folder=${JWS_WEBAPPS_FOLDER}
+fi
+
+
+# Check if the environment variables are set for JWS_CONF_FOLDER and JWS_WEBAPPS_FOLDER if not, set the default values for them
+if [ -z "${JWS_CONF_FOLDER}" ]; then
+    echo "JWS_CONF_FOLDER is not set. Setting default value of %{jws_config_folder}."
+    export jws_config_folder=%{jws_config_folder}
+else
+    export jws_config_folder=${JWS_CONF_FOLDER}
+fi
 
 # Do the same for the JWS_WEBAPPS_FOLDER
 if [ -z "${JWS_WEBAPPS_FOLDER}" ]; then

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -4,7 +4,9 @@
 %define tomcat_user tomcat
 %define ors_group openrouteservice
 %define ors_user  openrouteservice
-%define jws_webapps /var/opt/rh/jws5/tomcat/webapps/
+%define jws_home /var/opt/rh/jws5/tomcat
+%define jws_webapps %{jws_home}/webapps/
+%define jws_config_location %{jws_home}/conf/jws5-tomcat.conf
 Name: openrouteservice-jws5
 Version: %{ors_version}
 Release: 1
@@ -49,12 +51,23 @@ else
     exit 1
 fi
 
-echo "Create the webapps folder in ${JWS_HOME} if it does not exist."
 if [ -d %{jws_webapps} ]; then
     echo "JWS webapps dir found at %{jws_webapps}"
 else
     echo "No webapps folder found. Exiting installation."
     # Exit the rpm installation with an error
+    exit 1
+fi
+
+if [ -f %{jws_config_location} ]; then
+    echo "Tomcat config found at %{jws_config_location}"
+    echo "Permanently saving the given ORS_HOME=${ORS_HOME} location in the tomcat config."
+    # Remove any line that starts with ORS_HOME=
+    sed -i '/^ORS_HOME=/d' %{jws_config_location}
+    # Add the ORS_HOME variable to the tomcat config
+    echo "ORS_HOME=${ORS_HOME}" >> %{jws_config_location}
+else
+    echo "No tomcat config found at %{jws_config_location}. Exiting installation."
     exit 1
 fi
 

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -40,26 +40,25 @@ cp -f example-config.json %{buildroot}%{ors_local_folder}/config/example-config.
 "%{ors_local_folder}/.war-files/%{ors_version}_ors.war"
 "%{ors_local_folder}/config/example-config.json"
 
-%pre
-
+%post
 # Check if the environment variables are set for JWS_CONF_FOLDER and JWS_WEBAPPS_FOLDER if not, set the default values for them
 if [ -z "${JWS_CONF_FOLDER}" ]; then
     echo "JWS_CONF_FOLDER is not set. Setting default value of %{jws_config_folder}."
-    jws_config_folder=%{jws_config_folder}
+    export jws_config_folder=%{jws_config_folder}
 else
-    jws_config_folder=${JWS_CONF_FOLDER}
+    export jws_config_folder=${JWS_CONF_FOLDER}
 fi
 
 # Do the same for the JWS_WEBAPPS_FOLDER
 if [ -z "${JWS_WEBAPPS_FOLDER}" ]; then
     echo "JWS_WEBAPPS_FOLDER is not set. Setting default value of %{jws_webapps_folder}."
-    jws_webapps_folder=%{jws_webapps_folder}
+    export jws_webapps_folder=%{jws_webapps_folder}
 else
-    jws_webapps_folder=${JWS_WEBAPPS_FOLDER}
+    export jws_webapps_folder=${JWS_WEBAPPS_FOLDER}
 fi
 
 # Set the remaining variables
-jws_config_location=${jws_config_folder}/openrouteservice.conf
+export jws_config_location=${jws_config_folder}/openrouteservice.conf
 
 # Check for the JWS home ENV variable to be set and echo 'set'
 if [ -n "${ORS_HOME}" ]; then
@@ -70,10 +69,19 @@ else
     exit 1
 fi
 
-if [ -d ${jws_config_folder} ]; then
-    echo "JWS webapps dir found at ${jws_config_folder}"
+# Check if webapps folder exists
+if [ -d ${jws_webapps_folder} ]; then
+    echo "JWS webapps dir found at ${jws_webapps_folder}"
 else
     echo "No webapps folder found. Exiting installation."
+    # Exit the rpm installation with an error
+    exit 1
+fi
+
+if [ -d ${jws_config_folder} ]; then
+    echo "JWS conf.d dir found at ${jws_config_folder}"
+else
+    echo "No conf.d folder found. Exiting installation."
     # Exit the rpm installation with an error
     exit 1
 fi
@@ -139,7 +147,6 @@ mkdir -p "${ORS_HOME}/config"
 mkdir -p "${ORS_HOME}/files"
 mkdir -p "${ORS_HOME}/.elevation-cache"
 
-%post
 echo "Copy %{ors_version}_ors.war to ${jws_webapps_folder}"
 cp -f %{ors_local_folder}/config/example-config.json ${ORS_HOME}/config/example-config.json
 cp -f %{ors_local_folder}/.war-files/%{ors_version}_ors.war ${jws_webapps_folder}/ors.war

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -101,7 +101,7 @@ else
     echo "Permanently saving the given ORS_HOME=${ORS_HOME} in ${jws_config_location}."
     echo "ORS_HOME=${ORS_HOME}" >> ${jws_config_location}
     echo "Permanently saving -Xms${min_ram}k and -Xmx${max_ram}k in ${jws_config_location}."
-    echo 'CATALINA_OPTS="$CATALINA_OPTS -Xms'"${min_ram}"'k -Xmx'"${max_ram}"'k"' >> ${jws_config_location}
+    echo 'CATALINA_OPTS="-Xms'"${min_ram}"'k -Xmx'"${max_ram}"'k"' >> ${jws_config_location}
 fi
 
 

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -133,6 +133,8 @@ chmod -R 770 ${ORS_HOME}
 # For explanation check https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
 if [ "$1" = "0" ]; then
     echo "Uninstalling openrouteservice"
+    # Remove any line that starts with ORS_HOME=
+    sed -i '/^ORS_HOME=/d' %{jws_config_location}
     # Remove the ors folder and war file from the webapps folder
     rm -rf %{jws_webapps}/ors
     rm -rf %{jws_webapps}/ors.war

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -128,10 +128,6 @@ chown -R %{ors_user}:%{ors_group} ${ORS_HOME}
 # Set recursive 770 permissions for the /opt/openrouteservice folder so that the ${ors_group} can read and write to it
 chmod -R 770 ${ORS_HOME}
 
-%posttrans
-# Clean the ors_local_folder as the last step of the installation
-rm -rf %{ors_local_folder}
-
 %postun
 # Uninstall routine if $1 is 0 but leave the opt folder
 # For explanation check https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
@@ -140,6 +136,7 @@ if [ "$1" = "0" ]; then
     # Remove the ors folder and war file from the webapps folder
     rm -rf %{jws_webapps}/ors
     rm -rf %{jws_webapps}/ors.war
+    rm -rf %{ors_local_folder}
     # Remove the ors user
     userdel %{ors_user}
     # Remove the ors group

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -107,12 +107,11 @@ fi
 
 
 # Setup openrouteservice opt folder
-mkdir -p "${ORS_HOME}/graphs"
+mkdir -p "${ORS_HOME}/.graphs"
 mkdir -p "${ORS_HOME}/logs"
 mkdir -p "${ORS_HOME}/config"
 mkdir -p "${ORS_HOME}/files"
 mkdir -p "${ORS_HOME}/.elevation-cache"
-mkdir -p "${ORS_HOME}/.war-files"
 
 %post
 echo "Copy %{ors_version}_ors.war to %{jws_webapps}"
@@ -128,6 +127,10 @@ chmod 740 %{jws_webapps}/ors.war
 chown -R %{ors_user}:%{ors_group} ${ORS_HOME}
 # Set recursive 770 permissions for the /opt/openrouteservice folder so that the ${ors_group} can read and write to it
 chmod -R 770 ${ORS_HOME}
+
+%posttrans
+# Clean the ors_local_folder as the last step of the installation
+rm -rf %{ors_local_folder}
 
 %postun
 # Uninstall routine if $1 is 0 but leave the opt folder

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -1,10 +1,10 @@
 %define java_version 17
 %define ors_version %{getenv:ORS_VERSION}
-%define ors_local_folder /opt/openrouteservice
+%define ors_local_folder /tmp/openrouteservice
 %define tomcat_user tomcat
-%define jboss_user jboss
 %define ors_group openrouteservice
 %define ors_user  openrouteservice
+%define jws_webapps /var/opt/rh/jws5/tomcat/webapps/
 Name: openrouteservice-jws5
 Version: %{ors_version}
 Release: 1
@@ -41,50 +41,43 @@ cp -f example-config.json %{buildroot}%{ors_local_folder}/config/example-config.
 
 %pre
 # Check for the JWS home ENV variable to be set and echo 'set'
-if [ -n "${JWS_HOME}" ]; then
-    echo "JWS_HOME found. Assuming JWS installation at ${JWS_HOME}"
+if [ -n "${ORS_HOME}" ]; then
+    echo "ORS_HOME found. Attempting ORS installation at ${ORS_HOME}"
 else
-    echo "JWS_HOME is not set. Exiting installation."
+    echo "ORS_HOME is not set. Exiting installation."
     # Exit the rpm installation with an error
     exit 1
 fi
 
 echo "Create the webapps folder in ${JWS_HOME} if it does not exist."
-if [ -d ${JWS_HOME}/webapps ]; then
-    echo "JWS webapps dir found at ${JWS_HOME}/webapps"
+if [ -d %{jws_webapps} ]; then
+    echo "JWS webapps dir found at %{jws_webapps}"
 else
-    echo "No webapps folder found. Create JWS webapps dir at ${JWS_HOME}/webapps"
-    mkdir -p ${JWS_HOME}/webapps
+    echo "No webapps folder found. Exiting installation."
+    # Exit the rpm installation with an error
+    exit 1
 fi
 
 # Check for the existence of an old ors installation in the webapps folder and clean it.
-if [ -d ${JWS_HOME}/webapps/ors ]; then
-    echo "JWS webapps dir found with old ors installation at ${JWS_HOME}/webapps. Cleaning it."
-    rm -rf ${JWS_HOME}/webapps/ors
+if [ -d %{jws_webapps}/ors ]; then
+    echo "JWS webapps dir found with old ors installation at /var/opt/rh/jws5/tomcat/webapps. Cleaning it."
+    rm -rf %{jws_webapps}/ors
 fi
 
 # Create the correct group for the ors installation
 getent group %{ors_group} >/dev/null || groupadd -r %{ors_group}
 
-# Check if the jboss user exists and add it to the ors group
-if id -u jboss >/dev/null 2>&1; then
-    echo "jboss user exists. Adding it to the ors group for data access."
-    usermod -a -G %{ors_group} jboss
-else
-    echo "jboss user does not exist. Skipping adding it to the ors group."
-fi
-
 # Check if the tomcat user exists and add it to the ors group
-if id -u tomcat >/dev/null 2>&1; then
+if id -u %{tomcat_user} >/dev/null 2>&1; then
     echo "tomcat user exists. Adding it to the ors group for data access."
-    usermod -a -G %{ors_group} tomcat
+    usermod -a -G %{ors_group} %{tomcat_user}
 else
     echo "tomcat user does not exist. Skipping adding it to the ors group."
 fi
 
-# When neither jboss nor tomcat user exist, exit with an error
-if ! id -u jboss >/dev/null 2>&1 && ! id -u tomcat >/dev/null 2>&1; then
-    echo "Neither jboss nor tomcat user exist. Unknown tomcat setup. Exiting installation."
+# When tomcat user does not exist, exit with an error
+if ! id -u %{tomcat_user} >/dev/null 2>&1; then
+    echo "tomcat user does not exist. Unknown tomcat setup. Exiting installation."
     # Exit the rpm installation with an error
     exit 1
 fi
@@ -96,53 +89,41 @@ if id -u %{ors_user} >/dev/null 2>&1; then
     usermod -a -G %{ors_group} %{ors_user}
 else
     echo "openrouteservice user does not exist. Creating it and adding it to the ors group."
-    useradd -r -g %{ors_group} -d %{ors_local_folder} -s /sbin/nologin %{ors_user}
+    useradd -r -g %{ors_group} -d ${ORS_HOME} -s /sbin/nologin %{ors_user}
 fi
 
 
 # Setup openrouteservice opt folder
-mkdir -p "%{ors_local_folder}/graphs"
-mkdir -p "%{ors_local_folder}/logs"
-mkdir -p "%{ors_local_folder}/config"
-mkdir -p "%{ors_local_folder}/files"
-mkdir -p "%{ors_local_folder}/.elevation-cache"
-mkdir -p "%{ors_local_folder}/.war-files"
+mkdir -p "${ORS_HOME}/graphs"
+mkdir -p "${ORS_HOME}/logs"
+mkdir -p "${ORS_HOME}/config"
+mkdir -p "${ORS_HOME}/files"
+mkdir -p "${ORS_HOME}/.elevation-cache"
+mkdir -p "${ORS_HOME}/.war-files"
 
 %post
-# Check for the JWS home ENV variable to be set and echo 'set'
-if [ -n "${JWS_HOME}" ]; then
-    echo "Link %{ors_version}_ors.war to ${JWS_HOME}/webapps"
-    # Create a symlink that links the ors.war file to the webapps folder
-    ln -s %{ors_local_folder}/.war-files/%{ors_version}_ors.war ${JWS_HOME}/webapps/ors.war
-else
-    echo "JWS_HOME is not set. Exiting installation."
-    # Exit the rpm installation with an error
-    exit 1
-fi
-
-# Set environment variable in Tomcat startup script to pick up the correct config file
-echo 'export ORS_CONFIG=%{ors_local_folder}/config/ors-config.json' >> /etc/environment
-echo 'export ORS_LOG_LOCATION=%{ors_local_folder}/logs/' >> /etc/environment
+echo "Copy %{ors_version}_ors.war to %{jws_webapps}"
+cp -f %{ors_local_folder}/config/example-config.json ${ORS_HOME}/config/example-config.json
+cp -f %{ors_local_folder}/.war-files/%{ors_version}_ors.war %{jws_webapps}/ors.war
 
 # Switch to the installed java version
 alternatives --set java $(readlink -f /etc/alternatives/jre_%{java_version})/bin/java
 
+chown %{tomcat_user} %{jws_webapps}/ors.war
+chmod 740 %{jws_webapps}/ors.war
 # Set the correct permissions for the /opt/openrouteservice folder so that the ${ors_group} can read and write to it
-chown -R %{ors_user}:%{ors_group} %{ors_local_folder}
+chown -R %{ors_user}:%{ors_group} ${ORS_HOME}
 # Set recursive 770 permissions for the /opt/openrouteservice folder so that the ${ors_group} can read and write to it
-chmod -R 770 %{ors_local_folder}
+chmod -R 770 ${ORS_HOME}
 
 %postun
 # Uninstall routine if $1 is 0 but leave the opt folder
 # For explanation check https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
 if [ "$1" = "0" ]; then
     echo "Uninstalling openrouteservice"
-    # Remove environment variable from Tomcat startup script on uninstall
-    sed -i '/export ORS_CONFIG=/d' /etc/environment
-    sed -i '/export ORS_LOG_LOCATION=/d' /etc/environment
     # Remove the ors folder and war file from the webapps folder
-    rm -rf ${JWS_HOME}/webapps/ors
-    rm -rf ${JWS_HOME}/webapps/ors.war
+    rm -rf %{jws_webapps}/ors
+    rm -rf %{jws_webapps}/ors.war
     # Remove the ors user
     userdel %{ors_user}
     # Remove the ors group

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -62,7 +62,7 @@ fi
 
 # Check if the environment variables are set for JWS_CONF_FOLDER and JWS_WEBAPPS_FOLDER if not, set the default values for them
 if [ -z "${JWS_CONF_FOLDER}" ]; then
-    echo "JWS_CONF_FOLDER is not set. Setting default value of %{jws_config_folder}."
+    echo "JWS_CONF_FOLDER is not explicitly set. Setting default value to %{jws_config_folder}."
     jws_config_folder=%{jws_config_folder}
 else
     jws_config_folder=${JWS_CONF_FOLDER}
@@ -70,7 +70,7 @@ fi
 
 # Do the same for the JWS_WEBAPPS_FOLDER
 if [ -z "${JWS_WEBAPPS_FOLDER}" ]; then
-    echo "JWS_WEBAPPS_FOLDER is not set. Setting default value of %{jws_webapps_folder}."
+    echo "JWS_WEBAPPS_FOLDER is not explicitly set. Setting default value to %{jws_webapps_folder}."
     jws_webapps_folder=%{jws_webapps_folder}
 else
     jws_webapps_folder=${JWS_WEBAPPS_FOLDER}

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -4,9 +4,9 @@
 %define tomcat_user tomcat
 %define ors_group openrouteservice
 %define ors_user  openrouteservice
-%define jws_home /var/opt/rh/jws5/tomcat
+%define jws_home /etc/opt/rh/scls/jws5/tomcat
 %define jws_webapps %{jws_home}/webapps/
-%define jws_config_location %{jws_home}/conf/jws5-tomcat.conf
+%define jws_config_location %{jws_home}/conf.d/openrouteservice.conf
 Name: openrouteservice-jws5
 Version: %{ors_version}
 Release: 1
@@ -60,15 +60,12 @@ else
 fi
 
 if [ -f %{jws_config_location} ]; then
-    echo "Tomcat config found at %{jws_config_location}"
-    echo "Permanently saving the given ORS_HOME=${ORS_HOME} location in the tomcat config."
-    # Remove any line that starts with ORS_HOME=
-    sed -i '/^ORS_HOME=/d' %{jws_config_location}
-    # Add the ORS_HOME variable to the tomcat config
-    echo "ORS_HOME=${ORS_HOME}" >> %{jws_config_location}
+    echo "Custom Tomcat config found at %{jws_config_location}. "
 else
-    echo "No tomcat config found at %{jws_config_location}. Exiting installation."
-    exit 1
+    echo "Creating custom Tomcat config at %{jws_config_location}"
+    echo "Permanently saving the given ORS_HOME=${ORS_HOME} location in the tomcat config."
+    echo "ORS_HOME=${ORS_HOME}" >> %{jws_config_location}
+    echo 'CATALINA_OPTS="$CATALINA_OPTS -Xms4g -Xmx4g"' >> %{jws_config_location}
 fi
 
 # Check for the existence of an old ors installation in the webapps folder and clean it.
@@ -133,8 +130,8 @@ chmod -R 770 ${ORS_HOME}
 # For explanation check https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
 if [ "$1" = "0" ]; then
     echo "Uninstalling openrouteservice"
-    # Remove any line that starts with ORS_HOME=
-    sed -i '/^ORS_HOME=/d' %{jws_config_location}
+    # Remove custom tomcat config file
+    rm -rf %{jws_config_location}
     # Remove the ors folder and war file from the webapps folder
     rm -rf %{jws_webapps}/ors
     rm -rf %{jws_webapps}/ors.war

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -6,7 +6,7 @@
 %define jws_config_folder /etc/opt/rh/scls/jws5/tomcat/conf.d
 %define jws_webapps_folder /var/opt/rh/scls/jws5/lib/tomcat/webapps
 %define rpm_state_dir %{_localstatedir}/lib/rpm-state/openrouteservice
-%define ors_local_folder %{rpm_state_dir}/install
+%define ors_temporary_files_location %{rpm_state_dir}/install
 Name: openrouteservice-jws5
 Version: %{ors_version}
 Release: 1
@@ -28,18 +28,18 @@ It is highly customizable, performant and written in Java.
 This rpm package looks for an installation of JBoss JWS and installs the WAR file accordingly.
 
 %install
-mkdir -p %{buildroot}%{ors_local_folder}/.war-files/
-mkdir -p %{buildroot}%{ors_local_folder}/config/
+mkdir -p %{buildroot}%{ors_temporary_files_location}/.war-files/
+mkdir -p %{buildroot}%{ors_temporary_files_location}/config/
 # Copy the ors.war file to the .war-files folder
-cp -f ors.war %{buildroot}%{ors_local_folder}/.war-files/%{ors_version}_ors.war
+cp -f ors.war %{buildroot}%{ors_temporary_files_location}/.war-files/%{ors_version}_ors.war
 # Copy the example-config.json file to the config folder
-cp -f example-config.json %{buildroot}%{ors_local_folder}/config/example-config.json
+cp -f example-config.json %{buildroot}%{ors_temporary_files_location}/config/example-config.json
 
 %files
 # Allow 770 for read and write for files for the ors group
 %defattr(770,%{ors_user},%{ors_group},-)
-"%{ors_local_folder}/.war-files/%{ors_version}_ors.war"
-"%{ors_local_folder}/config/example-config.json"
+"%{ors_temporary_files_location}/.war-files/%{ors_version}_ors.war"
+"%{ors_temporary_files_location}/config/example-config.json"
 
 %pre
 ###############################################################################################################
@@ -52,7 +52,7 @@ cp -f example-config.json %{buildroot}%{ors_local_folder}/config/example-config.
 # Check for the JWS home ENV variable to be set and echo 'set'
 if [ -n "${ORS_HOME}" ]; then
     echo "ORS_HOME variable found. Attempting ORS installation at ${ORS_HOME}."
-    mkdir -p ${ORS_HOME} %{ors_local_folder}
+    mkdir -p ${ORS_HOME} %{ors_temporary_files_location}
     echo "ORS_HOME=${ORS_HOME}" > %{rpm_state_dir}/openrouteservice-jws5-temp-home-state
 else
     echo "ORS_HOME is not set. Exiting installation."
@@ -123,7 +123,7 @@ if [ $1 -eq 0 ]; then
     # Check for the JWS home ENV variable to be set and echo 'set'
     if [ -n "${ORS_HOME}" ]; then
         echo "ORS_HOME found. Uninstalling ORS from ${ORS_HOME}."
-        mkdir -p %{ors_local_folder}
+        mkdir -p %{ors_temporary_files_location}
         echo "ORS_HOME=${ORS_HOME}" > %{rpm_state_dir}/openrouteservice-jws5-temp-home-state
     else
         echo "ORS_HOME is not set. Exiting uninstall routine."
@@ -200,8 +200,8 @@ mkdir -p "${ORS_HOME}/files"
 mkdir -p "${ORS_HOME}/.elevation-cache"
 
 echo "Copy %{ors_version}_ors.war to ${jws_webapps_folder}"
-cp -f %{ors_local_folder}/config/example-config.json ${ORS_HOME}/config/example-config.json
-cp -f %{ors_local_folder}/.war-files/%{ors_version}_ors.war ${jws_webapps_folder}/ors.war
+cp -f %{ors_temporary_files_location}/config/example-config.json ${ORS_HOME}/config/example-config.json
+cp -f %{ors_temporary_files_location}/.war-files/%{ors_version}_ors.war ${jws_webapps_folder}/ors.war
 
 # Switch to the installed java version
 alternatives --set java $(readlink -f /etc/alternatives/jre_%{java_version})/bin/java

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -162,6 +162,23 @@ chown -R %{ors_user}:%{ors_group} ${ORS_HOME}
 chmod -R 770 ${ORS_HOME}
 
 %postun
+
+# Check if the environment variables are set for JWS_CONF_FOLDER and JWS_WEBAPPS_FOLDER if not, set the default values for them
+if [ -z "${JWS_CONF_FOLDER}" ]; then
+    echo "JWS_CONF_FOLDER is not set. Setting default value of %{jws_config_folder}."
+    export jws_config_folder=%{jws_config_folder}
+else
+    export jws_config_folder=${JWS_CONF_FOLDER}
+fi
+
+# Do the same for the JWS_WEBAPPS_FOLDER
+if [ -z "${JWS_WEBAPPS_FOLDER}" ]; then
+    echo "JWS_WEBAPPS_FOLDER is not set. Setting default value of %{jws_webapps_folder}."
+    export jws_webapps_folder=%{jws_webapps_folder}
+else
+    export jws_webapps_folder=${JWS_WEBAPPS_FOLDER}
+fi
+
 # Uninstall routine if $1 is 0 but leave the opt folder
 # For explanation check https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
 if [ "$1" = "0" ]; then

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -130,7 +130,6 @@ if [ $1 -eq 0 ]; then
         # Exit the rpm installation with an error
         exit 1
     fi
-    . ${ORS_HOME}/.openrouteservice-jws5-permanent-state
 fi
 
 %post

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -45,7 +45,9 @@ check_user_exists 'openrouteservice' true || SUCCESSFUL=false
 check_user_exists 'tomcat' true || SUCCESSFUL=false
 check_user_in_group 'tomcat' 'openrouteservice' || SUCCESSFUL=false
 check_user_in_group 'openrouteservice' 'openrouteservice' || SUCCESSFUL=false
-
+# Check environment variables
+# shellcheck disable=SC2016
+check_line_in_file 'ORS_HOME=/opt/openrouteservice' '/var/opt/rh/jws5/tomcat/conf/jws5-tomcat.conf' true || SUCCESSFUL=false
 # Check Java version
 check_java_version '17.' || SUCCESSFUL=false
 # Check for owned content

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -19,47 +19,43 @@ echo "Checking the installation"
 # Check if the RPM package is installed
 check_rpm_installed 'openrouteservice-jws5' true || SUCCESSFUL=false
 # Check the correct directory and file structure
-check_file_exists '/opt/openrouteservice/config/example-config.json' true || SUCCESSFUL=false
-check_file_exists '/opt/openrouteservice/.elevation-cache/srtm_38_03.gh' true || SUCCESSFUL=false
-check_file_exists '/opt/openrouteservice/files/osm-file.osm.gz' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.elevation-cache/srtm_38_03.gh' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/files/osm-file.osm.gz' true || SUCCESSFUL=false
 # shellcheck disable=SC2016
-check_folder_exists '${JWS_HOME}/webapps' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/config' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/logs' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/.war-files' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/.elevation-cache' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/files' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/graphs' true || SUCCESSFUL=false
-check_file_exists "/opt/openrouteservice/.war-files/${ORS_VERSION}_ors.war" true || SUCCESSFUL=false
-check_file_exists '/opt/openrouteservice/config/example-config.json' true || SUCCESSFUL=false
+check_folder_exists '/var/opt/rh/jws5/tomcat/webapps' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/config' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
+check_folder_exists '/tmp/openrouteservice/.war-files' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/files' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/graphs' true || SUCCESSFUL=false
+check_file_exists "/tmp/openrouteservice/.war-files/${ORS_VERSION}_ors.war" true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
 
 # shellcheck disable=SC2016
-check_folder_exists '${JWS_HOME}/webapps/ors' false || SUCCESSFUL=false
+check_folder_exists '/var/opt/rh/jws5/tomcat/webapps/ors' false || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # Check symlink ors.war to webapps folder
-check_file_is_symlink '${JWS_HOME}/webapps/ors.war' true || SUCCESSFUL=false
+check_file_exists '/var/opt/rh/jws5/tomcat/webapps/ors.war' true || SUCCESSFUL=false
 # Check user and group setup
 check_group_exists 'openrouteservice' true || SUCCESSFUL=false
 check_user_exists 'openrouteservice' true || SUCCESSFUL=false
-check_user_exists 'jboss' true || SUCCESSFUL=false
-check_user_in_group 'jboss' 'openrouteservice' || SUCCESSFUL=false
+check_user_exists 'tomcat' true || SUCCESSFUL=false
+check_user_in_group 'tomcat' 'openrouteservice' || SUCCESSFUL=false
 check_user_in_group 'openrouteservice' 'openrouteservice' || SUCCESSFUL=false
-# Check environment variables
-# shellcheck disable=SC2016
-check_line_in_file 'export ORS_CONFIG=/opt/openrouteservice/config/ors-config.json' '/etc/environment' true || SUCCESSFUL=false
-# shellcheck disable=SC2016
-check_line_in_file 'export ORS_LOG_LOCATION=/opt/openrouteservice/logs/' '/etc/environment' true || SUCCESSFUL=false
+
 # Check Java version
 check_java_version '17.' || SUCCESSFUL=false
 # Check for owned content
-find_owned_content "/opt/openrouteservice/*" "openrouteservice" "" 6 || SUCCESSFUL=false
-find_owned_content "/opt/openrouteservice/*" "" "openrouteservice" 6 || SUCCESSFUL=false
-find_owned_content "/opt/openrouteservice/*" "openrouteservice" "openrouteservice" 6 || SUCCESSFUL=false
-find_owned_content "/opt/openrouteservice/*" "" "root" 0 || SUCCESSFUL=false
-find_owned_content "/opt/openrouteservice/*" "root" "" 0 || SUCCESSFUL=false
-find_owned_content "/opt/openrouteservice/*" "jboss" "" 0 || SUCCESSFUL=false
-find_owned_content "/opt/openrouteservice/*" "" "jboss" 0 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "openrouteservice" "" 6 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 6 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "openrouteservice" "openrouteservice" 6 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "" "root" 0 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "root" "" 0 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "tomcat" "" 0 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "" "tomcat" 0 || SUCCESSFUL=false
 
 
 # Fail if any of the checks failed

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -14,6 +14,10 @@ START_DIRECTORY="$(
 # Assume successful at first and assign false if any of the checks fails
 SUCCESSFUL=true
 
+# Set variables
+JWS_WEBAPPS_DIRECTORY='/var/opt/rh/scls/jws5/lib/tomcat/webapps'
+JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d/'
+
 
 echo "Checking the installation"
 # Check if the RPM package is installed
@@ -23,7 +27,7 @@ check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=fa
 check_file_exists '${ORS_HOME}/.elevation-cache/srtm_38_03.gh' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/files/osm-file.osm.gz' true || SUCCESSFUL=false
 # shellcheck disable=SC2016
-check_folder_exists '/var/opt/rh/jws5/tomcat/webapps' true || SUCCESSFUL=false
+check_folder_exists "$JWS_WEBAPPS_DIRECTORY" true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/config' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
@@ -35,10 +39,10 @@ check_file_exists "/tmp/openrouteservice/.war-files/${ORS_VERSION}_ors.war" true
 check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
 
 # shellcheck disable=SC2016
-check_folder_exists '/var/opt/rh/jws5/tomcat/webapps/ors' false || SUCCESSFUL=false
+check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # Check symlink ors.war to webapps folder
-check_file_exists '/var/opt/rh/jws5/tomcat/webapps/ors.war' true || SUCCESSFUL=false
+check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" true || SUCCESSFUL=false
 # Check user and group setup
 check_group_exists 'openrouteservice' true || SUCCESSFUL=false
 check_user_exists 'openrouteservice' true || SUCCESSFUL=false
@@ -47,7 +51,9 @@ check_user_in_group 'tomcat' 'openrouteservice' || SUCCESSFUL=false
 check_user_in_group 'openrouteservice' 'openrouteservice' || SUCCESSFUL=false
 # Check environment variables
 # shellcheck disable=SC2016
-check_line_in_file 'ORS_HOME=/opt/openrouteservice' '/var/opt/rh/jws5/tomcat/conf/jws5-tomcat.conf' true || SUCCESSFUL=false
+check_line_in_file "ORS_HOME=/opt/openrouteservice" "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" true || SUCCESSFUL=false
+check_line_in_file 'CATALINA_OPTS=' "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" true || SUCCESSFUL=false
+
 # Check Java version
 check_java_version '17.' || SUCCESSFUL=false
 # Check for owned content

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -31,12 +31,17 @@ check_folder_exists "$JWS_WEBAPPS_DIRECTORY" true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/config' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
-check_folder_exists '/tmp/openrouteservice/.war-files' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/files' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/.graphs' true || SUCCESSFUL=false
-check_file_exists "/tmp/openrouteservice/.war-files/${ORS_VERSION}_ors.war" true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
+
+# Check the state file is created and contains the correct variables
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
 
 # shellcheck disable=SC2016
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -41,7 +41,7 @@ check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=fa
 # shellcheck disable=SC2016
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 # shellcheck disable=SC2016
-# Check symlink ors.war to webapps folder
+# Check ors.war in webapps folder
 check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" true || SUCCESSFUL=false
 # Check user and group setup
 check_group_exists 'openrouteservice' true || SUCCESSFUL=false
@@ -52,7 +52,7 @@ check_user_in_group 'openrouteservice' 'openrouteservice' || SUCCESSFUL=false
 # Check environment variables
 # shellcheck disable=SC2016
 check_line_in_file "ORS_HOME=/opt/openrouteservice" "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" true || SUCCESSFUL=false
-check_line_in_file 'CATALINA_OPTS=' "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" true || SUCCESSFUL=false
+check_line_in_file "CATALINA_OPTS=" "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" true || SUCCESSFUL=false
 
 # Check Java version
 check_java_version '17.' || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -44,8 +44,6 @@ check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-stat
 check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 
 # shellcheck disable=SC2016
-check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
-# shellcheck disable=SC2016
 # Check ors.war in webapps folder
 check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" true || SUCCESSFUL=false
 # Check user and group setup

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -47,9 +47,9 @@ check_user_in_group 'jboss' 'openrouteservice' || SUCCESSFUL=false
 check_user_in_group 'openrouteservice' 'openrouteservice' || SUCCESSFUL=false
 # Check environment variables
 # shellcheck disable=SC2016
-check_line_in_file 'export ORS_CONFIG=/opt/openrouteservice/config/ors-config.json' '${JWS_HOME}/bin/setenv.sh' true || SUCCESSFUL=false
+check_line_in_file 'export ORS_CONFIG=/opt/openrouteservice/config/ors-config.json' '/etc/environment' true || SUCCESSFUL=false
 # shellcheck disable=SC2016
-check_line_in_file 'export ORS_LOG_LOCATION=/opt/openrouteservice/logs/' '${JWS_HOME}/bin/setenv.sh' true || SUCCESSFUL=false
+check_line_in_file 'export ORS_LOG_LOCATION=/opt/openrouteservice/logs/' '/etc/environment' true || SUCCESSFUL=false
 # Check Java version
 check_java_version '17.' || SUCCESSFUL=false
 # Check for owned content

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -38,8 +38,8 @@ check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=fa
 
 # Check the state file is created and contains the correct variables
 check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
-check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
-check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_webapps_folder=${JWS_WEBAPPS_DIRECTORY}" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_config_location=${JWS_CONFIGURATION_DIRECTORY}" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -16,7 +16,7 @@ SUCCESSFUL=true
 
 # Set variables
 JWS_WEBAPPS_DIRECTORY='/var/opt/rh/scls/jws5/lib/tomcat/webapps'
-JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d/'
+JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d'
 
 
 echo "Checking the installation"

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -37,11 +37,11 @@ check_folder_exists '${ORS_HOME}/.graphs' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
 
 # Check the state file is created and contains the correct variables
-check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 
 # shellcheck disable=SC2016
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -30,7 +30,7 @@ check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
 check_folder_exists '/tmp/openrouteservice/.war-files' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/files' true || SUCCESSFUL=false
-check_folder_exists '${ORS_HOME}/graphs' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/.graphs' true || SUCCESSFUL=false
 check_file_exists "/tmp/openrouteservice/.war-files/${ORS_VERSION}_ors.war" true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
 
@@ -49,9 +49,9 @@ check_user_in_group 'openrouteservice' 'openrouteservice' || SUCCESSFUL=false
 # Check Java version
 check_java_version '17.' || SUCCESSFUL=false
 # Check for owned content
-find_owned_content '${ORS_HOME}/*' "openrouteservice" "" 6 || SUCCESSFUL=false
-find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 6 || SUCCESSFUL=false
-find_owned_content '${ORS_HOME}/*' "openrouteservice" "openrouteservice" 6 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "openrouteservice" "" 5 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 5 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "openrouteservice" "openrouteservice" 5 || SUCCESSFUL=false
 find_owned_content '${ORS_HOME}/*' "" "root" 0 || SUCCESSFUL=false
 find_owned_content '${ORS_HOME}/*' "root" "" 0 || SUCCESSFUL=false
 find_owned_content '${ORS_HOME}/*' "tomcat" "" 0 || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -18,41 +18,37 @@ echo "Checking the environment after uninstallation"
 # Check if the RPM package is installed
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
 # Check the correct directory and file structure
-check_file_exists '/opt/openrouteservice/config/example-config.json' false || SUCCESSFUL=false
-check_file_exists '/opt/openrouteservice/config/ors-config.json' true || SUCCESSFUL=false
-check_file_exists '/opt/openrouteservice/.elevation-cache/srtm_38_03.gh' true || SUCCESSFUL=false
-check_file_exists '/opt/openrouteservice/files/osm-file.osm.gz' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/config/ors-config.json' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.elevation-cache/srtm_38_03.gh' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/files/osm-file.osm.gz' true || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # The webapps folder belongs to JWS and shouldn't be removed
-check_folder_exists '${JWS_HOME}/webapps' true || SUCCESSFUL=false
+check_folder_exists '/var/opt/rh/jws5/tomcat/webapps' true || SUCCESSFUL=false
 # We leave the folder structure in place. No personal data will be removed
-check_folder_exists '/opt/openrouteservice' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/config' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/logs' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/.war-files' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/.elevation-cache' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/files' true || SUCCESSFUL=false
-check_folder_exists '/opt/openrouteservice/graphs' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/config' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/.war-files' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/files' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/graphs' true || SUCCESSFUL=false
 # Check that the war file is deleted
-check_file_exists "/opt/openrouteservice/.war-files/${ORS_VERSION}_ors.war" false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.war-files/'"${ORS_VERSION}"'_ors.war' false || SUCCESSFUL=false
 # The webapps/ors folder and the ors.war should not exist. Else ors would still be deployed
 # shellcheck disable=SC2016
-check_folder_exists '${JWS_HOME}/webapps/ors' false || SUCCESSFUL=false
+check_folder_exists '/var/opt/rh/jws5/tomcat/webapps/ors' false || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # Check symlink ors.war to webapps folder
-check_file_is_symlink '${JWS_HOME}/webapps/ors.war' false || SUCCESSFUL=false
+check_file_is_symlink '/var/opt/rh/jws5/tomcat/webapps/ors.war' false || SUCCESSFUL=false
 # openrouteservice user and group should be removed
 check_group_exists 'openrouteservice' false || SUCCESSFUL=false
 check_user_exists 'openrouteservice' false || SUCCESSFUL=false
-# The jboss user should still exist
-check_user_exists 'jboss' true || SUCCESSFUL=false
-# shellcheck disable=SC2016
-check_line_in_file 'export ORS_CONFIG=' '/etc/environment' false || SUCCESSFUL=false
-# shellcheck disable=SC2016
-check_line_in_file 'export ORS_LOG_LOCATION=' '/etc/environment' false || SUCCESSFUL=false
+# The tomcat user should still exist
+check_user_exists 'tomcat' true || SUCCESSFUL=false
 # Check for owned content
-find_owned_content "/opt/openrouteservice/*" "openrouteservice" "" 0 || SUCCESSFUL=false
-find_owned_content "/opt/openrouteservice/*" "" "openrouteservice" 0 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "openrouteservice" "" 0 || SUCCESSFUL=false
+find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 0 || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -55,7 +55,7 @@ find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 0 || SUCCESSFUL=false
 # Check environment variables are removed
 # shellcheck disable=SC2016
 check_file_exists "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" false || SUCCESSFUL=false
-check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -14,6 +14,10 @@ START_DIRECTORY="$(
 # Assume successful at first
 SUCCESSFUL=true
 
+# Set variables
+JWS_WEBAPPS_DIRECTORY='/var/opt/rh/scls/jws5/lib/tomcat/webapps'
+JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d/'
+
 echo "Checking the environment after uninstallation"
 # Check if the RPM package is installed
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
@@ -24,7 +28,7 @@ check_file_exists '${ORS_HOME}/.elevation-cache/srtm_38_03.gh' true || SUCCESSFU
 check_file_exists '${ORS_HOME}/files/osm-file.osm.gz' true || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # The webapps folder belongs to JWS and shouldn't be removed
-check_folder_exists '/var/opt/rh/jws5/tomcat/webapps' true || SUCCESSFUL=false
+check_folder_exists "$JWS_WEBAPPS_DIRECTORY" true || SUCCESSFUL=false
 # We leave the folder structure in place. No personal data will be removed
 check_folder_exists '${ORS_HOME}/config' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
@@ -33,10 +37,10 @@ check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/.graphs' true || SUCCESSFUL=false
 # The webapps/ors folder and the ors.war should not exist. Else ors would still be deployed
 # shellcheck disable=SC2016
-check_folder_exists '/var/opt/rh/jws5/tomcat/webapps/ors' false || SUCCESSFUL=false
+check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # Check symlink ors.war to webapps folder
-check_file_is_symlink '/var/opt/rh/jws5/tomcat/webapps/ors.war' false || SUCCESSFUL=false
+check_file_is_symlink "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
 # Check that the temp folder is deleted
 check_folder_exists '/tmp/openrouteservice' false || SUCCESSFUL=false
 # openrouteservice user and group should be removed
@@ -50,7 +54,8 @@ find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 0 || SUCCESSFUL=false
 
 # Check environment variables are removed
 # shellcheck disable=SC2016
-check_line_in_file 'ORS_HOME=/opt/openrouteservice' '/var/opt/rh/jws5/tomcat/conf/jws5-tomcat.conf' false || SUCCESSFUL=false
+check_line_in_file 'ORS_HOME=/opt/openrouteservice' "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" false || SUCCESSFUL=false
+check_line_in_file 'CATALINA_OPTS=' "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -16,7 +16,7 @@ SUCCESSFUL=true
 
 # Set variables
 JWS_WEBAPPS_DIRECTORY='/var/opt/rh/scls/jws5/lib/tomcat/webapps'
-JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d/'
+JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d'
 
 echo "Checking the environment after uninstallation"
 # Check if the RPM package is installed

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -40,7 +40,7 @@ check_folder_exists '${ORS_HOME}/.graphs' true || SUCCESSFUL=false
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # Check symlink ors.war to webapps folder
-check_file_is_symlink "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
+check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
 # Check that the temp folder is deleted
 check_folder_exists '/tmp/openrouteservice' false || SUCCESSFUL=false
 # openrouteservice user and group should be removed
@@ -54,8 +54,7 @@ find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 0 || SUCCESSFUL=false
 
 # Check environment variables are removed
 # shellcheck disable=SC2016
-check_line_in_file 'ORS_HOME=/opt/openrouteservice' "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" false || SUCCESSFUL=false
-check_line_in_file 'CATALINA_OPTS=' "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" false || SUCCESSFUL=false
+check_file_exists "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -55,6 +55,7 @@ find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 0 || SUCCESSFUL=false
 # Check environment variables are removed
 # shellcheck disable=SC2016
 check_file_exists "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -47,9 +47,9 @@ check_user_exists 'openrouteservice' false || SUCCESSFUL=false
 # The jboss user should still exist
 check_user_exists 'jboss' true || SUCCESSFUL=false
 # shellcheck disable=SC2016
-check_line_in_file 'export ORS_CONFIG=' '${JWS_HOME}/bin/setenv.sh' false || SUCCESSFUL=false
+check_line_in_file 'export ORS_CONFIG=' '/etc/environment' false || SUCCESSFUL=false
 # shellcheck disable=SC2016
-check_line_in_file 'export ORS_LOG_LOCATION=' '${JWS_HOME}/bin/setenv.sh' false || SUCCESSFUL=false
+check_line_in_file 'export ORS_LOG_LOCATION=' '/etc/environment' false || SUCCESSFUL=false
 # Check for owned content
 find_owned_content "/opt/openrouteservice/*" "openrouteservice" "" 0 || SUCCESSFUL=false
 find_owned_content "/opt/openrouteservice/*" "" "openrouteservice" 0 || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -48,6 +48,10 @@ check_user_exists 'tomcat' true || SUCCESSFUL=false
 find_owned_content '${ORS_HOME}/*' "openrouteservice" "" 0 || SUCCESSFUL=false
 find_owned_content '${ORS_HOME}/*' "" "openrouteservice" 0 || SUCCESSFUL=false
 
+# Check environment variables are removed
+# shellcheck disable=SC2016
+check_line_in_file 'ORS_HOME=/opt/openrouteservice' '/var/opt/rh/jws5/tomcat/conf/jws5-tomcat.conf' false || SUCCESSFUL=false
+
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then
   log_error "Post-install check failed. Please check the log for more details."

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -18,7 +18,7 @@ echo "Checking the environment after uninstallation"
 # Check if the RPM package is installed
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
 # Check the correct directory and file structure
-check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/ors-config.json' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/.elevation-cache/srtm_38_03.gh' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/files/osm-file.osm.gz' true || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -41,8 +41,6 @@ check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # Check symlink ors.war to webapps folder
 check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
-# Check that the temp folder is deleted
-check_folder_exists '/tmp/openrouteservice' false || SUCCESSFUL=false
 # openrouteservice user and group should be removed
 check_group_exists 'openrouteservice' false || SUCCESSFUL=false
 check_user_exists 'openrouteservice' false || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_post_uninstall_check.sh
@@ -26,21 +26,19 @@ check_file_exists '${ORS_HOME}/files/osm-file.osm.gz' true || SUCCESSFUL=false
 # The webapps folder belongs to JWS and shouldn't be removed
 check_folder_exists '/var/opt/rh/jws5/tomcat/webapps' true || SUCCESSFUL=false
 # We leave the folder structure in place. No personal data will be removed
-check_folder_exists '${ORS_HOME}' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/config' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
-check_folder_exists '${ORS_HOME}/.war-files' true || SUCCESSFUL=false
-check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/files' true || SUCCESSFUL=false
-check_folder_exists '${ORS_HOME}/graphs' true || SUCCESSFUL=false
-# Check that the war file is deleted
-check_file_exists '${ORS_HOME}/.war-files/'"${ORS_VERSION}"'_ors.war' false || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
+check_folder_exists '${ORS_HOME}/.graphs' true || SUCCESSFUL=false
 # The webapps/ors folder and the ors.war should not exist. Else ors would still be deployed
 # shellcheck disable=SC2016
 check_folder_exists '/var/opt/rh/jws5/tomcat/webapps/ors' false || SUCCESSFUL=false
 # shellcheck disable=SC2016
 # Check symlink ors.war to webapps folder
 check_file_is_symlink '/var/opt/rh/jws5/tomcat/webapps/ors.war' false || SUCCESSFUL=false
+# Check that the temp folder is deleted
+check_folder_exists '/tmp/openrouteservice' false || SUCCESSFUL=false
 # openrouteservice user and group should be removed
 check_group_exists 'openrouteservice' false || SUCCESSFUL=false
 check_user_exists 'openrouteservice' false || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -14,12 +14,17 @@ START_DIRECTORY="$(
 # Assume successful at first and assign false if any of the checks fails
 SUCCESSFUL=true
 
+# Set variables
+JWS_WEBAPPS_DIRECTORY='/var/opt/rh/scls/jws5/lib/tomcat/webapps'
+JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d/'
+
 ##### Check clean environment #####
 echo "Checking the clean environment"
-# shellcheck disable=SC2016
-check_folder_exists '/var/opt/rh/jws5/tomcat/webapps/ors' false || SUCCESSFUL=false
-# shellcheck disable=SC2016
-check_file_exists '/var/opt/rh/jws5/tomcat/webapps/ors.war' false || SUCCESSFUL=false
+check_folder_exists "$JWS_WEBAPPS_DIRECTORY" true || SUCCESSFUL=false
+check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
+check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
+check_file_exists "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" true || SUCCESSFUL=false
+
 check_file_exists '/etc/yum.repos.d/ors.repo' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -23,7 +23,6 @@ echo "Checking the clean environment"
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY" true || SUCCESSFUL=false
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
-check_folder_exists "$JWS_CONFIGURATION_DIRECTORY" false || SUCCESSFUL=false
 
 check_file_exists '/etc/yum.repos.d/ors.repo' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -23,7 +23,6 @@ echo "Checking the clean environment"
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY" true || SUCCESSFUL=false
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
-check_file_exists "$JWS_CONFIGURATION_DIRECTORY/openrouteservice.conf" true || SUCCESSFUL=false
 
 check_file_exists '/etc/yum.repos.d/ors.repo' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -24,7 +24,9 @@ check_file_exists '/etc/yum.repos.d/ors.repo' true || SUCCESSFUL=false
 check_file_exists '/opt/openrouteservice/config/example-config.json' false || SUCCESSFUL=false
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
 # shellcheck disable=SC2016
-check_line_in_file 'export ORS_CONFIG=' '${JWS_HOME}/bin/setenv.sh' false || SUCCESSFUL=false
+check_line_in_file 'export ORS_CONFIG=' '/etc/environment' false || SUCCESSFUL=false
+# shellcheck disable=SC2016
+check_line_in_file 'export ORS_LOG_LOCATION=' '/etc/environment' false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -24,6 +24,9 @@ check_file_exists '/etc/yum.repos.d/ors.repo' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
 
+# Check that the temp folder is not present
+check_folder_exists '/tmp/openrouteservice' false || SUCCESSFUL=false
+
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then
   log_error "Pre-install check failed. Please check the log for more details."

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -16,16 +16,18 @@ SUCCESSFUL=true
 
 # Set variables
 JWS_WEBAPPS_DIRECTORY='/var/opt/rh/scls/jws5/lib/tomcat/webapps'
-JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d/'
+JWS_CONFIGURATION_DIRECTORY='/etc/opt/rh/scls/jws5/tomcat/conf.d'
 
 ##### Check clean environment #####
 echo "Checking the clean environment"
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY" true || SUCCESSFUL=false
 check_folder_exists "$JWS_WEBAPPS_DIRECTORY/ors" false || SUCCESSFUL=false
 check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" false || SUCCESSFUL=false
+check_folder_exists "$JWS_CONFIGURATION_DIRECTORY" false || SUCCESSFUL=false
 
 check_file_exists '/etc/yum.repos.d/ors.repo' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false
+
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
 
 # Check that the temp folder is not present

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -29,7 +29,7 @@ check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=f
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
 
 # Check that the temp folder is not present
-check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -17,16 +17,12 @@ SUCCESSFUL=true
 ##### Check clean environment #####
 echo "Checking the clean environment"
 # shellcheck disable=SC2016
-check_folder_exists '${JWS_HOME}/webapps/ors' false || SUCCESSFUL=false
+check_folder_exists '/var/opt/rh/jws5/tomcat/webapps/ors' false || SUCCESSFUL=false
 # shellcheck disable=SC2016
-check_file_exists '${JWS_HOME}/webapps/ors.war' false || SUCCESSFUL=false
+check_file_exists '/var/opt/rh/jws5/tomcat/webapps/ors.war' false || SUCCESSFUL=false
 check_file_exists '/etc/yum.repos.d/ors.repo' true || SUCCESSFUL=false
-check_file_exists '/opt/openrouteservice/config/example-config.json' false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=false
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
-# shellcheck disable=SC2016
-check_line_in_file 'export ORS_CONFIG=' '/etc/environment' false || SUCCESSFUL=false
-# shellcheck disable=SC2016
-check_line_in_file 'export ORS_LOG_LOCATION=' '/etc/environment' false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_pre_install_check.sh
+++ b/.rpm-packaging/rhel8_pre_install_check.sh
@@ -29,7 +29,7 @@ check_file_exists '${ORS_HOME}/config/example-config.json' false || SUCCESSFUL=f
 check_rpm_installed 'openrouteservice-jws5' false || SUCCESSFUL=false
 
 # Check that the temp folder is not present
-check_folder_exists '/tmp/openrouteservice' false || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' false || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_pre_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_pre_uninstall_check.sh
@@ -16,7 +16,7 @@ SUCCESSFUL=true
 
 echo "Checking the environment before uninstallation"
 # Check the log file has been created in the correct location
-check_file_exists '/opt/openrouteservice/logs/ors.log' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/logs/ors.log' true || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_pre_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_pre_uninstall_check.sh
@@ -20,8 +20,8 @@ check_file_exists '${ORS_HOME}/logs/ors.log' true || SUCCESSFUL=false
 check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 # Check the state file is created and contains the correct variables
 check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
-check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
-check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_webapps_folder=${JWS_WEBAPPS_DIRECTORY}" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_config_location=${JWS_CONFIGURATION_DIRECTORY}" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 

--- a/.rpm-packaging/rhel8_pre_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_pre_uninstall_check.sh
@@ -17,13 +17,13 @@ SUCCESSFUL=true
 echo "Checking the environment before uninstallation"
 # Check the log file has been created in the correct location
 check_file_exists '${ORS_HOME}/logs/ors.log' true || SUCCESSFUL=false
-check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 # Check the state file is created and contains the correct variables
-check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
-check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
+check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/rhel8_pre_uninstall_check.sh
+++ b/.rpm-packaging/rhel8_pre_uninstall_check.sh
@@ -17,6 +17,13 @@ SUCCESSFUL=true
 echo "Checking the environment before uninstallation"
 # Check the log file has been created in the correct location
 check_file_exists '${ORS_HOME}/logs/ors.log' true || SUCCESSFUL=false
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+# Check the state file is created and contains the correct variables
+check_file_exists '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "jws_webapps_folder=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "jws_config_location=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
+check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-state' true || SUCCESSFUL=false
 
 # Fail if any of the checks failed
 if [[ "$SUCCESSFUL" == false ]]; then

--- a/.rpm-packaging/scripts/helper_functions.sh
+++ b/.rpm-packaging/scripts/helper_functions.sh
@@ -56,7 +56,7 @@ check_line_in_file() {
 
     local result
     local exit_code
-    result=$(${CONTAINER_ENGINE} exec -u root "$CONTAINER_NAME" bash -c "grep -Fx '$line' $path_to_file")
+    result=$(${CONTAINER_ENGINE} exec -u root "$CONTAINER_NAME" bash -c "grep '$line' $path_to_file")
     exit_code=$?
     if [[ "$should_exist" = true && $exit_code -ne 0 ]]; then
         log_error "Line '$line' should exist in file $path_to_file but does not."

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -25,26 +25,30 @@ More explanation about customization can be found in the [Advanced Docker Setup]
 
 ## Installation of `openrouteservice-jws5` via RPM Package
 
+The following explanation will guide you through the installation of the `openrouteservice-jws5` package
+on `RHEL 8.x` with `OpenJDK 17 headless` and `JBoss Web Server 5.x` for `ors version 7.2.x`.
+
 ### Prerequisites
 
 #### Installation via RedHat jws5 subscription
-Install the following packages via yum with a valid RedHat subscription for jws5:
+
+Install the following packages via dnf with a valid RedHat subscription for jws5:
 
 ```bash
-yum groupinstall jws5
-yum install -y java-17-openjdk-headless
+dnf groupinstall jws5
+dnf install -y java-17-openjdk-headless
 ```
 
-#### Set environment variable `ORS_HOME`
+#### Set environment variables
 
-The global variable showing the persistence directory of the OpenRouteService, e.g.
+For the installation, the variable `ORS_HOME` showing the persistence directory of the OpenRouteService needs to be set, e.g.
 
-    ORS_HOME=/opt/openrouteservice
+    export ORS_HOME=/opt/openrouteservice
 
-If JBoss Web Service is not installed as described above via yum groupinstall, some paths need to be specified additionally:
+Only if JBoss Web Service was installed _in a different way_ than described above, some paths need to be specified additionally:
 
-    JWS_CONF_FOLDER=<your custom path>
-    JWS_WEBAPPS_FOLDER=<your custom path>
+    export JWS_CONF_FOLDER=<your custom path>
+    export JWS_WEBAPPS_FOLDER=<your custom path>
 
 #### Yum .repo Configuration
 
@@ -74,16 +78,16 @@ This repository includes two channels: `snapshots` and `releases`.
 The `snapshots channel` contains the latest snapshot builds of the `openrouteservice-jws5` package,
 while the `releases channel` holds the latest release builds (though it is not yet operational).
 
-After adding the repository, update yum:
+After adding the repository, update dnf:
 
-    yum update -y
+    dnf update
 
 
 ### Installation
 
-No you can install the openrouteservice itself using the following command:
+Now you can install the openrouteservice itself using the following command:
 
-    yum install openrouteservice-jws5
+    dnf install openrouteservice-jws5
 
 This will install the openrouteservice WAR file into the jws5 webapps folder and generates the `ORS_HOME` working directory, which houses the
 subsequent subfolders:

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -23,10 +23,12 @@ You can also modify the configuration and source file settings to match your nee
 the [Running with Docker](Running-with-Docker)-Section.
 More explanation about customization can be found in the [Advanced Docker Setup](Advanced-Docker-Setup)
 
-## Installation of `openrouteservice-jws5` via RPM Package
+## Installation of `openrouteservice-jws5` via RPM Package for Enterprise Linux Environments
 
 The following explanation will guide you through the installation of the `openrouteservice-jws5` package
 on `RHEL 8.x` with `OpenJDK 17 headless` and `JBoss Web Server 5.x` for `ors version 7.2.x`.
+
+
 
 ### Prerequisites
 
@@ -43,12 +45,16 @@ dnf install -y java-17-openjdk-headless
 
 For the installation, the variable `ORS_HOME` showing the persistence directory of the OpenRouteService needs to be set, e.g.
 
-    export ORS_HOME=/opt/openrouteservice
+```bash
+echo "ORS_HOME=/opt/openrouteservice" >> /etc/environment
+```    
 
-Only if JBoss Web Service was installed _in a different way_ than described above, some paths need to be specified additionally:
+**Only if** JBoss Web Service was installed _in a different way_ than described above, some paths need to be specified additionally:
 
-    export JWS_CONF_FOLDER=<your custom path>
-    export JWS_WEBAPPS_FOLDER=<your custom path>
+```bash
+echo "JWS_CONF_FOLDER=<your custom path>" >> /etc/environment
+echo "JWS_WEBAPPS_FOLDER=<your custom path>" >> /etc/environment
+```
 
 #### Yum .repo Configuration
 
@@ -80,17 +86,40 @@ while the `releases channel` holds the latest release builds (though it is not y
 
 After adding the repository, update dnf:
 
-    dnf update
-
+```bash
+dnf update
+```
 
 ### Installation
 
 Now you can install the openrouteservice itself using the following command:
 
-    dnf install openrouteservice-jws5
+```bash
+sudo dnf clean all && sudo dnf check-update && sudo dnf install -y openrouteservice-jws5
+```
 
-This will install the openrouteservice WAR file into the jws5 webapps folder and generates the `ORS_HOME` working directory, which houses the
-subsequent subfolders:
+---
+**Default openrouteservice User and Group**
+
+The installation of `openrouteservice-jws5` establishes a `new openrouteservice user and group`.
+This `non-root`, `nologin` user is employed to securely manage RPM package files and directories during installation,
+upgrading, and removal of openrouteservice-jws5 packages.
+
+The `tomcat` user `is assigned membership` within the openrouteservice group,
+granting them access to manipulate files and folders within `ORS_HOME` and its subdirectories.
+
+Upon each execution of the openrouteservice-jws5 package's update routine, file and folder permissions
+within `ORS_HOME` are realigned to the openrouteservice user and group.
+
+This collaborative group setup prevents interference between the tomcat user permissions during installation,
+ensuring a smooth process.
+
+
+---
+**Default folder structure**
+
+Upon installation, `openrouteservice-jws5` generates the `ORS_HOME` working directory, which houses the
+subsequent subfolders (initially empty unless manually created):
 
 ```bash
 /opt/openrouteservice/
@@ -101,7 +130,15 @@ subsequent subfolders:
 └── logs # Contains the log files
 ```
 
-In the `config` folder a file `example-config.json` is extracted, which can be used as template for the file `ors-config.json` in the same directory. `ors-config.json` is your custom config file which is used by openrouteservice.
+---
+**Configuration**
+
+For proper operation, the `openrouteservice-jws5` installation `necessitates` the presence of the `ors-config.json`
+configuration file within the `$ORS_HOME/config` directory.
+This configuration file effectively configures the openrouteservice backend.
+
+Upon installation, a sample configuration file (`config-example.yml`) can be located `within`
+the `$ORS_HOME/config` directory.
 
 ---
 **Example Usage**
@@ -113,7 +150,7 @@ installed `openrouteservice-jws5` package:
 # Obtain a OSM file using curl
 curl https://download.geofabrik.de/europe/andorra-latest.osm.pbf -o /opt/openrouteservice/files/osm-file.osm.pbf
 # Utilize the default configuration file
-cp /opt/openrouteservice/config/config-example.yml /opt/openrouteservice/config/ors-config.yml
+cp /opt/openrouteservice/config/config-example.json /opt/openrouteservice/config/ors-config.json
 # Restart the tomcat server and await graph construction
 # Check the endpoint ors/v2/status, which should display "ready" once graph construction is complete.
 curl http://127.0.0.1:8080/ors/v2/status

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -25,147 +25,19 @@ More explanation about customization can be found in the [Advanced Docker Setup]
 
 ## Installation of `openrouteservice-jws5` via RPM Package
 
-The following explanation will guide you through the installation of the `openrouteservice-jws5` package
-on `RHEL8/CentOS 8` with `Java 17` and `JBoss Web Server 5` for `ors version 7.2.x`.
-
----
-**Necessary Packages**
-
-To successfully install OpenRouteService via the RPM package,
-ensure that your RedHat Enterprise Linux 8 or CentOS 8 system has the following packages enabled through the
-subscription manager::
+### Prerequisites
+#### Installation via RedHat jws5 subscription
+Install the following packages via yum with a valid RedHat subscription for jws5:
 
 ```bash
-- jws5-runtime  
-- jws5-tomcat  
-- jws5-tomcat-native  
-- jws5-tomcat-selinux  
-- java-17-openjdk
+yum groupinstall jws5
+yum install -y java-17-openjdk-headless
 ```
+TODO
 
-In case these packages are absent, the installation process will make an automatic attempt to install them.
-A failure to do so will result in the inability to install the `openrouteservice-jws5` package.
+### Installation
+TODO
 
----
-**Required environment variables**
-
-During the installation of the `openrouteservice-jws` package, specific environment variables are essential and the
-installation will fail if they are not present:
-
-- `JWS_HOME` - The global variable showing the`tomcat` installation directory of the JBoss Web Server 5, e.g. `/opt/jws5/tomcat`
-
-A description for the variable can be found in the [official Red Hat documentation](https://access.redhat.com/documentation/de-de/red_hat_jboss_web_server/5.7/html/installation_guide/assembly_installing-jws-on-rhel-from-rpm-packages_jboss_web_server_installation_guide#installing_from_rpm).
-
-Please ensure that the **global** `JWS_HOME` environment variable is set and points to the `tomcat` installation directory of JBoss
-Web Server 5, e.g. `/opt/jws5/tomcat`.
-If the `JWS_HOME` environment variable is not set, the installation process will fail.
-
-To check if the **global** `JWS_HOME` environment variable is set, run the following command:
-
-```bash
-echo $JWS_HOME
-```
-
-The expected output should be the `tomcat` installation directory of JBoss Web Server 5 (e.g., `/opt/jws5/tomcat`).
-
----
-**Required JWS5 User**
-
-The installation of `openrouteservice-jws5` anticipates one of the following users to be present and employed **as the
-execution user** by JBoss Web Server 5:
-
-- `jboss` or
-- `tomcat`
-
-The existence of either `jboss` **or** `tomcat` users is mandatory for the successful installation
-of `openrouteservice-jws5`.
-
----
-**Yum .repo Configuration**
-
-To access and install `openrouteservice` via RPM packages from our repository, set up the following .repo file
-within `/etc/yum.repos.d/`:
-
-> /etc/yum.repos.d/ors.repo
-
-```bash
-[openrouteservice-rpm-snapshots]
-name=openrouteservice RPM repository
-baseurl=https://test-repo.openrouteservice.org/repository/openrouteservice-rpm/snapshots/openrouteservice-jws
-enabled=1
-gpgcheck=1
-gpgkey=https://keys.openpgp.org/vks/v1/by-fingerprint/825F57B756C0B5851C398478585E8FA82AFB5B55
-
-# The releases repository is not yet available
-#[openrouteservice-rpm-releases]
-#name=openrouteservice RPM repository
-#baseurl=https://test-repo.openrouteservice.org/repository/openrouteservice-rpm/realeases/openrouteservice-jws
-#enabled=1
-#gpgcheck=1
-#gpgkey=https://keys.openpgp.org/vks/v1/by-fingerprint/825F57B756C0B5851C398478585E8FA82AFB5B55
-```
-
-This repository includes two channels: `snapshots` and `releases`.
-The `snapshots channel` contains the latest snapshot builds of the `openrouteservice-jws5` package,
-while the `releases channel` holds the latest release builds (though it is not yet operational).
-
----
-**Yum installation**
-
-To install the latest snapshot build of the `openrouteservice-jws5` package, run the following command:
-
-```bash
-sudo yum update && sudo yum install openrouteservice-jws5
-``` 
-
----
-**Default openrouteservice User and Group**
-
-The installation of `openrouteservice-jws5` establishes a `new openrouteservice user and group`.
-This `non-root`, `nologin` user is employed to securely manage RPM package files and directories during installation,
-upgrading, and removal of openrouteservice-jws5 packages.
-
-Both `jboss` and `tomcat` users `are assigned membership` within the openrouteservice group,
-granting them access to manipulate files and folders `within /opt/openrouteservice/` and its subdirectories.
-
-Upon each execution of the openrouteservice-jws5 package's update routine, file and folder permissions
-within `/opt/openrouteservice` are realigned to the openrouteservice user and group.
-
-This collaborative group setup prevents interference between the jboss and tomcat user permissions during installation,
-ensuring a smooth process.
-
----
-**Default folder structure**
-
-Upon installation, `openrouteservice-jws5` generates the `/opt/openrouteservice/ working directory`, which houses the
-subsequent subfolders (initially empty unless manually created):
-
-```bash
-/opt/openrouteservice/
-├── .elevation-cache # Contains the elevation data cache
-├── .war-files # Contains the versioned openrouteservice.war files
-├── config # Should contain the configuration file
-├── files # Should contain the osm.pbf source files
-├── graphs # Contains the graphhopper graph files when build
-└── logs # Contains the log files
-```
-
-Of these folders, only `.war-files` houses the versioned `.war files`.
-The remaining folders are empty following the first installation.
-Always, `the .war-files folder retains all versioned .war files` from prior installations.
-The current `.war file` from the latest package installation is `linked` to the tomcat server `through a symbolic link`,
-as follows:
-
-> (symlink) ${JWS_HOME}/webapps/ors.war -> /opt/openrouteservice/.war-files/openrouteservice-{LATEST_VERSION}.war
----
-**Configuration**
-
-For proper operation, the `openrouteservice-jws5` installation `necessitates` the presence of the `ors-config.yml`
-configuration file within the `/opt/openrouteservice/config/` directory.
-This configuration file effectively configures the openrouteservice backend.
-
-Upon installation, a sample configuration file (`config-example.yml`) can be located `within`
-the `/opt/openrouteservice/config/` directory.
 
 ---
 **Example Usage**

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -26,6 +26,7 @@ More explanation about customization can be found in the [Advanced Docker Setup]
 ## Installation of `openrouteservice-jws5` via RPM Package
 
 ### Prerequisites
+
 #### Installation via RedHat jws5 subscription
 Install the following packages via yum with a valid RedHat subscription for jws5:
 
@@ -33,11 +34,70 @@ Install the following packages via yum with a valid RedHat subscription for jws5
 yum groupinstall jws5
 yum install -y java-17-openjdk-headless
 ```
-TODO
+
+#### Set environment variable `ORS_HOME`
+
+The global variable showing the persistence directory of the OpenRouteService, e.g.
+
+    ORS_HOME=/opt/openrouteservice
+
+If JBoss Web Service is not installed as described above via yum groupinstall, some paths need to be specified additionally:
+
+    JWS_CONF_FOLDER=<your custom path>
+    JWS_WEBAPPS_FOLDER=<your custom path>
+
+#### Yum .repo Configuration
+
+To access and install `openrouteservice` via RPM packages from our repository, set up the following .repo file
+within `/etc/yum.repos.d/`:
+
+> /etc/yum.repos.d/ors.repo
+
+```bash
+[openrouteservice-rpm-snapshots]
+name=openrouteservice RPM repository
+baseurl=https://test-repo.openrouteservice.org/repository/openrouteservice-rpm/snapshots/openrouteservice-jws
+enabled=1
+gpgcheck=1
+gpgkey=https://keys.openpgp.org/vks/v1/by-fingerprint/825F57B756C0B5851C398478585E8FA82AFB5B55
+
+# The releases repository is not yet available
+#[openrouteservice-rpm-releases]
+#name=openrouteservice RPM repository
+#baseurl=https://test-repo.openrouteservice.org/repository/openrouteservice-rpm/realeases/openrouteservice-jws
+#enabled=1
+#gpgcheck=1
+#gpgkey=https://keys.openpgp.org/vks/v1/by-fingerprint/825F57B756C0B5851C398478585E8FA82AFB5B55
+```
+
+This repository includes two channels: `snapshots` and `releases`.
+The `snapshots channel` contains the latest snapshot builds of the `openrouteservice-jws5` package,
+while the `releases channel` holds the latest release builds (though it is not yet operational).
+
+After adding the repository, update yum:
+
+    yum update -y
+
 
 ### Installation
-TODO
 
+No you can install the openrouteservice itself using the following command:
+
+    yum install openrouteservice-jws5
+
+This will install the openrouteservice WAR file into the jws5 webapps folder and generates the `ORS_HOME` working directory, which houses the
+subsequent subfolders:
+
+```bash
+/opt/openrouteservice/
+├── .elevation-cache # Contains the elevation data cache
+├── config # Should contain the configuration file
+├── files # Should contain the osm.pbf source files
+├── .graphs # Contains the graph files when build
+└── logs # Contains the log files
+```
+
+In the `config` folder a file `example-config.json` is extracted, which can be used as template for the file `ors-config.json` in the same directory. `ors-config.json` is your custom config file which is used by openrouteservice.
 
 ---
 **Example Usage**

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -137,7 +137,7 @@ For proper operation, the `openrouteservice-jws5` installation `necessitates` th
 configuration file within the `$ORS_HOME/config` directory.
 This configuration file effectively configures the openrouteservice backend.
 
-Upon installation, a sample configuration file (`config-example.yml`) can be located `within`
+Upon installation, a sample configuration file (`config-example.json`) can be located `within`
 the `$ORS_HOME/config` directory.
 
 ---

--- a/ors-api/pom.xml
+++ b/ors-api/pom.xml
@@ -30,7 +30,7 @@
         <relativePath>../pom.xml</relativePath>
         <artifactId>openrouteservice</artifactId>
         <groupId>org.heigit.ors</groupId>
-        <version>7.2.0-SNAPSHOT-1</version>
+        <version>7.2.0-SNAPSHOT-2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ors-api/src/main/java/org/heigit/ors/api/Application.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/Application.java
@@ -26,7 +26,6 @@ import javax.servlet.ServletContextListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 @ServletComponentScan("org.heigit.ors.api.servlet.listeners")
 @Configuration
@@ -43,14 +42,7 @@ public class Application extends SpringBootServletInitializer {
     }
 
     private static void setSystemProperties() {
-        System.out.println("Printing from setProperties");
-        String orsHome = System.getenv("ORS_HOME");
-        Map<String, String> test = System.getenv();
-        System.out.println("ORS_HOME: " + orsHome);
-        // Print all variables in test
-        for (Map.Entry<String, String> entry : test.entrySet()) {
-            System.out.println(entry.getKey() + " = " + entry.getValue());
-        }
+        String orsHome = System.getenv(ORS_HOME_ENV);
         if (!Strings.isNullOrEmpty(orsHome)) {
             if (Strings.isNullOrEmpty(System.getenv("ORS_CONFIG")))
                 System.setProperty("ors_config", FilenameUtils.concat(orsHome, "config/ors-config.json"));
@@ -65,14 +57,12 @@ public class Application extends SpringBootServletInitializer {
     }
 
     public static void main(String[] args) {
-        System.out.println("Starting ORS API from main");
         setSystemProperties();
         SpringApplication.run(applicationClass, args);
     }
 
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-        System.out.println("Starting ORS API from configure");
         setSystemProperties();
         return application.sources(applicationClass);
     }

--- a/ors-api/src/main/java/org/heigit/ors/api/Application.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/Application.java
@@ -1,6 +1,7 @@
 package org.heigit.ors.api;
 
 import com.google.common.base.Strings;
+import org.apache.commons.io.FilenameUtils;
 import org.heigit.ors.api.servlet.listeners.ORSInitContextListener;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
@@ -40,8 +41,8 @@ public class Application extends SpringBootServletInitializer {
         String orsHome = System.getenv(ORS_HOME_ENV);
         if (!Strings.isNullOrEmpty(orsHome)) {
             if (Strings.isNullOrEmpty(System.getenv("ORS_CONFIG")))
-                System.setProperty("ors_config", orsHome + "/config/ors-config.json");
-            System.setProperty(LOG_PATH_SYS, orsHome + "/logs/");
+                System.setProperty("ors_config", FilenameUtils.concat(orsHome, "config/ors-config.json"));
+            System.setProperty(LOG_PATH_SYS, FilenameUtils.concat(orsHome, "logs/"));
         } else {
             System.setProperty(LOG_PATH_SYS, "./logs/");
         }

--- a/ors-api/src/main/java/org/heigit/ors/api/Application.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/Application.java
@@ -13,10 +13,12 @@ import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpoi
 import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
@@ -24,21 +26,31 @@ import javax.servlet.ServletContextListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 @ServletComponentScan("org.heigit.ors.api.servlet.listeners")
+@Configuration
 @SpringBootApplication
 public class Application extends SpringBootServletInitializer {
-
     private static final String ORS_HOME_ENV = "ORS_HOME";
     private static final String ORS_LOG_LOCATION_ENV = "ORS_LOG_LOCATION";
     public static final String LOG_PATH_SYS = "logPath";
+
+    private static final Class<Application> applicationClass = Application.class;
 
     static {
         System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
     }
 
-    public static void main(String[] args) {
-        String orsHome = System.getenv(ORS_HOME_ENV);
+    private static void setSystemProperties() {
+        System.out.println("Printing from setProperties");
+        String orsHome = System.getenv("ORS_HOME");
+        Map<String, String> test = System.getenv();
+        System.out.println("ORS_HOME: " + orsHome);
+        // Print all variables in test
+        for (Map.Entry<String, String> entry : test.entrySet()) {
+            System.out.println(entry.getKey() + " = " + entry.getValue());
+        }
         if (!Strings.isNullOrEmpty(orsHome)) {
             if (Strings.isNullOrEmpty(System.getenv("ORS_CONFIG")))
                 System.setProperty("ors_config", FilenameUtils.concat(orsHome, "config/ors-config.json"));
@@ -50,8 +62,21 @@ public class Application extends SpringBootServletInitializer {
         if (!Strings.isNullOrEmpty(logPathEnv)) {
             System.setProperty(LOG_PATH_SYS, logPathEnv);
         }
-        SpringApplication.run(Application.class, args);
     }
+
+    public static void main(String[] args) {
+        System.out.println("Starting ORS API from main");
+        setSystemProperties();
+        SpringApplication.run(applicationClass, args);
+    }
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        System.out.println("Starting ORS API from configure");
+        setSystemProperties();
+        return application.sources(applicationClass);
+    }
+
 
     /**
      * This is a workaround for the unmaintained springfox-swagger2.

--- a/ors-api/src/main/java/org/heigit/ors/api/Application.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/Application.java
@@ -30,6 +30,7 @@ public class Application extends SpringBootServletInitializer {
 
     private static final String ORS_HOME_ENV = "ORS_HOME";
     private static final String ORS_LOG_LOCATION_ENV = "ORS_LOG_LOCATION";
+    public static final String LOG_PATH_SYS = "logPath";
 
     static {
         System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
@@ -38,14 +39,15 @@ public class Application extends SpringBootServletInitializer {
     public static void main(String[] args) {
         String orsHome = System.getenv(ORS_HOME_ENV);
         if (!Strings.isNullOrEmpty(orsHome)) {
-            System.setProperty("ors_config", orsHome + "/config/ors-config.json");
-            System.setProperty("logPath", orsHome + "/logs/");
+            if (Strings.isNullOrEmpty(System.getenv("ORS_CONFIG")))
+                System.setProperty("ors_config", orsHome + "/config/ors-config.json");
+            System.setProperty(LOG_PATH_SYS, orsHome + "/logs/");
+        } else {
+            System.setProperty(LOG_PATH_SYS, "./logs/");
         }
         String logPathEnv = System.getenv(ORS_LOG_LOCATION_ENV);
         if (!Strings.isNullOrEmpty(logPathEnv)) {
-            System.setProperty("logPath", logPathEnv);
-        } else {
-            System.setProperty("logPath", "./logs/");
+            System.setProperty(LOG_PATH_SYS, logPathEnv);
         }
         SpringApplication.run(Application.class, args);
     }

--- a/ors-api/src/main/java/org/heigit/ors/api/Application.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/Application.java
@@ -1,5 +1,6 @@
 package org.heigit.ors.api;
 
+import com.google.common.base.Strings;
 import org.heigit.ors.api.servlet.listeners.ORSInitContextListener;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
@@ -27,11 +28,25 @@ import java.util.List;
 @SpringBootApplication
 public class Application extends SpringBootServletInitializer {
 
+    private static final String ORS_HOME_ENV = "ORS_HOME";
+    private static final String ORS_LOG_LOCATION_ENV = "ORS_LOG_LOCATION";
+
     static {
         System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
     }
 
     public static void main(String[] args) {
+        String orsHome = System.getenv(ORS_HOME_ENV);
+        if (!Strings.isNullOrEmpty(orsHome)) {
+            System.setProperty("ors_config", orsHome + "/config/ors-config.json");
+            System.setProperty("logPath", orsHome + "/logs/");
+        }
+        String logPathEnv = System.getenv(ORS_LOG_LOCATION_ENV);
+        if (!Strings.isNullOrEmpty(logPathEnv)) {
+            System.setProperty("logPath", logPathEnv);
+        } else {
+            System.setProperty("logPath", "./logs/");
+        }
         SpringApplication.run(Application.class, args);
     }
 

--- a/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${env:ORS_LOG_LOCATION:-logs/}ors.log",
-        "filePattern": "${env:ORS_LOG_LOCATION:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath}ors.log",
+        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
@@ -17,7 +17,7 @@
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "1", "modulate": "true" }
+        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
       }
     },
     "loggers": {

--- a/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${sys:logPath}ors.log",
-        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath:-logs/}ors.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${env:ORS_LOG_LOCATION:-logs/}ors.log",
-        "filePattern": "${env:ORS_LOG_LOCATION:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath}ors.log",
+        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
@@ -17,7 +17,7 @@
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "1", "modulate": "true" }
+        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
       }
     },
     "loggers": {

--- a/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${sys:logPath}ors.log",
-        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath:-logs/}ors.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
+++ b/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${env:ORS_LOG_LOCATION:-logs/}ors.log",
-        "filePattern": "${env:ORS_LOG_LOCATION:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath}ors.log",
+        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
+++ b/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
@@ -17,7 +17,7 @@
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "1", "modulate": "true" }
+        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
       }
     },
     "loggers": {

--- a/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
+++ b/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${sys:logPath}ors.log",
-        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath:-logs/}ors.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/test/resources/logs/TEST_LOGGING.json
+++ b/ors-api/src/test/resources/logs/TEST_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${env:ORS_LOG_LOCATION:-logs/}ors.log",
-        "filePattern": "${env:ORS_LOG_LOCATION:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath}ors.log",
+        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/test/resources/logs/TEST_LOGGING.json
+++ b/ors-api/src/test/resources/logs/TEST_LOGGING.json
@@ -17,7 +17,7 @@
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "1", "modulate": "true" }
+        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
       }
     },
     "loggers": {

--- a/ors-api/src/test/resources/logs/TEST_LOGGING.json
+++ b/ors-api/src/test/resources/logs/TEST_LOGGING.json
@@ -12,8 +12,8 @@
       },
       "RollingFile": {
         "name": "orslogfile",
-        "fileName": "${sys:logPath}ors.log",
-        "filePattern": "${sys:logPath}ors.%d{yyyy-MM-dd}.log.gz",
+        "fileName": "${sys:logPath:-logs/}ors.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-engine/pom.xml
+++ b/ors-engine/pom.xml
@@ -30,7 +30,7 @@
         <relativePath>../pom.xml</relativePath>
         <artifactId>openrouteservice</artifactId>
         <groupId>org.heigit.ors</groupId>
-        <version>7.2.0-SNAPSHOT-1</version>
+        <version>7.2.0-SNAPSHOT-2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ors-engine/src/main/java/org/heigit/ors/config/AppConfig.java
+++ b/ors-engine/src/main/java/org/heigit/ors/config/AppConfig.java
@@ -170,6 +170,11 @@ public class AppConfig {
         }
         String orsHome = System.getenv("ORS_HOME");
         if (!Strings.isNullOrEmpty(orsHome)) {
+            LOGGER.info("Printing from overrideFromEnvVariables");
+            LOGGER.info("Environment variable 'ORS_HOME' used as base path");
+            LOGGER.info("ORS_HOME: " + orsHome);
+            // Print info about the baseConfig
+            LOGGER.info("baseConfig: " + baseConfig.toString());
             String graphsFolderPath = baseConfig.getString("ors.services.routing.profiles.default_params.graphs_root_path");
             if (Strings.isNullOrEmpty(graphsFolderPath))
                 graphsFolderPath = "graphs";

--- a/ors-engine/src/main/java/org/heigit/ors/config/AppConfig.java
+++ b/ors-engine/src/main/java/org/heigit/ors/config/AppConfig.java
@@ -13,10 +13,12 @@
  */
 package org.heigit.ors.config;
 
+import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigValue;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.log4j.Logger;
 import org.heigit.ors.util.FileUtility;
 import org.heigit.ors.util.StringUtility;
@@ -165,6 +167,21 @@ public class AppConfig {
             String logsFolder = System.getenv("LOGS_FOLDER");
             Config newConfig = ConfigFactory.parseString("ors.logging.location=".concat(logsFolder));
             baseConfig = newConfig.withFallback(baseConfig);
+        }
+        String orsHome = System.getenv("ORS_HOME");
+        if (!Strings.isNullOrEmpty(orsHome)) {
+            String graphsFolderPath = baseConfig.getString("ors.services.routing.profiles.default_params.graphs_root_path");
+            if (Strings.isNullOrEmpty(graphsFolderPath))
+                graphsFolderPath = "graphs";
+            baseConfig = ConfigFactory.parseString("ors.services.routing.profiles.default_params.graphs_root_path=".concat(FilenameUtils.concat(orsHome, graphsFolderPath))).withFallback(baseConfig);
+            String elevationCachePath = baseConfig.getString("ors.services.routing.profiles.default_params.elevation_cache_path");
+            if (Strings.isNullOrEmpty(elevationCachePath))
+                elevationCachePath = ".elevation_cache";
+            baseConfig = ConfigFactory.parseString("ors.services.routing.profiles.default_params.elevation_cache_path=".concat(FilenameUtils.concat(orsHome, elevationCachePath))).withFallback(baseConfig);
+            String pbfPath = baseConfig.getString("ors.services.routing.profiles.default_params.elevation_cache_path");
+            if (Strings.isNullOrEmpty(pbfPath))
+                pbfPath = "files/osm-file.osm.gz";
+            baseConfig = ConfigFactory.parseString("ors.services.routing.sources=[".concat(FilenameUtils.concat(orsHome, pbfPath)).concat("]")).withFallback(baseConfig);
         }
         return baseConfig;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.heigit.ors</groupId>
     <artifactId>openrouteservice</artifactId>
-    <version>7.2.0-SNAPSHOT-1</version>
+    <version>7.2.0-SNAPSHOT-2</version>
     <packaging>pom</packaging>
     <name>openrouteservice</name>
     <url>https://openrouteservice.org</url>


### PR DESCRIPTION
### Information about the changes
- [x] Use JRE headless dependency
- [x] Write ENV variables into `/etc/.../openrouteservice.conf` instead of `setenv.sh`.
- [x] Turn JWS_HOME into ORS_HOME and use that to control where data is installed
	- [x] Add check if ors_home is set.
	- [x] Use ors_home as the base for data and such things.
- [x] Remove the war-file symlink.
- [x] Logging should go into $ORS_HOME/logs
	- [x] Remove logging variable from SPECS
- [x] Log rotation
	- [x] Set rotation interval to 7 days
- Config is a mix of json / yaml because we branched off at a place where config overhaul was incomplete.
	- [x] Adjust example config
- [ ] Adapt the GitHub workflow to test in a better suited environment (optional for the next cycle)
- [x] Adapt documentation
- [x] Set xmx and xms to max system memory - 4Gb.