### PR TITLE
feat: add x-ors-version extension to OpenAPI info

### DIFF
--- a/ors-api/src/main/java/org/heigit/ors/api/OpenAPIConfig.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/OpenAPIConfig.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.heigit.ors.api.util.AppInfo.VERSION;
 
@@ -94,7 +95,8 @@ public class OpenAPIConfig {
                 .description("This is the openrouteservice API documentation for ORS Core-Version " + VERSION + ". Documentations for [older Core-Versions](https://github.com/GIScience/openrouteservice-docs/releases) can be rendered with the [Swagger-Editor](https://editor-next.swagger.io/).")
                 .version("v2")
                 .contact(apiContact())
-                .license(apiLicence());
+                .license(apiLicence())
+                .extensions(Map.of("x-ors-version", VERSION));
     }
 
     private License apiLicence() {

--- a/ors-api/src/test/java/org/heigit/ors/apitests/openapi/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/openapi/ResultTest.java
@@ -59,6 +59,7 @@ class ResultTest extends ServiceTest {
                 .body("any { it.key == 'tags' }", is(true))
                 .body("any { it.key == 'paths' }", is(true))
                 .body("any { it.key == 'components' }", is(true))
+                .body("info", hasKey("x-ors-version"))
                 .body("servers", hasSize(2))
                 .body("servers[0].url", hasToString("https://api.openrouteservice.org"))
                 .body("servers[1].url", hasToString("http://localhost:{port}{basePath}"))


### PR DESCRIPTION
this is used for checking if the documentation needs updating

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added: property to OpenAPI specs containing ors-version
- Reason for change: needed for updating the ors specs in the docs API (used for API playground generation)

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
