### PR TITLE
fix(graphbuilder): Add a graph folder creation routine if the base fo…

### DIFF
--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   run_tests:

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/ORSGraphFileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/ORSGraphFileManager.java
@@ -35,6 +35,16 @@ public class ORSGraphFileManager {
         this.maxNumberOfGraphBackups = Math.max(maxBak, 0);
     }
 
+    public void initialize() {
+        File vehicleGraphDir = new File(hashDirAbsPath);
+        if (!vehicleGraphDir.exists()) {
+            LOGGER.info("[%s] Creating vehicle graph directory %s".formatted(getProfileWithHash(), hashDirAbsPath));
+            if (!vehicleGraphDir.mkdirs()) {
+                LOGGER.error("[%s] Could not create vehicle graph directory %s".formatted(getProfileWithHash(), hashDirAbsPath));
+            }
+        }
+    }
+
     public String getHash() {
         return hash;
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/ORSGraphManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/ORSGraphManager.java
@@ -28,6 +28,7 @@ public class ORSGraphManager {
 
     void initialize(EngineConfig engineConfig) {
         fileManager = new ORSGraphFileManager(engineConfig, hash, hashDirAbsPath, vehicleGraphDirAbsPath, routeProfileName);
+        fileManager.initialize();
         repoManager = new ORSGraphRepoManager(engineConfig, fileManager, routeProfileName, graphsRepoGraphVersion);
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/ORSGraphRepoManagerTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/ORSGraphRepoManagerTest.java
@@ -80,7 +80,7 @@ class ORSGraphRepoManagerTest {
     void setupLocalGraphDirectory(String hash, Long osmDateLocal) throws IOException {
         if (hash == null) return;
         hashDir = new File(hashDirAbsPath);
-        hashDir.mkdir();
+        hashDir.mkdirs();
         ORSGraphInfoV1 localOrsGraphInfoV1Object = new ORSGraphInfoV1(new Date(osmDateLocal));
         localGraphInfoV1File = new File(hashDir, hash + ".json");
         new ObjectMapper().writeValue(localGraphInfoV1File, localOrsGraphInfoV1Object);
@@ -191,7 +191,7 @@ class ORSGraphRepoManagerTest {
                 new AssetXO().path("https://example.com/test-repo/planet/wrong/car/abc123/202301011200/abc123.json"),
                 new AssetXO().path("https://example.com/test-repo/wrong/1/car/abc123/202301011200/abc123.ghz"),
                 new AssetXO().path("https://example.com/test-repo/wrong/1/car/abc123/202301011200/abc123.json")
-                );
+        );
         AssetXO filtered = orsGraphRepoManager.filterLatestAsset("abc123.json", items);
         assertEquals("https://example.com/test-repo/planet/1/car/abc123/202301011200/abc123.json", filtered.getPath());
     }
@@ -267,6 +267,7 @@ class ORSGraphRepoManagerTest {
                 Arguments.of(missingGraphInfo, missingGraphInfo, nonexistingFile, null, false)
         );
     }
+
     @Test
     void findLatestGraphComponent() {
     }


### PR DESCRIPTION
…lder is missing

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
