### PR TITLE
fix: Set right permissions for the openrouteservice folders and files

### DIFF
--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -34,7 +34,7 @@ cp -f ors.war %{buildroot}%{ors_temporary_files_location}/.war-files/%{ors_versi
 cp -f example-config.json %{buildroot}%{ors_temporary_files_location}/config/example-config.json
 
 %files
-# Allow 770 for read and write for files for the ors group
+# 770 for all permissions for owner and group
 %defattr(770,%{ors_user},%{ors_group},-)
 "%{ors_temporary_files_location}/.war-files/%{ors_version}_ors.war"
 "%{ors_temporary_files_location}/config/example-config.json"
@@ -181,7 +181,7 @@ if id -u %{ors_user} >/dev/null 2>&1; then
     usermod -a -G %{ors_group} %{ors_user}
 else
     echo "openrouteservice user does not exist. Creating it and adding it to the ors group."
-    useradd -r -g %{ors_group} -d ${ORS_HOME} -s /sbin/nologin %{ors_user}
+    useradd -r -g %{ors_group} -d ${ORS_HOME}  %{ors_user}
 fi
 
 # Setup openrouteservice opt folder
@@ -200,12 +200,18 @@ echo "Switching the default java to version %{java_version}"
 alternatives --install /usr/bin/java java $(readlink -f /etc/alternatives/jre_%{java_version})/bin/java 1
 alternatives --set java $(readlink -f /etc/alternatives/jre_%{java_version})/bin/java
 
+# chown to the tomcat user and ors group and give owner read and write permissions and group read and execute permissions
 chown %{tomcat_user} ${jws_webapps_folder}/ors.war
-chmod 740 ${jws_webapps_folder}/ors.war
-# Set the correct permissions for the /opt/openrouteservice folder so that the ${ors_group} can read and write to it
+chmod 750 ${jws_webapps_folder}/ors.war
+# Set ownership of the ors home folder to the ors user and ors group
 chown -R %{ors_user}:%{ors_group} ${ORS_HOME}
-# Set recursive 770 permissions for the /opt/openrouteservice folder so that the ${ors_group} can read and write to it
-chmod -R 770 ${ORS_HOME}
+# Make everything 770 for Owner read+write and Group read+write and the ability to create folders.
+chmod -R 770 ${ORS_HOME}/
+# Make exceptions for config, files with owner read+write and group read permissions
+chmod -R 770 ${ORS_HOME}/files
+# Make exceptions for example-config.json and the permanent state file with only read access on the files
+chmod 440 ${ORS_HOME}/config/example-config.json
+chmod 440 ${ORS_HOME}/.openrouteservice-jws5-permanent-state
 
 %postun
 ###############################################################################################################

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -181,7 +181,7 @@ if id -u %{ors_user} >/dev/null 2>&1; then
     usermod -a -G %{ors_group} %{ors_user}
 else
     echo "openrouteservice user does not exist. Creating it and adding it to the ors group."
-    useradd -r -g %{ors_group} -d ${ORS_HOME}  %{ors_user}
+    useradd -r -g %{ors_group} -d ${ORS_HOME}  -s /sbin/nologin %{ors_user}
 fi
 
 # Setup openrouteservice opt folder

--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -207,8 +207,6 @@ chmod 750 ${jws_webapps_folder}/ors.war
 chown -R %{ors_user}:%{ors_group} ${ORS_HOME}
 # Make everything 770 for Owner read+write and Group read+write and the ability to create folders.
 chmod -R 770 ${ORS_HOME}/
-# Make exceptions for config, files with owner read+write and group read permissions
-chmod -R 770 ${ORS_HOME}/files
 # Make exceptions for example-config.json and the permanent state file with only read access on the files
 chmod 440 ${ORS_HOME}/config/example-config.json
 chmod 440 ${ORS_HOME}/.openrouteservice-jws5-permanent-state

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -42,7 +42,7 @@ check_line_in_file "jws_config_location=${JWS_CONFIGURATION_DIRECTORY}" '${ORS_H
 check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 
-# Check 660 permissions
+# Check 770 permissions
 check_user_group_permissions '${ORS_HOME}/' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
 check_user_group_permissions '${ORS_HOME}/.elevation-cache' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
 check_user_group_permissions '${ORS_HOME}/.graphs' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -34,7 +34,6 @@ check_folder_exists '${ORS_HOME}/logs' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/.elevation-cache' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/files' true || SUCCESSFUL=false
 check_folder_exists '${ORS_HOME}/.graphs' true || SUCCESSFUL=false
-check_file_exists '${ORS_HOME}/config/example-config.json' true || SUCCESSFUL=false
 
 # Check the state file is created and contains the correct variables
 check_file_exists '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
@@ -43,9 +42,26 @@ check_line_in_file "jws_config_location=${JWS_CONFIGURATION_DIRECTORY}" '${ORS_H
 check_line_in_file "min_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 check_line_in_file "max_ram=" '${ORS_HOME}/.openrouteservice-jws5-permanent-state' true || SUCCESSFUL=false
 
+# Check 660 permissions
+check_user_group_permissions '${ORS_HOME}/' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
+check_user_group_permissions '${ORS_HOME}/.elevation-cache' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
+check_user_group_permissions '${ORS_HOME}/.graphs' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
+check_user_group_permissions '${ORS_HOME}/logs' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
+
+# Check 640 permissions
+check_user_group_permissions '${ORS_HOME}/config' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
+check_user_group_permissions '${ORS_HOME}/files' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
+
+# Check 440 permissions
+check_user_group_permissions '${ORS_HOME}/config/example-config.json' "openrouteservice" "openrouteservice" "440" || SUCCESSFUL=false
+check_user_group_permissions '${ORS_HOME}/.openrouteservice-jws5-permanent-state' "openrouteservice" "openrouteservice" "440" || SUCCESSFUL=false
+
 # shellcheck disable=SC2016
 # Check ors.war in webapps folder
 check_file_exists "$JWS_WEBAPPS_DIRECTORY/ors.war" true || SUCCESSFUL=false
+# Check the ownership of the file
+find_owned_content "$JWS_WEBAPPS_DIRECTORY/ors.war" "tomcat" "" 1 || SUCCESSFUL=false
+
 # Check user and group setup
 check_group_exists 'openrouteservice' true || SUCCESSFUL=false
 check_user_exists 'openrouteservice' true || SUCCESSFUL=false

--- a/.rpm-packaging/rhel8_post_install_check.sh
+++ b/.rpm-packaging/rhel8_post_install_check.sh
@@ -47,8 +47,6 @@ check_user_group_permissions '${ORS_HOME}/' "openrouteservice" "openrouteservice
 check_user_group_permissions '${ORS_HOME}/.elevation-cache' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
 check_user_group_permissions '${ORS_HOME}/.graphs' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
 check_user_group_permissions '${ORS_HOME}/logs' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
-
-# Check 640 permissions
 check_user_group_permissions '${ORS_HOME}/config' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
 check_user_group_permissions '${ORS_HOME}/files' "openrouteservice" "openrouteservice" "770" || SUCCESSFUL=false
 

--- a/.rpm-packaging/scripts/helper_functions.sh
+++ b/.rpm-packaging/scripts/helper_functions.sh
@@ -286,8 +286,7 @@ check_user_group_permissions() {
         return 1
     fi
 
-    local result
-    result=$(${CONTAINER_ENGINE} exec -u root "$CONTAINER_NAME" bash -c "stat -c '%a %U %G' $path_to_file")
+    local result=$(${CONTAINER_ENGINE} exec -u root "$CONTAINER_NAME" bash -c "stat -c '%a %U %G' $path_to_file")
     if [[ "$result" != "$permissions $user $group" ]]; then
         log_error "Permissions for $path_to_file should be $permissions $user $group but are $result"
         return 1

--- a/.rpm-packaging/scripts/helper_functions.sh
+++ b/.rpm-packaging/scripts/helper_functions.sh
@@ -272,6 +272,28 @@ check_rpm_installed() {
     fi
 }
 
+# Function to check user and group permissions on a file or folder
+# Usage: check_user_group_permissions <path_to_file> <user> <group> <permissions>
+check_user_group_permissions() {
+    local path_to_file="$1"
+    local user="$2"
+    local group="$3"
+    local permissions="$4"
+
+    # Fail if any of the variables are empty
+    if [ -z "$path_to_file" ] || [ -z "$permissions" ] || [ -z "$user" ] || [ -z "$group" ]; then
+        log_error "Please provide all variables to the check_user_group_permissions function."
+        return 1
+    fi
+
+    local result
+    result=$(${CONTAINER_ENGINE} exec -u root "$CONTAINER_NAME" bash -c "stat -c '%a %U %G' $path_to_file")
+    if [[ "$result" != "$permissions $user $group" ]]; then
+        log_error "Permissions for $path_to_file should be $permissions $user $group but are $result"
+        return 1
+    fi
+    log_success "Permissions for $path_to_file are $permissions $user $group as expected."
+}
 # Check that the CONTAINER_NAME variables are set
 if [ -z "$CONTAINER_NAME" ]; then
     log_error "Please set the CONTAINER_NAME variable."

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -125,7 +125,7 @@ subsequent subfolders (initially empty unless manually created):
 /opt/openrouteservice/ # Ownership: 770 openrouteservice:openrouteservice | Desc: Base for $ORS_HOME
 ├── .elevation-cache   # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the elevation cache
 ├── logs               # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the log files
-├── .graphs            # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the graph files when build
+├── .graphs            # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the graph files when built
 ├── files              # Ownership: 770 openrouteservice:openrouteservice | Desc: Should contain the OSM file(s)
 ├── config             # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the example-config.json configuration file
 ├── config/example-config.json # Ownership: 440 openrouteservice:openrouteservice | Desc: Contains the example-config.json configuration file

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -122,13 +122,27 @@ Upon installation, `openrouteservice-jws5` generates the `ORS_HOME` working dire
 subsequent subfolders (initially empty unless manually created):
 
 ```bash
-/opt/openrouteservice/
-├── .elevation-cache # Contains the elevation data cache
-├── config # Should contain the configuration file
-├── files # Should contain the osm.pbf source files
-├── .graphs # Contains the graph files when build
-└── logs # Contains the log files
+/opt/openrouteservice/ # Ownership: 770 openrouteservice:openrouteservice | Desc: Base for $ORS_HOME
+├── .elevation-cache   # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the elevation cache
+├── logs               # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the log files
+├── .graphs            # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the graph files when build
+├── files              # Ownership: 770 openrouteservice:openrouteservice | Desc: Should contain the OSM file(s)
+├── config             # Ownership: 770 openrouteservice:openrouteservice | Desc: Contains the example-config.json configuration file
+├── config/example-config.json # Ownership: 440 openrouteservice:openrouteservice | Desc: Contains the example-config.json configuration file
+└──.openrouteservice-jws5-permanent-state # Ownership: 440 openrouteservice:openrouteservice | Desc: Contains the permanent state of the openrouteservice installation
 ```
+
+The directory structure at `$ORS_HOME` is configured with specific permissions to maintain security and access control.
+In general, it follows the `770` permission scheme, allowing both the Owner and Group to read and write to the necessary
+folders and have the search bit enabled to create files.
+
+In instances where write access is unnecessary, permissions are set to `640`, restricting write privileges for
+user `openrouteservice` and group members to read only.
+This arrangement ensures that the 'tomcat' user can access and read the files without the ability to make changes.
+
+Notably, the `.openrouteservice-jws5-permanent-state` file and the `config/example-config.json` are assigned `440`
+permissions, ensuring that only the
+installation processes can write to it, while access for others is restricted.
 
 ---
 **Configuration**


### PR DESCRIPTION
The webapps ors.war needs to have full rights for owner tomcat but only read and execution for group. Everything in the openrouteservice folder is max 770 and 440 where possible to reduce external influence and files only being changed while installing them with root permissions.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
