### PR TITLE
fix: log rotation with CronTriggeringPolicy, set by ENV

### DIFF
--- a/.rpm-packaging/ors-war.spec
+++ b/.rpm-packaging/ors-war.spec
@@ -153,6 +153,7 @@ else
     echo "export ORS_HOME=${ORS_HOME}" >> ${jws_config_location}
     echo "Permanently saving -Xms${min_ram}k and -Xmx${max_ram}k in ${jws_config_location}."
     echo 'CATALINA_OPTS="-Xms'"${min_ram}"'k -Xmx'"${max_ram}"'k"' >> ${jws_config_location}
+    echo "export ORS_LOG_ROTATION='0 0 0 * * ?'" >> ${jws_config_location}
 fi
 
 # Check for the existence of an old ors installation in the webapps folder and clean it.

--- a/docs/installation/Installation-and-Usage.md
+++ b/docs/installation/Installation-and-Usage.md
@@ -151,8 +151,11 @@ For proper operation, the `openrouteservice-jws5` installation `necessitates` th
 configuration file within the `$ORS_HOME/config` directory.
 This configuration file effectively configures the openrouteservice backend.
 
-Upon installation, a sample configuration file (`config-example.json`) can be located `within`
-the `$ORS_HOME/config` directory.
+Upon installation, a sample configuration file (`config-example.json`) can be located within the `$ORS_HOME/config` directory.
+
+Upon installation, a tomcat configuration file (`openrouteservice-jws5-permanent-state`) can be located within the `$ORS_HOME/` directory. This file contains variables set for the JWS5 Tomcat instance running ORS. You should not  change the content of this file, EXCEPT in some cases the folling variables: 
+- `CATALINA_OPTS`: Memory settings for the VM running the ORS instance. Max heap memory is set to max amount of ram available on the system as per cat /proc/meminfo, minus  4 GB if it is more than 4 GB; initial heap size is set to half the max value. Change these settings only if necessary and on your own risk.
+- `ORS_LOG_ROTATION`: Cron-like pattern passed to Log4J to determine log rotation timing and frequency. Defaults to 00:00:00 h every day. See [Log4J documentation](https://logging.apache.org/log4j/2.x/manual/appenders.html#cron-triggering-policy) for details. Note that ORS does not log any individual requests, and the log file(s) will normally only contain startup information and any occurring error messages.
 
 ---
 **Example Usage**

--- a/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
@@ -13,11 +13,16 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
+        "Policies": {
+          "CronTriggeringPolicy": {
+            "schedule": "${env:ORS_LOG_PATTERN:-0 0 0 * * ?}",
+            "evaluateOnStartup": "true"
+          }
+        }
       }
     },
     "loggers": {

--- a/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
@@ -13,11 +13,16 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
+        "Policies": {
+          "CronTriggeringPolicy": {
+            "schedule": "${env:ORS_LOG_PATTERN:-0 0 0 * * ?}",
+            "evaluateOnStartup": "true"
+          }
+        }
       }
     },
     "loggers": {

--- a/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
+++ b/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
@@ -13,11 +13,16 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
+        "Policies": {
+          "CronTriggeringPolicy": {
+            "schedule": "${env:ORS_LOG_PATTERN:-0 0 0 * * ?}",
+            "evaluateOnStartup": "true"
+          }
+        }
       }
     },
     "loggers": {

--- a/ors-api/src/test/resources/logs/TEST_LOGGING.json
+++ b/ors-api/src/test/resources/logs/TEST_LOGGING.json
@@ -13,11 +13,16 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd}.log.gz",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },
-        "TimeBasedTriggeringPolicy": { "interval": "7", "modulate": "true" }
+        "Policies": {
+          "CronTriggeringPolicy": {
+            "schedule": "${env:ORS_LOG_PATTERN:-0 0 0 * * ?}",
+            "evaluateOnStartup": "true"
+          }
+        }
       }
     },
     "loggers": {


### PR DESCRIPTION
- changed logging policy to `CronTriggeringPolicy`, defaulting to 00:00:00 h every day
- introduced ENV variable `ORS_LOG_PATTERN` that sets this policy
- added default of said ENV variable to `openrouteservice-jws5-permanent-state` file
- added documentation to `docs/installation/Installation-and-Usage.md` 