### PR TITLE
chore: log openrouteservice version and build date

### DIFF
--- a/ors-api/src/main/java/org/heigit/ors/api/Application.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/Application.java
@@ -1,7 +1,9 @@
 package org.heigit.ors.api;
 
 import jakarta.servlet.ServletContextListener;
+import org.apache.log4j.Logger;
 import org.heigit.ors.api.servlet.listeners.ORSInitContextListener;
+import org.heigit.ors.api.util.AppInfo;
 import org.heigit.ors.routing.RoutingProfileManagerStatus;
 import org.heigit.ors.util.StringUtility;
 import org.springframework.boot.SpringApplication;
@@ -14,6 +16,7 @@ import org.springframework.context.annotation.Bean;
 @ServletComponentScan("org.heigit.ors.api.servlet.listeners")
 @SpringBootApplication
 public class Application extends SpringBootServletInitializer {
+    private static final Logger LOG = Logger.getLogger(Application.class.getName());
 
     static {
         System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
@@ -24,6 +27,7 @@ public class Application extends SpringBootServletInitializer {
             System.setProperty(ORSEnvironmentPostProcessor.ORS_CONFIG_LOCATION_PROPERTY, args[0]);
         }
         SpringApplication.run(Application.class, args);
+        LOG.info("openrouteservice %s".formatted(AppInfo.getEngineInfo()));
         if (RoutingProfileManagerStatus.hasFailed()) {
             System.exit(1);
         }

--- a/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
@@ -25,6 +25,7 @@ import jakarta.servlet.ServletContextListener;
 import org.apache.juli.logging.LogFactory;
 import org.apache.log4j.Logger;
 import org.heigit.ors.api.EngineProperties;
+import org.heigit.ors.api.util.AppInfo;
 import org.heigit.ors.config.EngineConfig;
 import org.heigit.ors.isochrones.statistics.StatisticsProviderFactory;
 import org.heigit.ors.routing.RoutingProfileManager;
@@ -77,7 +78,7 @@ public class ORSInitContextListener implements ServletContextListener {
     @Override
     public void contextDestroyed(ServletContextEvent contextEvent) {
         try {
-            LOGGER.info("Shutting down ORS and releasing resources.");
+            LOGGER.info("Shutting down openrouteservice %s and releasing resources.".formatted(AppInfo.getEngineInfo()));
             FormatUtility.unload();
             if (RoutingProfileManagerStatus.isReady())
                 RoutingProfileManager.getInstance().destroy();


### PR DESCRIPTION
Added openrouteservice version and build date to log at startup

```
...
03 Nov 14:42:39 INFO                                                  main [ o.h.o.a.Application                      ]   Started Application in 2.71 seconds (process running for 3.547)
03 Nov 14:42:39 INFO                                                  main [ o.h.o.a.Application                      ]   openrouteservice {"build_date":"2023-11-03T13:39:24Z","version":"8.0"}
...
```

 and shutdown of the application (like it is returned by status endpoint):

```
...
03 Nov 14:42:53 INFO                         SpringApplicationShutdownHook [ o.h.o.a.s.l.ORSInitContextListener       ]   Shutting down openrouteservice {"build_date":"2023-11-03T13:39:24Z","version":"8.0"} and releasing resources.
```