### PR TITLE
fix: revert rotated log files to being gzipped

### DIFF
--- a/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEBUG_LOGGING.json
@@ -13,7 +13,7 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
+++ b/ors-api/src/main/resources/logs/DEFAULT_LOGGING.json
@@ -13,7 +13,7 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
+++ b/ors-api/src/main/resources/logs/PRODUCTION_LOGGING.json
@@ -13,7 +13,7 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },

--- a/ors-api/src/test/resources/logs/TEST_LOGGING.json
+++ b/ors-api/src/test/resources/logs/TEST_LOGGING.json
@@ -13,7 +13,7 @@
       "RollingFile": {
         "name": "orslogfile",
         "fileName": "${sys:logPath:-logs/}ors.log",
-        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log",
+        "filePattern": "${sys:logPath:-logs/}ors.%d{yyyy-MM-dd-HH-mm-ss}.log.gz",
         "PatternLayout": {
           "pattern": "%d %p [%c{2}] - %m%n"
         },


### PR DESCRIPTION
### Information about the changes
Fixes removing `.gz` from rotated log files name pattern accidentally.