### PR TITLE
fix: accidential execution rpm postun

### DIFF
--- a/.rpm-packaging/ors-selinux.spec
+++ b/.rpm-packaging/ors-selinux.spec
@@ -100,5 +100,7 @@ restorecon -vvRF ${ORS_HOME}
 
 %postun
 
-semanage fcontext -a -t unlabeled_t ${ORS_HOME}
-restorecon -vvRF ${ORS_HOME}
+if [ "$1" = "0" ]; then
+    semanage fcontext -a -t unlabeled_t ${ORS_HOME}
+    restorecon -vvRF ${ORS_HOME}
+fi

--- a/.rpm-packaging/ors-selinux.spec
+++ b/.rpm-packaging/ors-selinux.spec
@@ -100,7 +100,7 @@ restorecon -vvRF ${ORS_HOME}
 
 %postun
 
-if [ "$1" = "0" ]; then
+if [ "$1" == "0" ]; then
     semanage fcontext -a -t unlabeled_t ${ORS_HOME}
     restorecon -vvRF ${ORS_HOME}
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ RELEASING:
  -->
 
 ## [Unreleased]
+### Fixed
+- fixed setting SELinux type during update of SELinux RPM package  
 
 ## [7.2.0] - 2023-11-16
 ### Added

--- a/ors-api/pom.xml
+++ b/ors-api/pom.xml
@@ -30,7 +30,7 @@
         <relativePath>../pom.xml</relativePath>
         <artifactId>openrouteservice</artifactId>
         <groupId>org.heigit.ors</groupId>
-        <version>7.2.0</version>
+        <version>7.2.1-SNAPSHOT-1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/ors-engine/pom.xml
+++ b/ors-engine/pom.xml
@@ -30,7 +30,7 @@
         <relativePath>../pom.xml</relativePath>
         <artifactId>openrouteservice</artifactId>
         <groupId>org.heigit.ors</groupId>
-        <version>7.2.0</version>
+        <version>7.2.1-SNAPSHOT-1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.heigit.ors</groupId>
     <artifactId>openrouteservice</artifactId>
-    <version>7.2.0</version>
+    <version>7.2.1-SNAPSHOT-1</version>
     <packaging>pom</packaging>
     <name>openrouteservice</name>
     <url>https://openrouteservice.org</url>


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added: none
- Reason for change: bug report of SELinux Expert from BKG: During installaion (update) of SELinux RPM Package, the selinux type of ORS_HOME directory was set first to jws5_tomcat_var_lib_t (correct) and then to unlabeled_t (this is only correct for uninstall)

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
- none

### Required changes to ors config (if applicable)
- none

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
