### PR TITLE
feat: add dataaccess routing profile configuration parameter

### DIFF
--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -178,7 +178,7 @@ public class RoutingProfile {
 
     private static ORSGraphHopperConfig createGHSettings(String sourceFile, RouteProfileConfiguration config) {
         ORSGraphHopperConfig ghConfig = new ORSGraphHopperConfig();
-        ghConfig.putObject("graph.dataaccess", "RAM_STORE");
+        ghConfig.putObject("graph.dataaccess", config.getGraphDataAccess());
         ghConfig.putObject("datareader.file", sourceFile);
         ghConfig.putObject("graph.location", config.getGraphPath());
         ghConfig.putObject("graph.bytes_for_flags", config.getEncoderFlagsSize());

--- a/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
@@ -66,6 +66,7 @@ public class RouteProfileConfiguration {
 
     private boolean turnCostEnabled = false;
     private boolean enforceTurnCosts = false;
+    private String graphDataAccess = "RAM_STORE";
 
     public RouteProfileConfiguration() {
         extStorages = new HashMap<>();
@@ -366,5 +367,56 @@ public class RouteProfileConfiguration {
 
     public void setMaximumVisitedNodesPT(int maximumVisitedNodesPT) {
         this.maximumVisitedNodesPT = maximumVisitedNodesPT;
+    }
+
+    public String getGraphDataAccess() {
+        return graphDataAccess;
+    }
+
+    public void setGraphDataAccess(String graphDataAccess) {
+        this.graphDataAccess = graphDataAccess;
+    }
+
+    @Override
+    public String toString() {
+        return "RouteProfileConfiguration{" +
+                "name='" + name + '\'' +
+                ", enabled=" + enabled +
+                ", profiles='" + profiles + '\'' +
+                ", graphPath='" + graphPath + '\'' +
+                ", extStorages=" + extStorages +
+                ", graphBuilders=" + graphBuilders +
+                ", maximumDistance=" + maximumDistance +
+                ", maximumDistanceDynamicWeights=" + maximumDistanceDynamicWeights +
+                ", maximumDistanceAvoidAreas=" + maximumDistanceAvoidAreas +
+                ", maximumDistanceAlternativeRoutes=" + maximumDistanceAlternativeRoutes +
+                ", maximumDistanceRoundTripRoutes=" + maximumDistanceRoundTripRoutes +
+                ", maximumWayPoints=" + maximumWayPoints +
+                ", instructions=" + instructions +
+                ", optimize=" + optimize +
+                ", encoderFlagsSize=" + encoderFlagsSize +
+                ", encoderOptions='" + encoderOptions + '\'' +
+                ", gtfsFile='" + gtfsFile + '\'' +
+                ", isochronePreparationOpts=" + isochronePreparationOpts +
+                ", preparationOpts=" + preparationOpts +
+                ", executionOpts=" + executionOpts +
+                ", elevationProvider='" + elevationProvider + '\'' +
+                ", elevationCachePath='" + elevationCachePath + '\'' +
+                ", elevationDataAccess='" + elevationDataAccess + '\'' +
+                ", elevationCacheClear=" + elevationCacheClear +
+                ", elevationSmoothing=" + elevationSmoothing +
+                ", interpolateBridgesAndTunnels=" + interpolateBridgesAndTunnels +
+                ", maximumSnappingRadius=" + maximumSnappingRadius +
+                ", extent=" + extent +
+                ", hasMaximumSnappingRadius=" + hasMaximumSnappingRadius +
+                ", locationIndexResolution=" + locationIndexResolution +
+                ", locationIndexSearchIterations=" + locationIndexSearchIterations +
+                ", maximumSpeedLowerBound=" + maximumSpeedLowerBound +
+                ", trafficExpirationMin=" + trafficExpirationMin +
+                ", maximumVisitedNodesPT=" + maximumVisitedNodesPT +
+                ", turnCostEnabled=" + turnCostEnabled +
+                ", enforceTurnCosts=" + enforceTurnCosts +
+                ", graphDataAccess='" + graphDataAccess + '\'' +
+                '}';
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RoutingManagerConfiguration.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RoutingManagerConfiguration.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RoutingManagerConfiguration {
+    public static final String PARAM_GRAPH_DATA_ACCESS = "graph_data_access";
     public static final String PARAM_ELEVATION_CACHE_CLEAR = "elevation_cache_clear";
     public static final String PARAM_ELEVATION_DATA_ACCESS = "elevation_data_access";
     public static final String PARAM_ELEVATION_SMOOTHING = "elevation_smoothing";
@@ -106,6 +107,9 @@ public class RoutingManagerConfiguration {
             if (profileParams != null) {
                 for (Map.Entry<String, Object> paramItem : profileParams.entrySet()) {
                     switch (paramItem.getKey()) {
+                        case PARAM_GRAPH_DATA_ACCESS:
+                            profile.setGraphDataAccess(StringUtility.trimQuotes(paramItem.getValue().toString()));
+                            break;
                         case "preparation":
                             profile.setPreparationOpts(ConfigFactory.parseString(paramItem.getValue().toString()));
                             break;


### PR DESCRIPTION
Adding a new parameter to the routing-profile-configuration which allows to choose the graph-dataaccess type. Defaults to "RAM_STORE", valid parameters are 
- "RAM_STORE", "MMAP", "MMAP_RO"


### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
