### PR TITLE
refactor: move APIEnums into api module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ RELEASING:
 - silence traffic map-matching internal errors ([#1635](https://github.com/GIScience/openrouteservice/pulls/1635))
 - fix IN1-JAVA-ORGMOZILLA-1314295 ([#1627](https://github.com/GIScience/openrouteservice/issues/1627))
 - log summary stats on traffic mapmatching and use progress bar only in debug mode ([#1647](https://github.com/GIScience/openrouteservice/pull/1647))
+- move APIEnums into API module ([#1634](https://github.com/GIScience/openrouteservice/issues/1634))
 
 ### Deprecated
 - JSON configuration and related classes ([#1506](https://github.com/GIScience/openrouteservice/pull/1506))

--- a/ors-api/src/main/java/org/heigit/ors/api/APIEnums.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/APIEnums.java
@@ -13,13 +13,14 @@
  * if not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.heigit.ors.routing;
+package org.heigit.ors.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.heigit.ors.exceptions.ParameterValueException;
+import org.heigit.ors.routing.GenericErrorCodes;
 
 
 public class APIEnums {

--- a/ors-api/src/main/java/org/heigit/ors/api/controllers/ExportAPI.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/controllers/ExportAPI.java
@@ -33,7 +33,7 @@ import org.heigit.ors.api.services.ExportService;
 import org.heigit.ors.exceptions.*;
 import org.heigit.ors.export.ExportErrorCodes;
 import org.heigit.ors.export.ExportResult;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.http.converter.HttpMessageNotReadableException;

--- a/ors-api/src/main/java/org/heigit/ors/api/controllers/IsochronesAPI.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/controllers/IsochronesAPI.java
@@ -37,7 +37,7 @@ import org.heigit.ors.api.util.AppConfigMigration;
 import org.heigit.ors.exceptions.*;
 import org.heigit.ors.isochrones.IsochroneMapCollection;
 import org.heigit.ors.isochrones.IsochronesErrorCodes;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;

--- a/ors-api/src/main/java/org/heigit/ors/api/controllers/MatrixAPI.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/controllers/MatrixAPI.java
@@ -37,7 +37,7 @@ import org.heigit.ors.api.util.AppConfigMigration;
 import org.heigit.ors.exceptions.*;
 import org.heigit.ors.matrix.MatrixErrorCodes;
 import org.heigit.ors.matrix.MatrixResult;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;

--- a/ors-api/src/main/java/org/heigit/ors/api/controllers/RoutingAPI.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/controllers/RoutingAPI.java
@@ -36,7 +36,7 @@ import org.heigit.ors.api.responses.routing.json.JSONRouteResponse;
 import org.heigit.ors.api.services.RoutingService;
 import org.heigit.ors.api.util.AppConfigMigration;
 import org.heigit.ors.exceptions.*;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RouteResult;
 import org.heigit.ors.routing.RoutingErrorCodes;
 import org.locationtech.jts.geom.Coordinate;

--- a/ors-api/src/main/java/org/heigit/ors/api/controllers/SnappingAPI.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/controllers/SnappingAPI.java
@@ -35,7 +35,7 @@ import org.heigit.ors.api.responses.snapping.json.JsonSnappingResponse;
 import org.heigit.ors.api.services.SnappingService;
 import org.heigit.ors.api.util.AppConfigMigration;
 import org.heigit.ors.exceptions.*;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.snapping.SnappingErrorCodes;
 import org.heigit.ors.snapping.SnappingResult;
 import org.springframework.core.convert.ConversionFailedException;

--- a/ors-api/src/main/java/org/heigit/ors/api/converters/APIRequestProfileConverter.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/converters/APIRequestProfileConverter.java
@@ -15,7 +15,7 @@
 
 package org.heigit.ors.api.converters;
 
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.springframework.core.convert.converter.Converter;
 
 public class APIRequestProfileConverter implements Converter<String, APIEnums.Profile> {

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/common/APIRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/common/APIRequest.java
@@ -3,7 +3,7 @@ package org.heigit.ors.api.requests.common;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 
 public class APIRequest {
     public static final String PARAM_ID = "id";

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/common/RequestOptions.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/common/RequestOptions.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.heigit.ors.api.requests.matrix.MatrixRequest;
 import org.heigit.ors.api.requests.routing.RequestProfileParams;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RouteRequestParameterNames;
 import org.json.simple.JSONObject;
 

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/export/ExportRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/export/ExportRequest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.heigit.ors.api.requests.common.APIRequest;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 
 import java.util.List;
 

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
@@ -28,7 +28,7 @@ import org.heigit.ors.exceptions.ParameterValueException;
 import org.heigit.ors.isochrones.IsochroneMapCollection;
 import org.heigit.ors.isochrones.IsochroneRequest;
 import org.heigit.ors.isochrones.IsochronesErrorCodes;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RoutingProfileType;
 
 import java.time.LocalDateTime;

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
@@ -26,7 +26,7 @@ import org.heigit.ors.api.EndpointsProperties;
 import org.heigit.ors.api.requests.common.APIRequest;
 import org.heigit.ors.exceptions.ParameterValueException;
 import org.heigit.ors.matrix.MatrixErrorCodes;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/routing/RequestProfileParamsRestrictions.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/routing/RequestProfileParamsRestrictions.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/routing/RouteRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/routing/RouteRequest.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.heigit.ors.api.requests.common.APIRequest;
 import org.heigit.ors.exceptions.ParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RouteRequestParameterNames;
 import org.heigit.ors.routing.RoutingErrorCodes;
 import org.heigit.ors.routing.RoutingProfileType;

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/snapping/SnappingApiRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/snapping/SnappingApiRequest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.heigit.ors.api.requests.common.APIRequest;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 
 import java.util.List;
 

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/common/boundingbox/BoundingBoxFactory.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/common/boundingbox/BoundingBoxFactory.java
@@ -22,7 +22,7 @@ import org.heigit.ors.api.responses.routing.gpx.GPXBounds;
 import org.heigit.ors.api.responses.routing.json.JSON3DBoundingBox;
 import org.heigit.ors.api.responses.routing.json.JSONBoundingBox;
 import org.heigit.ors.exceptions.ParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RoutingErrorCodes;
 
 public class BoundingBoxFactory {

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXExtensions.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXExtensions.java
@@ -19,7 +19,7 @@ import com.graphhopper.util.Helper;
 import jakarta.xml.bind.annotation.XmlElement;
 import org.heigit.ors.api.requests.routing.RouteRequest;
 import org.heigit.ors.api.util.AppInfo;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 
 public class GPXExtensions {
     @XmlElement(name = "attribution")

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/json/JSONSegment.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/json/JSONSegment.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.heigit.ors.api.requests.routing.RouteRequest;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RouteSegment;
 import org.heigit.ors.routing.RouteStep;
 import org.heigit.ors.util.FormatUtility;

--- a/ors-api/src/main/java/org/heigit/ors/api/services/ApiService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/ApiService.java
@@ -1,5 +1,6 @@
 package org.heigit.ors.api.services;
 
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.api.EndpointsProperties;
 import org.heigit.ors.api.requests.common.APIRequest;
 import org.heigit.ors.api.requests.common.RequestOptions;
@@ -326,7 +327,7 @@ public class ApiService {
         if (restrictions.hasTrackType())
             params.setTrackType(WheelchairTypesEncoder.getTrackType(restrictions.getTrackType()));
         if (restrictions.hasSmoothnessType())
-            params.setSmoothnessType(WheelchairTypesEncoder.getSmoothnessType(restrictions.getSmoothnessType()));
+            params.setSmoothnessType(WheelchairTypesEncoder.getSmoothnessType(restrictions.getSmoothnessType().toString()));
         if (restrictions.hasMaxSlopedKerb())
             params.setMaximumSlopedKerb(restrictions.getMaxSlopedKerb());
         if (restrictions.hasMaxIncline())

--- a/ors-api/src/main/java/org/heigit/ors/api/services/IsochronesService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/IsochronesService.java
@@ -15,7 +15,7 @@ import org.heigit.ors.exceptions.StatusCodeException;
 import org.heigit.ors.fastisochrones.partitioning.FastIsochroneFactory;
 import org.heigit.ors.isochrones.*;
 import org.heigit.ors.isochrones.statistics.StatisticsProviderConfiguration;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RouteSearchParameters;
 import org.heigit.ors.routing.RoutingProfileManager;
 import org.heigit.ors.routing.RoutingProfileType;

--- a/ors-api/src/main/java/org/heigit/ors/api/services/MatrixService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/MatrixService.java
@@ -11,7 +11,7 @@ import org.heigit.ors.matrix.MatrixErrorCodes;
 import org.heigit.ors.matrix.MatrixMetricsType;
 import org.heigit.ors.matrix.MatrixResult;
 import org.heigit.ors.matrix.MatrixSearchParameters;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RoutingErrorCodes;
 import org.heigit.ors.routing.RoutingProfileManager;
 import org.heigit.ors.routing.RoutingProfileType;

--- a/ors-api/src/main/java/org/heigit/ors/api/services/RoutingService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/RoutingService.java
@@ -1,5 +1,6 @@
 package org.heigit.ors.api.services;
 
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.api.EndpointsProperties;
 import org.heigit.ors.api.requests.routing.RouteRequest;
 import org.heigit.ors.api.requests.routing.RouteRequestRoundTripOptions;

--- a/ors-api/src/test/java/org/heigit/ors/api/converters/APIMatrixRequestProfileConverterTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/converters/APIMatrixRequestProfileConverterTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ors.api.converters;
 
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/ors-api/src/test/java/org/heigit/ors/api/requests/isochrones/IsochronesRequestTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/requests/isochrones/IsochronesRequestTest.java
@@ -2,7 +2,7 @@ package org.heigit.ors.api.requests.isochrones;
 
 import org.heigit.ors.api.requests.routing.RouteRequestOptions;
 import org.heigit.ors.exceptions.ParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/ors-api/src/test/java/org/heigit/ors/api/requests/matrix/MatrixRequestTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/requests/matrix/MatrixRequestTest.java
@@ -3,7 +3,7 @@ package org.heigit.ors.api.requests.matrix;
 import org.heigit.ors.api.EndpointsProperties;
 import org.heigit.ors.api.util.HelperFunctions;
 import org.heigit.ors.exceptions.ParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/ors-api/src/test/java/org/heigit/ors/api/requests/routing/APIEnumsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/requests/routing/APIEnumsTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ors.api.requests.routing;
 
 import org.heigit.ors.exceptions.ParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/ors-api/src/test/java/org/heigit/ors/api/requests/routing/RouteRequestTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/requests/routing/RouteRequestTest.java
@@ -16,7 +16,7 @@
 package org.heigit.ors.api.requests.routing;
 
 import org.heigit.ors.exceptions.ParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/matrix/json/JSONBasedIndividualMatrixResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/matrix/json/JSONBasedIndividualMatrixResponseTest.java
@@ -5,7 +5,7 @@ import org.heigit.ors.api.requests.matrix.MatrixRequestEnums;
 import org.heigit.ors.matrix.MatrixMetricsType;
 import org.heigit.ors.matrix.MatrixResult;
 import org.heigit.ors.matrix.ResolvedLocation;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/matrix/json/JSONIndividualMatrixResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/matrix/json/JSONIndividualMatrixResponseTest.java
@@ -7,7 +7,7 @@ import org.heigit.ors.exceptions.StatusCodeException;
 import org.heigit.ors.matrix.MatrixMetricsType;
 import org.heigit.ors.matrix.MatrixResult;
 import org.heigit.ors.matrix.ResolvedLocation;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/matrix/json/JSONMatrixResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/matrix/json/JSONMatrixResponseTest.java
@@ -9,7 +9,7 @@ import org.heigit.ors.exceptions.StatusCodeException;
 import org.heigit.ors.matrix.MatrixMetricsType;
 import org.heigit.ors.matrix.MatrixResult;
 import org.heigit.ors.matrix.ResolvedLocation;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/routing/boundingbox/BoundingBoxFactoryTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/routing/boundingbox/BoundingBoxFactoryTest.java
@@ -7,7 +7,7 @@ import org.heigit.ors.api.responses.common.boundingbox.BoundingBoxFactory;
 import org.heigit.ors.api.responses.routing.gpx.GPXBounds;
 import org.heigit.ors.api.responses.routing.json.JSON3DBoundingBox;
 import org.heigit.ors.api.responses.routing.json.JSONBoundingBox;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/ors-api/src/test/java/org/heigit/ors/api/services/APIServiceTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/services/APIServiceTest.java
@@ -7,7 +7,7 @@ import org.heigit.ors.exceptions.IncompatibleParameterException;
 import org.heigit.ors.exceptions.ParameterValueException;
 import org.heigit.ors.exceptions.StatusCodeException;
 import org.heigit.ors.exceptions.UnknownParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.parameters.ProfileParameters;
 import org.heigit.ors.routing.parameters.VehicleParameters;
 import org.heigit.ors.routing.pathprocessors.BordersExtractor;

--- a/ors-api/src/test/java/org/heigit/ors/api/services/IsochronesServiceTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/services/IsochronesServiceTest.java
@@ -1,5 +1,6 @@
 package org.heigit.ors.api.services;
 
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.api.EndpointsProperties;
 import org.heigit.ors.api.requests.isochrones.IsochronesRequest;
 import org.heigit.ors.api.requests.isochrones.IsochronesRequestEnums;

--- a/ors-api/src/test/java/org/heigit/ors/api/services/MatrixServiceTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/services/MatrixServiceTest.java
@@ -9,7 +9,7 @@ import org.heigit.ors.exceptions.ServerLimitExceededException;
 import org.heigit.ors.exceptions.StatusCodeException;
 import org.heigit.ors.matrix.MatrixMetricsType;
 import org.heigit.ors.matrix.MatrixRequest;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RoutingProfileType;
 import org.heigit.ors.routing.WeightingMethod;
 import org.junit.jupiter.api.BeforeEach;

--- a/ors-api/src/test/java/org/heigit/ors/api/services/RoutingServiceTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/services/RoutingServiceTest.java
@@ -15,6 +15,7 @@
 
 package org.heigit.ors.api.services;
 
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.api.EndpointsProperties;
 import org.heigit.ors.api.requests.routing.*;
 import org.heigit.ors.common.DistanceUnit;
@@ -233,7 +234,7 @@ class RoutingServiceTest {
         RoutingRequest routingRequest = routingService.convertRouteRequest(request);
 
         WheelchairParameters params = (WheelchairParameters) routingRequest.getSearchParameters().getProfileParameters();
-        assertEquals(WheelchairTypesEncoder.getSmoothnessType(APIEnums.SmoothnessTypes.SMOOTHNESS_GOOD), params.getSmoothnessType());
+        assertEquals(WheelchairTypesEncoder.getSmoothnessType(APIEnums.SmoothnessTypes.SMOOTHNESS_GOOD.toString()), params.getSmoothnessType());
         assertEquals(3.0f, params.getMaximumIncline(), 0);
         assertEquals(1.0f, params.getMaximumSlopedKerb(), 0);
         assertEquals(2.0f, params.getMinimumWidth(), 0);

--- a/ors-api/src/test/java/org/heigit/ors/api/util/SystemMessageTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/util/SystemMessageTest.java
@@ -5,7 +5,7 @@ import org.heigit.ors.api.requests.isochrones.IsochronesRequest;
 import org.heigit.ors.api.requests.matrix.MatrixRequest;
 import org.heigit.ors.api.requests.routing.RouteRequest;
 import org.heigit.ors.exceptions.ParameterValueException;
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.heigit.ors.routing.RoutingRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/ors-api/src/test/java/org/heigit/ors/api/util/TestProvider.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/util/TestProvider.java
@@ -1,6 +1,6 @@
 package org.heigit.ors.api.util;
 
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.api.APIEnums;
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/WheelchairTypesEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/WheelchairTypesEncoder.java
@@ -13,7 +13,8 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions;
 
-import org.heigit.ors.routing.APIEnums;
+import org.heigit.ors.exceptions.ParameterValueException;
+import org.heigit.ors.routing.GenericErrorCodes;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -154,15 +155,19 @@ public final class WheelchairTypesEncoder {
 
     public static int getEncodedType(WheelchairAttributes.Attribute attribute, String value) throws Exception {
         return switch (attribute) {
-            case SMOOTHNESS -> getSmoothnessType(APIEnums.SmoothnessTypes.forValue(value));
+            case SMOOTHNESS -> { int smoothness = getSmoothnessType(value);
+                    if (smoothness==-1)
+                        throw new ParameterValueException(GenericErrorCodes.INVALID_PARAMETER_VALUE, "surface_type", value);
+                    yield smoothness;
+                }
             case SURFACE -> getSurfaceType(value);
             case TRACK -> getTrackType(value);
             default -> throw new Exception("Attribute is not a recognised encoded type");
         };
     }
 
-    public static int getSmoothnessType(APIEnums.SmoothnessTypes smoothnessType) {
-        return SMOOTHNESS_MAP.getOrDefault(smoothnessType.toString(), -1);
+    public static int getSmoothnessType(String value)  {
+        return SMOOTHNESS_MAP.getOrDefault(value.toLowerCase(), -1);
     }
 
     public static int getTrackType(String value) {

--- a/ors-engine/src/test/java/org/heigit/ors/routing/RouteResultBuilderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/RouteResultBuilderTest.java
@@ -20,21 +20,21 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class RouteResultBuilderTest {
     private RoutingRequest request1;
     private RoutingRequest request2;
+    private static final String OSM_ID = "osmid"; // TODO: find a better solution than a hardcoded string
 
-
-    public RouteResultBuilderTest() throws Exception {
+    public RouteResultBuilderTest() {
         init();
     }
 
     @BeforeEach
-    void init() throws Exception {
+    void init() {
         Coordinate[] coordinates = new Coordinate[2];
         coordinates[0] = new Coordinate(12.3, 45.6);
         coordinates[1] = new Coordinate(23.4, 56.7);
         request1 = new RoutingRequest();
         request1.setCoordinates(coordinates);
         request1.setAttributes(new String[]{"detourfactor"});
-        request1.setExtraInfo(RouteExtraInfoFlag.getFromString("osmid"));
+        request1.setExtraInfo(RouteExtraInfoFlag.getFromString(OSM_ID));
         request1.setIncludeManeuvers(true);
 
         coordinates = new Coordinate[2];
@@ -105,7 +105,7 @@ class RouteResultBuilderTest {
         List<GHResponse> responseList = new ArrayList<>();
         List<RouteExtraInfo> extrasList = new ArrayList<>();
         RouteResultBuilder builder = new RouteResultBuilder();
-        extrasList.add(new RouteExtraInfo(APIEnums.ExtraInfo.OSM_ID.toString()));
+        extrasList.add(new RouteExtraInfo("osmid"));
         responseList.add(constructResponse(request1));
         //noinspection unchecked
         RouteResult result = builder.createMergedRouteResultFromBestPaths(responseList, request1, new List[]{extrasList});
@@ -126,7 +126,7 @@ class RouteResultBuilderTest {
         assertEquals(10, result.getSegments().get(0).getSteps().get(1).getType(), "Single response should return valid RouteResult (segments[0].steps[1].type = 10)");
         assertEquals(0, result.getSegments().get(0).getSteps().get(1).getManeuver().getBearingAfter(), "Single response should return valid RouteResult (segments[0].steps[1].maneuver.bearingAfter = 0)");
         assertEquals(1, result.getExtraInfo().size(), "Single response should return valid RouteResult (extrainfo.size = 1)");
-        assertEquals(APIEnums.ExtraInfo.OSM_ID.toString(), result.getExtraInfo().get(0).getName(), "Single response should return valid RouteResult (extrainfo[0].name = 'osmid)");
+        assertEquals(OSM_ID, result.getExtraInfo().get(0).getName(), "Single response should return valid RouteResult (extrainfo[0].name = 'osmid)");
         assertEquals(2, result.getWayPointsIndices().size(), "Single response should return valid RouteResult (waypointindices.size = 2)");
     }
 
@@ -136,7 +136,7 @@ class RouteResultBuilderTest {
         List<GHResponse> responseList = new ArrayList<>();
         List<RouteExtraInfo> extrasList = new ArrayList<>();
         RouteResultBuilder builder = new RouteResultBuilder();
-        extrasList.add(new RouteExtraInfo(APIEnums.ExtraInfo.OSM_ID.toString()));
+        extrasList.add(new RouteExtraInfo(OSM_ID));
         responseList.add(constructResponse(request1));
         responseList.add(constructResponse(request2));
         //noinspection unchecked
@@ -168,7 +168,7 @@ class RouteResultBuilderTest {
         assertEquals(10, result.getSegments().get(1).getSteps().get(1).getType(), "Two responses should return merged RouteResult (segments[1].steps[1].type = 10)");
         assertEquals(0, result.getSegments().get(1).getSteps().get(1).getManeuver().getBearingAfter(), "Two responses should return merged RouteResult (segments[1].steps[1].maneuver.bearingAfter = 0)");
         assertEquals(1, result.getExtraInfo().size(), "Two responses should return merged RouteResult (extrainfo.size = 1)");
-        assertEquals(APIEnums.ExtraInfo.OSM_ID.toString(), result.getExtraInfo().get(0).getName(), "Two responses should return merged RouteResult (extrainfo[0].name = 'osmid)");
+        assertEquals(OSM_ID, result.getExtraInfo().get(0).getName(), "Two responses should return merged RouteResult (extrainfo[0].name = 'osmid)");
         assertEquals(3, result.getWayPointsIndices().size(), "Two responses should return merged RouteResult (waypointindices.size = 3)");
 
     }
@@ -178,7 +178,7 @@ class RouteResultBuilderTest {
         List<GHResponse> responseList = new ArrayList<>();
         List<RouteExtraInfo> extrasList = new ArrayList<>();
         RouteResultBuilder builder = new RouteResultBuilder();
-        extrasList.add(new RouteExtraInfo(APIEnums.ExtraInfo.OSM_ID.toString()));
+        extrasList.add(new RouteExtraInfo(OSM_ID));
         List<Integer> skipSegments = new ArrayList<>();
         skipSegments.add(1);
         request1.setSkipSegments(skipSegments);


### PR DESCRIPTION
APIEnums are concerned with API code and should not be used by the engine core. This refactoring removes the last dependencies of engine code on APIEnums and moves the APIEnums class into the api module.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1634  .

### Information about the changes
- Key functionality added: refactor to get better seperation of engine code and api code
- Reason for change: Improve maintainability
