### PR TITLE
refactor(Data Access): Remove unused methods

### DIFF
--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
@@ -60,10 +60,6 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
         return res;
     }
 
-    public void setSegmentSize(int bytes) {
-        orsEdges.setSegmentSize(bytes);
-    }
-
     public HeavyVehicleAttributesGraphStorage create(long initBytes) {
         orsEdges.create(initBytes * edgeEntryBytes);
         return this;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/RoadAccessRestrictionsGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/RoadAccessRestrictionsGraphStorage.java
@@ -79,10 +79,6 @@ public class RoadAccessRestrictionsGraphStorage implements GraphExtension, Warni
         return res;
     }
 
-    public void setSegmentSize(int bytes) {
-        edges.setSegmentSize(bytes);
-    }
-
     public RoadAccessRestrictionsGraphStorage create(long initBytes) {
         edges.create(initBytes * edgeEntryBytes);
         return this;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TollwaysGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TollwaysGraphStorage.java
@@ -47,10 +47,6 @@ public class TollwaysGraphStorage implements GraphExtension {
         return res;
     }
 
-    public void setSegmentSize(int bytes) {
-        edges.setSegmentSize(bytes);
-    }
-
     public TollwaysGraphStorage create(long initBytes) {
         edges.create(initBytes * edgeEntryBytes);
         return this;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrafficGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrafficGraphStorage.java
@@ -460,17 +460,6 @@ public class TrafficGraphStorage implements GraphExtension {
     }
 
     /**
-     * sets the segment size in all additional data storages
-     *
-     * @param bytes Size in bytes.
-     */
-    public void setSegmentSize(int bytes) {
-        orsEdgesProperties.setSegmentSize(bytes);
-        orsEdgesTrafficLinkLookup.setSegmentSize(bytes);
-        orsSpeedPatternLookup.setSegmentSize(bytes);
-    }
-
-    /**
      * @return true if successfully loaded from persistent storage.
      */
     @Override

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrailDifficultyScaleGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrailDifficultyScaleGraphStorage.java
@@ -48,10 +48,6 @@ public class TrailDifficultyScaleGraphStorage implements GraphExtension {
         return res;
     }
 
-    public void setSegmentSize(int bytes) {
-        edges.setSegmentSize(bytes);
-    }
-
     public TrailDifficultyScaleGraphStorage create(long initBytes) {
         edges.create(initBytes * edgeEntryBytes);
         return this;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WayCategoryGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WayCategoryGraphStorage.java
@@ -41,10 +41,6 @@ public class WayCategoryGraphStorage implements GraphExtension {
         this.orsEdges = dir.find("ext_waycategory");
     }
 
-    public void setSegmentSize(int bytes) {
-        orsEdges.setSegmentSize(bytes);
-    }
-
     public WayCategoryGraphStorage create(long initBytes) {
         orsEdges.create(initBytes * edgeEntryBytes);
         return this;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
@@ -50,10 +50,6 @@ public class WaySurfaceTypeGraphStorage implements GraphExtension {
         return edgeEntryIndex;
     }
 
-    public void setSegmentSize(int bytes) {
-        orsEdges.setSegmentSize(bytes);
-    }
-
     public WaySurfaceTypeGraphStorage create(long initBytes) {
         orsEdges.create(initBytes * edgeEntryBytes);
         return this;


### PR DESCRIPTION
In order to prepare for an update to the DataAccess (gh5+) this PR removes some unused methods which access the in future removed `setSegmentSize` DataAccess method.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the master branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/master/CONTRIBUTE.md#pull-request-guidelines
