### PR TITLE
fix: no config loading if test profile is active

### DIFF
--- a/ors-api/src/main/java/org/heigit/ors/api/ORSEnvironmentPostProcessor.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/ORSEnvironmentPostProcessor.java
@@ -29,6 +29,10 @@ public class ORSEnvironmentPostProcessor implements EnvironmentPostProcessor {
 
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        if (environment.matchesProfiles("test")) {
+            log.info("No additional configuration loaded, test profile is active.");
+            return;
+        }
         // Override values from application.yml with contents of custom config yml file.
         List<String> configLocations = new ArrayList<>();
         log.info("");


### PR DESCRIPTION
### Information about the changes
- Reason for change:

Added a check in the ORSEnvironmentPostProcessor to skip configuration files loading if the "test" profile is active. That way the API tests won't break in the future because of changes to `ors-config.yml` 