### PR TITLE
fix: set correct working directory for maven

### DIFF
--- a/ors-api/pom.xml
+++ b/ors-api/pom.xml
@@ -101,7 +101,7 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
-                    <workingDirectory>${basedir}</workingDirectory>
+                    <workingDirectory>${project.parent.basedir}</workingDirectory>
                     <jmxPort>${tomcat.http.jmxPort}</jmxPort>
                 </configuration>
             </plugin>


### PR DESCRIPTION

Fixes #1675 .

### Information about the changes
- Key functionality added: set correct working directory for maven
- Reason for change: fixes startup failure when running in maven

