### PR TITLE
fix(isochrones): avoid speed reduction on ways tagged with `access=destination`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ RELEASING:
 - log summary stats on traffic mapmatching and use progress bar only in debug mode ([#1647](https://github.com/GIScience/openrouteservice/pull/1647))
 - move APIEnums into API module ([#1634](https://github.com/GIScience/openrouteservice/issues/1634))
 - performance improvements to isochrone calculations ([#1607](https://github.com/GIScience/openrouteservice/pull/1607))
+- do not apply speed penalty to roads tagged with "access=destination" when computing isochrones ([#1682](https://github.com/GIScience/openrouteservice/pull/1682))
 
 ### Deprecated
 - JSON configuration and related classes ([#1506](https://github.com/GIScience/openrouteservice/pull/1506))

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ResultTest.java
@@ -122,7 +122,7 @@ class ResultTest extends ServiceTest {
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].geometry.coordinates[0].size()", is(both(greaterThan(80)).and(lessThan(90))))
+                .body("features[0].geometry.coordinates[0].size()", is(both(greaterThan(70)).and(lessThan(80))))
                 .body("features[0].properties.center.size()", is(2))
                 .body("bbox", hasItems(closeTo(8.652489f, 0.02f), closeTo(49.40263f, 0.02f), closeTo(8.708881f, 0.02f), closeTo(49.447865f, 0.02f)))
                 .body("features[0].type", is("Feature"))

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSWeightingFactory.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSWeightingFactory.java
@@ -144,7 +144,7 @@ public class ORSWeightingFactory implements WeightingFactory {
 
     public static Weighting createIsochroneWeighting(RouteSearchContext searchContext, TravelRangeType travelRangeType) {
         if (travelRangeType == TravelRangeType.TIME) {
-            return new FastestWeighting(searchContext.getEncoder());
+            return new ORSFastestWeighting(searchContext.getEncoder());
         } else {
             return new ShortestWeighting(searchContext.getEncoder());
         }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/weighting/ORSFastestWeighting.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/weighting/ORSFastestWeighting.java
@@ -26,6 +26,10 @@ import com.graphhopper.util.Parameters;
 public class ORSFastestWeighting extends FastestWeighting {
     private final double headingPenalty;
 
+    public ORSFastestWeighting(FlagEncoder encoder) {
+        this(encoder, new PMap(0), TurnCostProvider.NO_TURN_COST_PROVIDER);
+    }
+
     public ORSFastestWeighting(FlagEncoder encoder, PMap map, TurnCostProvider turnCostProvider) {
         super(encoder, map, turnCostProvider);
         headingPenalty = map.getDouble(Parameters.Routing.HEADING_PENALTY, Parameters.Routing.DEFAULT_HEADING_PENALTY);


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added: ignore speed penalty on roads tagged with `access = destination` when computing isochrones.
- Reason for change: isochrones starting around ways tagged as `access = destination` were smaller than expected

### Examples and reasons for differences between live ORS routes, and those generated from this pull request.

Original 5-minutes isochrone (the smaller inner polygon) vs. one generated with this PR (the larger enclosing polygon).

![image](https://github.com/GIScience/openrouteservice/assets/6545356/5bdcc622-15bc-4431-a523-0fa8898fb78f)


[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
