### PR TITLE
ci(docker-nightly): move to separate build/publish from test

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build and publish the nightly Docker image
+name: Build and test the Docker image
 on:
   pull_request:
     types: [ opened, synchronize, ready_for_review ]
@@ -8,7 +8,6 @@ on:
 
 env:
   TEST_IMAGE_NAME: 'local/openrouteservice:test'
-  PRODUCTION_IMAGE_NAME: 'openrouteservice/openrouteservice:nightly'
   BUILD_PLATFORMS: 'linux/amd64,linux/arm64/v8'
 
 
@@ -19,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       test_image_name: ${{ env.TEST_IMAGE_NAME }}
-      production_image_name: ${{ env.PRODUCTION_IMAGE_NAME }}
       build_platforms: ${{ env.BUILD_PLATFORMS }}
     steps:
       - run: |
@@ -47,7 +45,7 @@ jobs:
           context: .
           push: false
           load: false
-          tags: ${{ needs.prepare_environment.outputs.test_image_name }}, ${{ needs.prepare_environment.outputs.production_image_name }}
+          tags: ${{ needs.prepare_environment.outputs.test_image_name }}
           platforms: "${{ needs.prepare_environment.outputs.build_platforms }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -127,39 +125,3 @@ jobs:
           ./.github/utils/cors_check.sh 127.0.0.1 8080 /ors/v2/isochrones/geojson "https://example.org" 200 50
           # It should fail with http code 403 for https://example.com since the Origin is not covered.
           ./.github/utils/cors_check.sh 127.0.0.1 8080 /ors/v2/isochrones/geojson "https://example.com" 403 10
-  publish_docker:
-    name: Publish the docker image to docker hub
-    runs-on: ubuntu-latest
-    needs:
-      - prepare_environment
-      - build_docker_images
-      - run_docker_image_tests
-    steps:
-      - run: |
-          echo "Publish image ${{ needs.prepare_environment.outputs.production_image_name }}"
-      - name: Checkout
-        uses: actions/checkout@v2.2.0
-        with:
-          fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        id: buildx
-        with:
-          install: true
-      - name: Login to DockerHub
-        if: ${{ success() && github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Publish nightly
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: ${{ needs.prepare_environment.outputs.production_image_name }}
-          platforms: "${{ needs.prepare_environment.outputs.build_platforms }}"
-          cache-from: type=gha

--- a/.github/workflows/docker-nightly-image.yml
+++ b/.github/workflows/docker-nightly-image.yml
@@ -1,0 +1,87 @@
+name: Docker Nightly Image CI
+run-name: Build ${{ inputs.branch }} - ${{ inputs.user }}
+
+on:
+  schedule:
+    - cron: '15 1 * * *'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'GitHub repository to create image off.'
+        required: true
+        default: 'GIScience/openrouteservice'
+      branch:
+        description: 'GitHub branch to create image off.'
+        required: true
+        default: 'main'
+      tag:
+        description: 'Name of the docker tag to create.'
+        required: true
+        default: 'nightly'
+      ignore-24h-commit-check:
+        description: 'Build image regardless of last commit date.'
+        required: true
+        type: boolean
+        default: false
+      user:
+        description: ''
+        required: false
+        default: 'schedule'
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    outputs:
+      new_commits: ${{ steps.check.outputs.NEW_COMMITS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: ${{ inputs.repository || 'GIScience/openrouteservice' }}
+          ref: ${{ inputs.branch || 'main' }}
+
+      - name: Check for new commits since 24 h ago
+        id: check
+        run: |
+          export LOG_LINES=$(git log --oneline --since '24 hours ago')
+          export NUM_LINES=$(echo "$LOG_LINES" | grep -c .)
+          if [ "$NUM_LINES" -eq "0" ]; then
+            export NEW_COMMITS="false"
+          else
+            export NEW_COMMITS="true"
+          fi
+          echo "NEW_COMMITS=$NEW_COMMITS" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: check-commits
+    runs-on: ubuntu-latest
+    if: inputs.ignore-24h-commit-check || needs.check-commits.outputs.new_commits == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: ${{ inputs.repository || 'GIScience/openrouteservice' }}
+          ref: ${{ inputs.branch || 'main' }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64/v8
+          provenance: false
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ secrets.DOCKER_USERNAME }}/openrouteservice:${{ inputs.tag || 'nightly' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ RELEASING:
 - performance improvements to isochrone calculations ([#1607](https://github.com/GIScience/openrouteservice/pull/1607))
 - do not apply speed penalty to roads tagged with "access=destination" when computing isochrones ([#1682](https://github.com/GIScience/openrouteservice/pull/1682))
 - backend documentation overhaul ([#1651](https://github.com/GIScience/openrouteservice/pull/1651))
+- separate docker image build from test workflow. Build nightly on schedule if there are changes to main ([#1689](https://github.com/GIScience/openrouteservice/pull/1689))
 
 ### Deprecated
 - JSON configuration and related classes ([#1506](https://github.com/GIScience/openrouteservice/pull/1506))


### PR DESCRIPTION
previously the nightly build was not built nightly but on many changes in PRs as well.
This is now moved to a separate workflow that runs nightly, with workflow_dispatch option to build images for different branches & repos on demand.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes https://github.com/GIScience/openrouteservice/issues/1686

### Information about the changes
- Key functionality added: real nightly build
- Reason for change: nightly was not built nightly

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/installation/Configuration.html
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
