### PR TITLE
build(maven): Fix the docker-build pipeline

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         id: buildx
@@ -84,7 +84,7 @@ jobs:
             echo "HEALTH_WAIT_TIME=260" >> $GITHUB_ENV
           fi
       - name: Set up QEMU for ${{ matrix.platform }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.platform }}
       - name: Set up Docker Buildx

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Set up QEMU for ${{ matrix.platform }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.platform }}
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ COPY ors-engine /ors-core/ors-engine
 COPY pom.xml /ors-core/pom.xml
 COPY ors-report-aggregation /ors-core/ors-report-aggregation
 
-# Build the project and ignore the report aggregation module as not needed for the API
-RUN mvn package -DskipTests -pl '!ors-report-aggregation'
+# Build the project and ignore the report aggregation module as not needed for the API build war
+RUN mvn package -DskipTests -P buildWar
 
 # build final image, just copying stuff inside
 FROM amazoncorretto:17.0.7-alpine3.17 as publish

--- a/ors-api/pom.xml
+++ b/ors-api/pom.xml
@@ -39,15 +39,6 @@
 
     <packaging>${packagingValue}</packaging>
 
-    <properties>
-        <!--
-            A default for packagingValue is needed, if profiles other than buildWar or buildFatJar are used, e.g. apitests.
-            The value is set/overridden in the profiles buildWar and buildFatJar, e.g.
-                mvn clean package -PbuildWar
-         -->
-        <packagingValue>jar</packagingValue>
-    </properties>
-
     <build>
         <finalName>ors</finalName>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -290,21 +281,6 @@
     </dependencies>
 
     <profiles>
-        <profile>
-            <id>buildWar</id>
-            <properties>
-                <packagingValue>war</packagingValue>
-            </properties>
-        </profile>
-        <profile>
-            <id>buildFatJar</id>
-            <properties>
-                <packagingValue>jar</packagingValue>
-            </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
         <profile>
             <id>apitests</id>
             <build>

--- a/ors-report-aggregation/pom.xml
+++ b/ors-report-aggregation/pom.xml
@@ -23,7 +23,7 @@
             <groupId>org.heigit.ors</groupId>
             <artifactId>ors-api</artifactId>
             <version>${project.version}</version>
-            <type>jar</type>
+            <type>${packagingValue}</type>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
     </modules>
 
     <properties>
+        <!--
+            A default for packagingValue is needed, if profiles other than buildWar or buildFatJar are used, e.g. apitests.
+            The value is set/overridden in the profiles buildWar and buildFatJar, e.g.
+                mvn clean package -PbuildWar
+         -->
+        <packagingValue>jar</packagingValue>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -80,6 +86,24 @@
             </releases>
         </repository>
     </repositories>
+
+    <profiles>
+        <profile>
+            <id>buildWar</id>
+            <properties>
+                <packagingValue>war</packagingValue>
+            </properties>
+        </profile>
+        <profile>
+            <id>buildFatJar</id>
+            <properties>
+                <packagingValue>jar</packagingValue>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+    </profiles>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This PR moves the war/jar logic to the main pom.xml. This allows us to use the `packagingValue` inside the ors-report-aggregation as well and build it in jar/war mode. Before, we always needed to exclude the package when building with war target.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
