### PR TITLE
fix(logging): Repair the logging backend

### DIFF
--- a/ors-api/pom.xml
+++ b/ors-api/pom.xml
@@ -152,11 +152,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
-            <scope>runtime</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.json</groupId>
@@ -243,12 +238,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-slf4j2-impl</artifactId>
-                </exclusion>
-            </exclusions>
+            <!-- Don't exclude log4j-slf4j2-impl -->
+            <!-- This implements log4j logging as well as proper forwarding from slf4j to log4j -->
+            <!-- It is necessary when artifacts in the dependency tree use slf4j but we use log4j -->
+            <!-- Right now, we use log4j2 as logging framework but the graphhopper library uses slf4j -->
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/ors-api/pom.xml
+++ b/ors-api/pom.xml
@@ -184,7 +184,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <!-- The following dependency is needed for the Spring Boot Actuator and validates beans -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/ors-engine/pom.xml
+++ b/ors-engine/pom.xml
@@ -133,11 +133,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
-            <scope>runtime</scope>
-        </dependency>
 
         <dependency>
             <groupId>me.tongfei</groupId>

--- a/ors-engine/pom.xml
+++ b/ors-engine/pom.xml
@@ -137,12 +137,6 @@
         <dependency>
             <groupId>me.tongfei</groupId>
             <artifactId>progressbar</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jline</groupId>
-                    <artifactId>jline</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -261,13 +261,6 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-reload4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This removes the exclusion of log4j-slf4j2-impl (therefore including it) and removes the package slf4j-reload4j.

Graphhopper uses slf4j as a logging backend, whereas ors uses log4j.
We need log4j-slf4j2-impl to tunnel slf4j through our log4j logging interface. This is not 100% evident in all run scenarios. While native spring runs can cope with this partially, running in an external tomcat environment leads to no or missing log output once the war is deployed.

We don't need slf4j-reload4j right now, as it would only be useful for hot-reloading logging configs while ors is running. Another side effect of just keeping the lib is that when spring or tomcat is looking for a log facility, it sees log4j as well as slf4j-reload4j. It can happen, that it appends to slf4j-reload4j instead of log4j in certain scenarios, which leads to no available logging output. This confusion can lead to no log output in tomcat/war deployment scenarios.

Additionally, a redundant exclusion is removed as well as the missing spring-boot-starter-validation included.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
