### PR TITLE
fix(isochrones): correct and unify edge splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ RELEASING:
 - backend documentation overhaul ([#1651](https://github.com/GIScience/openrouteservice/pull/1651))
 - separate docker image build from test workflow. Build nightly on schedule if there are changes to main ([#1689](https://github.com/GIScience/openrouteservice/pull/1689))
 - refactor isochrone builder classes ([#1699](https://github.com/GIScience/openrouteservice/pull/1699))
+- unify edge splitting across isochrone builders, and split edges based on coordinates rather than their actual distance in meters ([#1708](https://github.com/GIScience/openrouteservice/pull/1708))
 
 ### Deprecated
 - JSON configuration and related classes ([#1506](https://github.com/GIScience/openrouteservice/pull/1506))

--- a/ors-api/src/main/resources/application.yml
+++ b/ors-api/src/main/resources/application.yml
@@ -81,7 +81,7 @@ ors:
       enabled: true
       attribution: openrouteservice.org, OpenStreetMap contributors
       maximum_locations: 2
-      maximum_intervals: 10
+      maximum_intervals: 1
       allow_compute_area: true
       maximum_range_distance_default: 50000
       maximum_range_distance:

--- a/ors-api/src/main/resources/application.yml
+++ b/ors-api/src/main/resources/application.yml
@@ -81,7 +81,7 @@ ors:
       enabled: true
       attribution: openrouteservice.org, OpenStreetMap contributors
       maximum_locations: 2
-      maximum_intervals: 1
+      maximum_intervals: 10
       allow_compute_area: true
       maximum_range_distance_default: 50000
       maximum_range_distance:

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ResultTest.java
@@ -237,7 +237,7 @@ class ResultTest extends ServiceTest {
                 .when()
                 .post(getEndPointPath() + "/{profile}/geojson")
                 .then().log().ifValidationFails()
-                .body("features[0].properties.area", is(closeTo(1114937.0f, 10000f)))
+                .body("features[0].properties.area", is(closeTo(1069855.2f, 10000f)))
                 .statusCode(200);
     }
 

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ResultTest.java
@@ -122,7 +122,7 @@ class ResultTest extends ServiceTest {
                 .then()
                 .body("any { it.key == 'type' }", is(true))
                 .body("any { it.key == 'features' }", is(true))
-                .body("features[0].geometry.coordinates[0].size()", is(both(greaterThan(40)).and(lessThan(50))))
+                .body("features[0].geometry.coordinates[0].size()", is(both(greaterThan(45)).and(lessThan(55))))
                 .body("features[0].properties.center.size()", is(2))
                 .body("bbox", hasItems(closeTo(8.652489f, 0.02f), closeTo(49.40263f, 0.02f), closeTo(8.708881f, 0.02f), closeTo(49.447865f, 0.02f)))
                 .body("features[0].type", is("Feature"))

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/AbstractIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/AbstractIsochroneMapBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static org.locationtech.jts.algorithm.hull.ConcaveHull.concaveHullByLength;
 
 public abstract class AbstractIsochroneMapBuilder implements IsochroneMapBuilder {
-    private static final double MAX_SEGMENT_LENGTH = 0.18;// corresponds to 20000 m
+    private static final double MAX_SEGMENT_ANGLE = 0.18;// in degrees, corresponds to 20000 m
     protected static final DistanceCalc dcFast = new DistancePlaneProjection();
     protected GeometryFactory geometryFactory;
     protected RouteSearchContext searchContext;
@@ -170,7 +170,7 @@ public abstract class AbstractIsochroneMapBuilder implements IsochroneMapBuilder
                 lat1 = pl.getLat(i);
                 lon1 = pl.getLon(i);
                 addPoint(points, lon0, lat0);
-                splitLineSegment(lat0, lon0, lat1, lon1, points, minSplitLength, MAX_SEGMENT_LENGTH);
+                splitLineSegment(lat0, lon0, lat1, lon1, points, minSplitLength, MAX_SEGMENT_ANGLE);
                 lon0 = lon1;
                 lat0 = lat1;
             }

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/AbstractIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/AbstractIsochroneMapBuilder.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static org.locationtech.jts.algorithm.hull.ConcaveHull.concaveHullByLength;
 
 public abstract class AbstractIsochroneMapBuilder implements IsochroneMapBuilder {
-    private static final double MAX_SPLIT_LENGTH = 20000.0;
+    private static final double MAX_SPLIT_LENGTH = 0.18;// corresponds to 20000 m
     protected static final DistanceCalc dcFast = new DistancePlaneProjection();
     protected GeometryFactory geometryFactory;
     protected RouteSearchContext searchContext;
@@ -141,12 +141,16 @@ public abstract class AbstractIsochroneMapBuilder implements IsochroneMapBuilder
      * @param maxlim limit above which the edge will NOT be split anymore (in meters)
      */
     protected void splitLineSegment(double lat0, double lon0, double lat1, double lon1, List<Coordinate> points, double minlim, double maxlim) {
-        double dist = dcFast.calcDist(lat0, lon0, lat1, lon1);
+        double dx = (lon1 - lon0);
+        double dy = (lat1 - lat0);
+        double normLength = Math.sqrt((dx * dx) + (dy * dy));
 
-        if (dist > minlim && dist < maxlim) {
-            int n = (int) Math.ceil(dist / minlim);
+        if (minlim < normLength && normLength < maxlim) {
+            int n = (int) Math.ceil(normLength / minlim);
+            double dx2 = dx / n;
+            double dy2 = dy / n;
             for (int i = 1; i < n; i++) {
-                addPoint(points, lon0 + i * (lon1 - lon0) / n, lat0 + i * (lat1 - lat0) / n);
+                addPoint(points, lon0 + i * dx2, lat0 + i * dy2);
             }
         }
     }

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/AbstractIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/AbstractIsochroneMapBuilder.java
@@ -22,11 +22,11 @@ import java.util.List;
 import static org.locationtech.jts.algorithm.hull.ConcaveHull.concaveHullByLength;
 
 public abstract class AbstractIsochroneMapBuilder implements IsochroneMapBuilder {
-    private static final double MAX_SPLIT_LENGTH = 0.18;// corresponds to 20000 m
+    private static final double MAX_SEGMENT_LENGTH = 0.18;// corresponds to 20000 m
     protected static final DistanceCalc dcFast = new DistancePlaneProjection();
     protected GeometryFactory geometryFactory;
     protected RouteSearchContext searchContext;
-    protected double defaultSmoothingDistance = 0.012;// Use a default length of ~1333m
+    private static final double DEFAULT_SMOOTHING_DISTANCE = 0.009;// Use a default length of ~1000m
     protected Polygon previousIsochronePolygon = null;
 
     public abstract Logger getLogger();
@@ -55,7 +55,7 @@ public abstract class AbstractIsochroneMapBuilder implements IsochroneMapBuilder
             if (maxRadius < 5000)
                 return MINIMUM_DISTANCE;
 
-            return defaultSmoothingDistance;
+            return DEFAULT_SMOOTHING_DISTANCE;
         }
 
         double intervalDegrees = GeomUtility.metresToDegrees(maxRadius);
@@ -170,7 +170,7 @@ public abstract class AbstractIsochroneMapBuilder implements IsochroneMapBuilder
                 lat1 = pl.getLat(i);
                 lon1 = pl.getLon(i);
                 addPoint(points, lon0, lat0);
-                splitLineSegment(lat0, lon0, lat1, lon1, points, minSplitLength, MAX_SPLIT_LENGTH);
+                splitLineSegment(lat0, lon0, lat1, lon1, points, minSplitLength, MAX_SEGMENT_LENGTH);
                 lon0 = lon1;
                 lat0 = lat1;
             }

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -122,11 +122,9 @@ public class ConcaveBallsIsochroneMapBuilder extends AbstractIsochroneMapBuilder
                 isochronesDifference = metersPerSecond * isochronesDifference;
             }
 
-            float smoothingFactor = parameters.getSmoothingFactor();
-            var smoothingDistance = convertSmoothingFactorToDistance(smoothingFactor, maxRadius);
-            var smoothingDistanceMeter = GeomUtility.degreesToMetres(smoothingDistance);
+            double smoothingDistance = convertSmoothingFactorToDistance(parameters.getSmoothingFactor(), maxRadius);
 
-            GeometryCollection points = buildIsochrone(edgeMap, isoPoints, isoValue, prevCost, isochronesDifference, 0.85, smoothingDistanceMeter);
+            GeometryCollection points = buildIsochrone(edgeMap, isoPoints, isoValue, prevCost, isochronesDifference, 0.85, smoothingDistance);
 
             if (LOGGER.isDebugEnabled()) {
                 sw.stop();

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -28,7 +28,6 @@ import org.heigit.ors.isochrones.IsochroneMap;
 import org.heigit.ors.isochrones.IsochroneSearchParameters;
 import org.heigit.ors.isochrones.builders.AbstractIsochroneMapBuilder;
 import org.heigit.ors.routing.graphhopper.extensions.AccessibilityMap;
-import org.heigit.ors.util.GeomUtility;
 import org.locationtech.jts.geom.*;
 
 import java.util.ArrayList;
@@ -194,15 +193,12 @@ public class ConcaveBallsIsochroneMapBuilder extends AbstractIsochroneMapBuilder
             bufferSize = 0.00018;
         }
 
-        int nodeId;
-        int edgeId;
-
         StopWatch sw = new StopWatch();
 
         for (IntObjectCursor<SPTEntry> entry : map) {
             SPTEntry goalEdge = entry.value;
-            edgeId = goalEdge.originalEdge;
-            nodeId = goalEdge.adjNode;
+            int edgeId = goalEdge.originalEdge;
+            int nodeId = goalEdge.adjNode;
 
             if (edgeId == -1 || nodeId == -1 || nodeId > maxNodeId || edgeId > maxEdgeId)
                 continue;
@@ -235,7 +231,7 @@ public class ConcaveBallsIsochroneMapBuilder extends AbstractIsochroneMapBuilder
                     }
                 }
             } else {
-                if ((minCost < isolineCost && maxCost >= isolineCost)) {
+                if (minCost < isolineCost && maxCost >= isolineCost) {
                     if (LOGGER.isDebugEnabled())
                         sw.start();
                     addBorderEdgeGeometry(points, isolineCost, minSplitLength, iter, maxCost, minCost, bufferSize);

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
@@ -66,7 +66,7 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
     private CellStorage cellStorage;
     private IsochroneNodeStorage isochroneNodeStorage;
     private QueryGraph queryGraph;
-    private static final int MAX_EDGE_LENGTH_LIMIT = Integer.MAX_VALUE;
+    private static final int MAX_SEGMENT_LENGTH = Integer.MAX_VALUE;
     private static final double ACTIVE_CELL_APPROXIMATION_FACTOR = 0.99;
     private static final Logger LOGGER = Logger.getLogger(FastIsochroneMapBuilder.class.getName());
 
@@ -78,7 +78,6 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
     @Override
     public void initialize(RouteSearchContext searchContext) {
         super.initialize(searchContext);
-        defaultSmoothingDistance = 0.010;// Use a default length of ~1000m
         var fastIsochroneFactory = ((ORSGraphHopper) searchContext.getGraphHopper()).getFastIsochroneFactory();
         this.cellStorage = fastIsochroneFactory.getCellStorage();
         this.isochroneNodeStorage = fastIsochroneFactory.getIsochroneNodeStorage();
@@ -283,7 +282,7 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
                 for (int i = 0; i < ringCoords.size(); i++) {
                     lat1 = ringCoords.get(i).y;
                     lon1 = ringCoords.get(i).x;
-                    splitLineSegment(lat0, lon0, lat1, lon1, contourCoords, minSplitLength, MAX_EDGE_LENGTH_LIMIT);
+                    splitLineSegment(lat0, lon0, lat1, lon1, contourCoords, minSplitLength, MAX_SEGMENT_LENGTH);
                     lon0 = lon1;
                     lat0 = lat1;
                 }

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
@@ -200,13 +200,11 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
                 meanRadius = isoValue;
             }
 
-            float smoothingFactor = parameters.getSmoothingFactor();
-            var smoothingDistance = convertSmoothingFactorToDistance(smoothingFactor, maxRadius);
-            var smoothingDistanceMeter = GeomUtility.degreesToMetres(smoothingDistance);
+            double smoothingDistance = convertSmoothingFactorToDistance(parameters.getSmoothingFactor(), maxRadius);
 
             //Add previous isochrone interval polygon
             addPreviousIsochronePolygon(isochroneGeometries);
-            buildActiveCellsConcaveHulls(fastIsochroneAlgorithm, isochroneGeometries, snappedLoc, snappedPosition, isoValue, smoothingDistance, smoothingDistanceMeter);
+            buildActiveCellsConcaveHulls(fastIsochroneAlgorithm, isochroneGeometries, snappedLoc, snappedPosition, isoValue, smoothingDistance);
 
             if (!isochroneGeometries.isEmpty()) {
                 //Make a union of all now existing polygons to reduce coordinate list
@@ -218,8 +216,8 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
                 StopWatch finalConcaveHullStopWatch = new StopWatch();
                 if (DebugUtility.isDebug())
                     finalConcaveHullStopWatch.start();
-                isoPoints.addAll(createCoordinateListFromGeometry(preprocessedGeometry, smoothingDistanceMeter));
-                GeometryCollection points = buildIsochrone(new AccessibilityMap(new GHIntObjectHashMap<>(0), snappedPosition), isoPoints, isoValue, smoothingDistanceMeter);
+                isoPoints.addAll(createCoordinateListFromGeometry(preprocessedGeometry, smoothingDistance));
+                GeometryCollection points = buildIsochrone(new AccessibilityMap(new GHIntObjectHashMap<>(0), snappedPosition), isoPoints, isoValue, smoothingDistance);
                 addIsochrone(isochroneMap, points, isoValue, meanRadius, smoothingDistance);
                 if (DebugUtility.isDebug()) {
                     LOGGER.debug("Build final concave hull from " + points.getNumGeometries() + " points: " + finalConcaveHullStopWatch.stop().getSeconds());
@@ -241,7 +239,7 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
         return edgeFilterSequence;
     }
 
-    private void buildActiveCellsConcaveHulls(FastIsochroneAlgorithm fastIsochroneAlgorithm, Set<Geometry> isochroneGeometries, Coordinate snappedLoc, GHPoint3D snappedPosition, double isoValue, double smoothingDistance, double minSplitLength) {
+    private void buildActiveCellsConcaveHulls(FastIsochroneAlgorithm fastIsochroneAlgorithm, Set<Geometry> isochroneGeometries, Coordinate snappedLoc, GHPoint3D snappedPosition, double isoValue, double smoothingDistance) {
         //Build concave hulls of all active cells individually
         StopWatch swActiveCellSeparate = new StopWatch();
         StopWatch swActiveCellBuild = new StopWatch();
@@ -258,8 +256,8 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
                 if (largestSubCellProcessed && splitMap.size() < getMinCellNodesNumber())
                     continue;
                 largestSubCellProcessed = true;
-                GeometryCollection points = buildIsochrone(new AccessibilityMap(splitMap, snappedPosition), new ArrayList<>(), isoValue, minSplitLength);
-                createPolyFromPoints(isochroneGeometries, points, smoothingDistance, minSplitLength);
+                GeometryCollection points = buildIsochrone(new AccessibilityMap(splitMap, snappedPosition), new ArrayList<>(), isoValue, smoothingDistance);
+                createPolyFromPoints(isochroneGeometries, points, smoothingDistance);
             }
             swActiveCellBuild.stop();
         }
@@ -286,7 +284,7 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
                 for (int i = 0; i < ringCoords.size(); i++) {
                     lat1 = ringCoords.get(i).y;
                     lon1 = ringCoords.get(i).x;
-                    splitLineSegment(lat0, lon0, lat1, lon1, contourCoords, minSplitLength / 2, MAX_EDGE_LENGTH_LIMIT);
+                    splitLineSegment(lat0, lon0, lat1, lon1, contourCoords, minSplitLength, MAX_EDGE_LENGTH_LIMIT);
                     lon0 = lon1;
                     lat0 = lat1;
                 }
@@ -315,7 +313,7 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
             isochroneGeometries.add(previousIsochronePolygon);
     }
 
-    private void createPolyFromPoints(Set<Geometry> isochroneGeometries, GeometryCollection points, double smoothingDistance, double minSplitLength) {
+    private void createPolyFromPoints(Set<Geometry> isochroneGeometries, GeometryCollection points, double smoothingDistance) {
         if (points.isEmpty())
             return;
 

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/fast/FastIsochroneMapBuilder.java
@@ -50,7 +50,6 @@ import org.heigit.ors.routing.graphhopper.extensions.ORSWeightingFactory;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.AvoidFeaturesEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.EdgeFilterSequence;
 import org.heigit.ors.util.DebugUtility;
-import org.heigit.ors.util.GeomUtility;
 
 import java.util.*;
 
@@ -335,8 +334,6 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
         int maxNodeId = graphHopperStorage.getNodes() - 1;
         int maxEdgeId = graphHopperStorage.getEdges() - 1;
 
-        SPTEntry goalEdge;
-
         double bufferSize = 0.0018;
 
         boolean useHighDetail = map.size() < 1000;
@@ -346,7 +343,7 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
         }
 
         for (IntObjectCursor<SPTEntry> entry : map) {
-            goalEdge = entry.value;
+            SPTEntry goalEdge = entry.value;
             int edgeId = goalEdge.originalEdge;
             int nodeId = goalEdge.adjNode;
 
@@ -366,7 +363,7 @@ public class FastIsochroneMapBuilder extends AbstractIsochroneMapBuilder {
                     addBufferedEdgeGeometry(points, minSplitLength, iter, true, goalEdge, bufferSize);
                 }
             } else {
-                if ((minCost < isolineCost && maxCost >= isolineCost)) {
+                if (minCost < isolineCost && maxCost >= isolineCost) {
                     addBorderEdgeGeometry(points, isolineCost, minSplitLength, iter, maxCost, minCost, bufferSize);
                 }
             }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].


### Information about the changes
- Key functionality added: Split edges based on difference in coordinates rather than their actual distance in meters, and use the same splitting length across isochrone builders.
- Reason for change: Distance-based splitting proved to be unreliable, while different defaults across the builders introduced additional differences in the generated geometries.

In order to guarantee correct construction of the concave hull edge splitting operations need to be performed based on the differences computed on geocoordinates rather than on the actual distances in meters. In practice, this switch makes  little difference to the produced geometries and has virtually no measurable impact on performance. Typical differences in geometries observed are as follows, where blue is the geometry produced with  the previous approach, and red with the new one.

![image](https://github.com/GIScience/openrouteservice/assets/6545356/5b11e037-f511-48b2-b17e-cefe00d2b76e)

The reduction of the splitting length has more noticeable effects, see [report](https://rpubs.com/aoles/splitting_length_reduction). For regular isochrones going down by 1/3 from `0.012` to `0.009`, which corresponds to 1333 and 999 meters in latitude, respectively, comes with a performance penalty of around 15%. However, it helps to increase isochrone accuracy and avoid false inclusion of unreachable areas, which is best illustrated by the following example.

![image](https://github.com/GIScience/openrouteservice/assets/6545356/4920b53c-0e71-4421-9e9e-7210d4006e9f)
<sup>Location 10</sup>

Typically, the observed differences are more subtle, such as

![image](https://github.com/GIScience/openrouteservice/assets/6545356/06e77e2d-a4ec-49af-b6b9-6c29b204c00d)
<sup>Location 4</sup>

and

![image](https://github.com/GIScience/openrouteservice/assets/6545356/fbbf92fc-983d-4916-834d-1c65dfbcbae7)
<sup>Location 7</sup>

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
