### PR TITLE
fix(config): Resolve absolute paths for the config

### DIFF
--- a/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
@@ -56,7 +56,7 @@ public class EngineProperties {
     }
 
     public void setGraphsRootPath(String graphsRootPath) {
-        this.graphsRootPath = graphsRootPath;
+        this.graphsRootPath = Paths.get(graphsRootPath).toAbsolutePath().toString();
     }
 
     public String getGraphsDataAccess() {
@@ -108,8 +108,6 @@ public class EngineProperties {
                 if (!Helper.isEmpty(rootGraphsPath)) {
                     if (Helper.isEmpty(graphPath))
                         graphPath = Paths.get(rootGraphsPath, profileEntry.getKey()).toString();
-                    else if (!FileUtility.isAbsolutePath(graphPath))
-                        graphPath = Paths.get(rootGraphsPath, graphPath).toString();
                 }
                 convertedProfile.setGraphPath(graphPath);
                 convertedProfile.setEncoderOptions(profile.getEncoderOptionsString());
@@ -198,7 +196,7 @@ public class EngineProperties {
         }
 
         public void setCachePath(String cachePath) {
-            this.cachePath = cachePath;
+            this.cachePath = Paths.get(cachePath).toAbsolutePath().toString();
         }
 
         public String getDataAccess() {
@@ -312,7 +310,7 @@ public class EngineProperties {
         }
 
         public void setGraphPath(String graphPath) {
-            this.graphPath = graphPath;
+            this.graphPath = Paths.get(graphPath).toAbsolutePath().toString();
         }
 
         public Map<String, String> getEncoderOptions() {
@@ -486,7 +484,7 @@ public class EngineProperties {
         }
 
         public void setGtfsFile(String gtfsFile) {
-            this.gtfsFile = gtfsFile;
+            this.gtfsFile = Paths.get(gtfsFile).toAbsolutePath().toString();
         }
 
 //        For later use when refactoring RoutingManagerConfiguration

--- a/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
@@ -48,7 +48,7 @@ public class EngineProperties {
     }
 
     public void setSourceFile(String sourceFile) {
-        this.sourceFile = sourceFile;
+        this.sourceFile = Paths.get(sourceFile).toAbsolutePath().toString();
     }
 
     public String getGraphsRootPath() {

--- a/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
@@ -373,6 +373,51 @@ public class EngineProperties {
 
         public void setExtStorages(Map<String, Map<String, String>> extStorages) {
             // Todo write individual storage config classes
+            // Iterate over each storage in the extStorages and overwrite all paths variables with absolute paths#
+            for (Map.Entry<String, Map<String, String>> storage : extStorages.entrySet()) {
+                if (storage.getKey().equals("HereTraffic")) {
+                    // Replace streets, ref_pattern pattern_15min and log_location with absolute paths
+                    String hereTrafficPath = storage.getValue().get("streets");
+                    if (hereTrafficPath != null) {
+                        storage.getValue().put("streets", Paths.get(hereTrafficPath).toAbsolutePath().toString());
+                    }
+                    String hereTrafficRefPattern = storage.getValue().get("ref_pattern");
+                    if (hereTrafficRefPattern != null) {
+                        storage.getValue().put("ref_pattern", Paths.get(hereTrafficRefPattern).toAbsolutePath().toString());
+                    }
+                    String hereTrafficPattern15min = storage.getValue().get("pattern_15min");
+                    if (hereTrafficPattern15min != null) {
+                        storage.getValue().put("pattern_15min", Paths.get(hereTrafficPattern15min).toAbsolutePath().toString());
+                    }
+                    String hereTrafficLogLocation = storage.getValue().get("log_location");
+                    if (hereTrafficLogLocation != null) {
+                        storage.getValue().put("log_location", Paths.get(hereTrafficLogLocation).toAbsolutePath().toString());
+                    }
+                }
+                if (storage.getKey().equals("Borders")) {
+                    // Replace boundaries, ids and openborders with absolute paths
+                    String bordersBoundaries = storage.getValue().get("boundaries");
+                    if (bordersBoundaries != null) {
+                        storage.getValue().put("boundaries", Paths.get(bordersBoundaries).toAbsolutePath().toString());
+                    }
+                    String bordersIds = storage.getValue().get("ids");
+                    if (bordersIds != null) {
+                        storage.getValue().put("ids", Paths.get(bordersIds).toAbsolutePath().toString());
+                    }
+                    String openBorders = storage.getValue().get("openborders");
+                    if (openBorders != null) {
+                        storage.getValue().put("openborders", Paths.get(openBorders).toAbsolutePath().toString());
+                    }
+                }
+
+                if (storage.getKey().equals("GreenIndex") || storage.getKey().equals("NoiseIndex") || storage.getKey().equals("csv") || storage.getKey().equals("ShadowIndex")) {
+                    // replace filepath
+                    String indexFilePath = storage.getValue().get("filepath");
+                    if (indexFilePath != null) {
+                        storage.getValue().put("filepath", Paths.get(indexFilePath).toAbsolutePath().toString());
+                    }
+                }
+            }
             this.extStorages = extStorages;
         }
 

--- a/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
@@ -372,6 +372,7 @@ public class EngineProperties {
         }
 
         public void setExtStorages(Map<String, Map<String, String>> extStorages) {
+            // Todo write individual storage config classes
             this.extStorages = extStorages;
         }
 

--- a/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/EngineProperties.java
@@ -2,9 +2,9 @@ package org.heigit.ors.api;
 
 import com.graphhopper.util.Helper;
 import com.typesafe.config.ConfigFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.heigit.ors.routing.RoutingProfileType;
 import org.heigit.ors.routing.configuration.RouteProfileConfiguration;
-import org.heigit.ors.util.FileUtility;
 import org.heigit.ors.util.ProfileTools;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -48,7 +48,9 @@ public class EngineProperties {
     }
 
     public void setSourceFile(String sourceFile) {
-        this.sourceFile = Paths.get(sourceFile).toAbsolutePath().toString();
+        if (StringUtils.isNotBlank(sourceFile))
+            this.sourceFile = Paths.get(sourceFile).toAbsolutePath().toString();
+        else this.sourceFile = sourceFile;
     }
 
     public String getGraphsRootPath() {
@@ -56,7 +58,9 @@ public class EngineProperties {
     }
 
     public void setGraphsRootPath(String graphsRootPath) {
-        this.graphsRootPath = Paths.get(graphsRootPath).toAbsolutePath().toString();
+        if (StringUtils.isNotBlank(graphsRootPath))
+            this.graphsRootPath = Paths.get(graphsRootPath).toAbsolutePath().toString();
+        else this.graphsRootPath = graphsRootPath;
     }
 
     public String getGraphsDataAccess() {
@@ -196,7 +200,9 @@ public class EngineProperties {
         }
 
         public void setCachePath(String cachePath) {
-            this.cachePath = Paths.get(cachePath).toAbsolutePath().toString();
+            if (StringUtils.isNotBlank(cachePath))
+                this.cachePath = Paths.get(cachePath).toAbsolutePath().toString();
+            else this.cachePath = cachePath;
         }
 
         public String getDataAccess() {
@@ -310,7 +316,9 @@ public class EngineProperties {
         }
 
         public void setGraphPath(String graphPath) {
-            this.graphPath = Paths.get(graphPath).toAbsolutePath().toString();
+            if (StringUtils.isNotBlank(graphPath))
+                this.graphPath = Paths.get(graphPath).toAbsolutePath().toString();
+            else this.graphPath = graphPath;
         }
 
         public Map<String, String> getEncoderOptions() {
@@ -378,34 +386,34 @@ public class EngineProperties {
                 if (storage.getKey().equals("HereTraffic")) {
                     // Replace streets, ref_pattern pattern_15min and log_location with absolute paths
                     String hereTrafficPath = storage.getValue().get("streets");
-                    if (hereTrafficPath != null) {
+                    if (StringUtils.isNotBlank(hereTrafficPath)) {
                         storage.getValue().put("streets", Paths.get(hereTrafficPath).toAbsolutePath().toString());
                     }
                     String hereTrafficRefPattern = storage.getValue().get("ref_pattern");
-                    if (hereTrafficRefPattern != null) {
+                    if (StringUtils.isNotBlank(hereTrafficRefPattern)) {
                         storage.getValue().put("ref_pattern", Paths.get(hereTrafficRefPattern).toAbsolutePath().toString());
                     }
                     String hereTrafficPattern15min = storage.getValue().get("pattern_15min");
-                    if (hereTrafficPattern15min != null) {
+                    if (StringUtils.isNotBlank(hereTrafficPattern15min)) {
                         storage.getValue().put("pattern_15min", Paths.get(hereTrafficPattern15min).toAbsolutePath().toString());
                     }
                     String hereTrafficLogLocation = storage.getValue().get("log_location");
-                    if (hereTrafficLogLocation != null) {
+                    if (StringUtils.isNotBlank(hereTrafficLogLocation)) {
                         storage.getValue().put("log_location", Paths.get(hereTrafficLogLocation).toAbsolutePath().toString());
                     }
                 }
                 if (storage.getKey().equals("Borders")) {
                     // Replace boundaries, ids and openborders with absolute paths
                     String bordersBoundaries = storage.getValue().get("boundaries");
-                    if (bordersBoundaries != null) {
+                    if (StringUtils.isNotBlank(bordersBoundaries)) {
                         storage.getValue().put("boundaries", Paths.get(bordersBoundaries).toAbsolutePath().toString());
                     }
                     String bordersIds = storage.getValue().get("ids");
-                    if (bordersIds != null) {
+                    if (StringUtils.isNotBlank(bordersIds)) {
                         storage.getValue().put("ids", Paths.get(bordersIds).toAbsolutePath().toString());
                     }
                     String openBorders = storage.getValue().get("openborders");
-                    if (openBorders != null) {
+                    if (StringUtils.isNotBlank(openBorders)) {
                         storage.getValue().put("openborders", Paths.get(openBorders).toAbsolutePath().toString());
                     }
                 }
@@ -530,7 +538,9 @@ public class EngineProperties {
         }
 
         public void setGtfsFile(String gtfsFile) {
-            this.gtfsFile = Paths.get(gtfsFile).toAbsolutePath().toString();
+            if (StringUtils.isNotBlank(gtfsFile))
+                this.gtfsFile = Paths.get(gtfsFile).toAbsolutePath().toString();
+            else this.gtfsFile = gtfsFile;
         }
 
 //        For later use when refactoring RoutingManagerConfiguration

--- a/ors-engine/src/main/java/org/heigit/ors/config/EngineConfig.java
+++ b/ors-engine/src/main/java/org/heigit/ors/config/EngineConfig.java
@@ -1,5 +1,6 @@
 package org.heigit.ors.config;
 
+import org.apache.commons.lang3.StringUtils;
 import org.heigit.ors.routing.configuration.RouteProfileConfiguration;
 import org.heigit.ors.util.StringUtility;
 
@@ -81,12 +82,16 @@ public class EngineConfig {
         }
 
         public EngineConfigBuilder setSourceFile(String sourceFile) {
-            this.sourceFile = Paths.get(sourceFile).toAbsolutePath().toString();
+            if (StringUtils.isNotBlank(sourceFile))
+                this.sourceFile = Paths.get(sourceFile).toAbsolutePath().toString();
+            else this.sourceFile = sourceFile;
             return this;
         }
 
         public EngineConfigBuilder setGraphsRootPath(String graphsRootPath) {
-            this.graphsRootPath = Paths.get(graphsRootPath).toAbsolutePath().toString();
+            if (StringUtils.isNotBlank(graphsRootPath))
+                this.graphsRootPath = Paths.get(graphsRootPath).toAbsolutePath().toString();
+            else this.graphsRootPath = graphsRootPath;
             return this;
         }
 

--- a/ors-engine/src/main/java/org/heigit/ors/config/EngineConfig.java
+++ b/ors-engine/src/main/java/org/heigit/ors/config/EngineConfig.java
@@ -3,6 +3,7 @@ package org.heigit.ors.config;
 import org.heigit.ors.routing.configuration.RouteProfileConfiguration;
 import org.heigit.ors.util.StringUtility;
 
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -80,12 +81,12 @@ public class EngineConfig {
         }
 
         public EngineConfigBuilder setSourceFile(String sourceFile) {
-            this.sourceFile = sourceFile;
+            this.sourceFile = Paths.get(sourceFile).toAbsolutePath().toString();
             return this;
         }
 
         public EngineConfigBuilder setGraphsRootPath(String graphsRootPath) {
-            this.graphsRootPath = graphsRootPath;
+            this.graphsRootPath = Paths.get(graphsRootPath).toAbsolutePath().toString();
             return this;
         }
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
@@ -14,6 +14,7 @@
 package org.heigit.ors.routing.configuration;
 
 import com.typesafe.config.Config;
+import org.apache.commons.lang3.StringUtils;
 import org.heigit.ors.routing.RoutingProfileType;
 import org.locationtech.jts.geom.Envelope;
 
@@ -125,7 +126,9 @@ public class RouteProfileConfiguration {
     }
 
     public void setGraphPath(String value) {
-        graphPath = Paths.get(value).toAbsolutePath().toString();
+        if (StringUtils.isNotBlank(value))
+            graphPath = Paths.get(value).toAbsolutePath().toString();
+        else graphPath = value;
     }
 
     public String getGraphPath() {
@@ -230,7 +233,9 @@ public class RouteProfileConfiguration {
     }
 
     public void setElevationCachePath(String value) {
-        elevationCachePath = Paths.get(value).toAbsolutePath().toString();
+        if (StringUtils.isNotBlank(value))
+            elevationCachePath = Paths.get(value).toAbsolutePath().toString();
+        else elevationCachePath = value;
     }
 
     public String getElevationCachePath() {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/configuration/RouteProfileConfiguration.java
@@ -17,6 +17,7 @@ import com.typesafe.config.Config;
 import org.heigit.ors.routing.RoutingProfileType;
 import org.locationtech.jts.geom.Envelope;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -124,7 +125,7 @@ public class RouteProfileConfiguration {
     }
 
     public void setGraphPath(String value) {
-        graphPath = value;
+        graphPath = Paths.get(value).toAbsolutePath().toString();
     }
 
     public String getGraphPath() {
@@ -229,7 +230,7 @@ public class RouteProfileConfiguration {
     }
 
     public void setElevationCachePath(String value) {
-        elevationCachePath = value;
+        elevationCachePath = Paths.get(value).toAbsolutePath().toString();
     }
 
     public String getElevationCachePath() {


### PR DESCRIPTION
The config is handling paths internally without modifying it (except once for graphs) and expects the relative rundir not to change. The consistency of the rundir is not given so the paths should be resolved to absolute paths when the engine starts.
This is missing the paths from the external storages that are in graphhopper.### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added: Resolve relative paths to their absolute paths. Relative paths can still be used in the config files but once ors started they're resolved to their runtime absolute path.
- Reason for change: For now, the relative paths are continuously used, also when ors has long started. This could lead to problems when the working path of the ors app changes during runtime unexpectedly.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
- None

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
