### PR TITLE
fix: preparation mode not failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ RELEASING:
 ### Added
 - documentation for A* config parameters ([#1759](https://github.com/GIScience/openrouteservice/pull/1759))
 
+### Fixed
+- preparation mode exiting with code 0 on fail ([#1772](https://github.com/GIScience/openrouteservice/pull/1772))
+
 ## [8.0.0] - 2024-03-21
 ### Added
 - snapping service endpoints for returning nearest points on the graph ([#1519](https://github.com/GIScience/openrouteservice/issues/1519))

--- a/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
@@ -55,7 +55,12 @@ public class ORSInitContextListener implements ServletContextListener {
             try {
                 LOGGER.info("Initializing ORS...");
                 new RoutingProfileManager(config);
+                // TODO if feasible, move the preparation mode check to Application.java after the
+                //  RoutingProfileManagerStatus.hasFailed() check.
                 if (engineProperties.isPreparationMode()) {
+                    if (RoutingProfileManagerStatus.hasFailed()) {
+                        System.exit(1);
+                    }
                     LOGGER.info("Running in preparation mode, all enabled graphs are built, job is done.");
                     System.exit(0);
                 }
@@ -81,4 +86,4 @@ public class ORSInitContextListener implements ServletContextListener {
             LOGGER.error(e.getMessage());
         }
     }
-} 
+}

--- a/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
@@ -65,7 +65,7 @@ public class ORSInitContextListener implements ServletContextListener {
                     System.exit(0);
                 }
             } catch (Exception e) {
-                LOGGER.warn("Unable to initialize ORS due to an unexpected exeception: " + e);
+                LOGGER.warn("Unable to initialize ORS due to an unexpected exception: " + e);
             }
         };
         Thread thread = new Thread(runnable);


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added: fixes preparation mode exiting with code 0 in case of RoutingProfileManager fails
- Reason for change: https://ask.openrouteservice.org/t/verifying-successful-graph-preparation/5925

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
