### PR TITLE
Support bicycle=destination for bike profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ RELEASING:
 - documentation for A* config parameters ([#1759](https://github.com/GIScience/openrouteservice/pull/1759))
 - documentation for non-positive values of `maximum_grade_level` encoder config parameter ([#1775](https://github.com/GIScience/openrouteservice/pull/1775))
 - keep-alive-timeout for spring internal tomcat ([#1780](https://github.com/GIScience/openrouteservice/pull/1780))
+- support bicycle=destination for bike profiles ([#1782](https://github.com/GIScience/openrouteservice/issues/1782))
 
 ### Fixed
 - preparation mode exiting with code 0 on fail ([#1772](https://github.com/GIScience/openrouteservice/pull/1772))

--- a/docs/technical-details/tag-filtering.md
+++ b/docs/technical-details/tag-filtering.md
@@ -65,7 +65,7 @@ and the following additional rule which replace the check for `ford`:
 Definitions:  
 _restrictions_ = `[bicycle, vehicle, access]`  
 _restrictedValues_ = `[private, no, restricted, military, emergency]`  
-_intendedValues_ = `[yes, designated, official, permissive]`  
+_intendedValues_ = `[yes, designated, official, permissive, destination]`  
 _wayTypesWithDefaultSpeed_ = `[unclassified, tertiary_link, primary_link, bridleway, tertiary, living_street, trunk, motorway_link, steps, motorway, secondary, path, residential, road, service, footway, pedestrian, track, secondary_link, cycleway, trunk_link, primary]`  
 
 | Tag combination                                                                                                                                                                                                                      |       Reject       |       Accept       |    Conditional     |

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
@@ -133,6 +133,7 @@ public abstract class CommonBikeFlagEncoder extends BikeCommonFlagEncoder {
         intendedValues.add(KEY_DESIGNATED);
         intendedValues.add(KEY_OFFICIAL);
         intendedValues.add("permissive");
+        intendedValues.add("destination");
 
         oppositeLanes.add("opposite");
         oppositeLanes.add("opposite_lane");

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/RegularBikeFlagEncoderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/RegularBikeFlagEncoderTest.java
@@ -46,6 +46,12 @@ class RegularBikeFlagEncoderTest {
         way.setTag("bicycle", "yes");
         assertTrue(flagEncoder.getAccess(way).isWay());
 
+        way.setTag("bicycle", "permissive");
+        assertTrue(flagEncoder.getAccess(way).isWay());
+
+        way.setTag("bicycle", "destination");
+        assertTrue(flagEncoder.getAccess(way).isWay());
+
         way.setTag("bicycle", "no");
         assertTrue(flagEncoder.getAccess(way).canSkip());
     }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1782.

### Information about the changes
- Key functionality added: Added support for routing bikes through ways tagged with `bicycle=destination`.
- Reason for change: Such tags should be routeable for bicycles, per the meaning of the tag.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
