### PR TITLE
fix: way surface type storage

### DIFF
--- a/docs/api-reference/endpoints/directions/extra-info/surface.md
+++ b/docs/api-reference/endpoints/directions/extra-info/surface.md
@@ -7,27 +7,28 @@ $.routes[*].extras.surface.values
 ```
 
 This extra provides info about the [surface](https://wiki.openstreetmap.org/wiki/Key:surface) of the corresponding parts of the route.
+The strike-through values have been recently removed.
 
-| Value |       Name       |
-|:-----:|:----------------:|
-| 0     | Unknown          |
-| 1     | Paved            |
-| 2     | Unpaved          |
-| 3     | Asphalt          |
-| 4     | Concrete         |
-| 5     | Cobblestone      |
-| 6     | Metal            |
-| 7     | Wood             |
-| 8     | Compacted Gravel |
-| 9     | Fine Gravel      |
-| 10    | Gravel           |
-| 11    | Dirt             |
-| 12    | Ground           |
-| 13    | Ice              |
-| 14    | Paving Stones    |
-| 15    | Sand             |
-| 16    | Woodchips        |
-| 17    | Grass            |
-| 18    | Grass Paver      |
+| Value  |       Name       |
+|:------:|:----------------:|
+|   0    |     Unknown      |
+|   1    |      Paved       |
+|   2    |     Unpaved      |
+|   3    |     Asphalt      |
+|   4    |     Concrete     |
+| ~~5~~  | ~~Cobblestone~~  |
+|   6    |      Metal       |
+|   7    |       Wood       |
+|   8    | Compacted Gravel |
+| ~~9~~  | ~~Fine Gravel~~  |
+|   10   |      Gravel      |
+|   11   |       Dirt       |
+|   12   |      Ground      |
+|   13   |       Ice        |
+|   14   |  Paving Stones   |
+|   15   |       Sand       |
+| ~~16~~ |  ~~Woodchips~~   |
+|   17   |      Grass       |
+|   18   |   Grass Paver    |
 
 [//]: # (keep in sync with org.heigit.ors.routing.graphhopper.extensions.SurfaceType)

--- a/docs/api-reference/endpoints/directions/extra-info/surface.md
+++ b/docs/api-reference/endpoints/directions/extra-info/surface.md
@@ -9,26 +9,31 @@ $.routes[*].extras.surface.values
 This extra provides info about the [surface](https://wiki.openstreetmap.org/wiki/Key:surface) of the corresponding parts of the route.
 The strike-through values have been recently removed.
 
-| Value  |       Name       |
-|:------:|:----------------:|
-|   0    |     Unknown      |
-|   1    |      Paved       |
-|   2    |     Unpaved      |
-|   3    |     Asphalt      |
-|   4    |     Concrete     |
-| ~~5~~  | ~~Cobblestone~~  |
-|   6    |      Metal       |
-|   7    |       Wood       |
-|   8    | Compacted Gravel |
-| ~~9~~  | ~~Fine Gravel~~  |
-|   10   |      Gravel      |
-|   11   |       Dirt       |
-|   12   |      Ground      |
-|   13   |       Ice        |
-|   14   |  Paving Stones   |
-|   15   |       Sand       |
-| ~~16~~ |  ~~Woodchips~~   |
-|   17   |      Grass       |
-|   18   |   Grass Paver    |
+| Value  |       Name       |   Corresponding value* of [`surface`](https://wiki.openstreetmap.org/wiki/Key:surface)-tag(s)   |
+|:------:|:----------------:|:-----------------------------------------------------------------------------------------------:|
+|   0    |     Unknown      |                                                                                                 |
+|   1    |      Paved       |                                             `paved`                                             |
+|   2    |     Unpaved      |               `unpaved`, `woodchips`, `rock`, `rocks`, `stone`, `shells`, `salt`                |
+|   3    |     Asphalt      |                            `asphalt`, `chipseal`, `bitmac`, `tarmac`                            |
+|   4    |     Concrete     |                                      `concrete`, `cement`                                       |
+| ~~5~~  | ~~Cobblestone~~  |                                                                                                 |
+|   6    |      Metal       |                                             `metal`                                             |
+|   7    |       Wood       |                                             `wood`                                              |
+|   8    | Compacted Gravel |                                   `compacted`, `pebblestone`                                    |
+| ~~9~~  | ~~Fine Gravel~~  |                                                                                                 |
+|   10   |      Gravel      |                                     `gravel`, `fine_gravel`                                     |
+|   11   |       Dirt       |                                     `dirt`, `earth`, `soil`                                     |
+|   12   |      Ground      |                                         `ground`, `mud`                                         |
+|   13   |       Ice        |                                          `ice`, `snow`                                          |
+|   14   |  Paving Stones   | `paving_stones`, `paved_stones`, `sett`, `cobblestone`, `unhewn_cobblestone`, `bricks`, `brick` |
+|   15   |       Sand       |                                             `sand`                                              |
+| ~~16~~ |  ~~Woodchips~~   |                                                                                                 |
+|   17   |      Grass       |                                             `grass`                                             |
+|   18   |   Grass Paver    |                                          `grass_paver`                                          |
+
+*) For tags listing multiple values separated by a semicolon `;` only the first value is considered, and for a
+given `value` all values of the form `value[:*]` are matched, where the part `[:*]` is optional. For example, all the
+three ways tagged with `surface=concrete`, `surface=concrete:plates;asphalt` and `surface=cement`, respectively, would
+be categorized as "Concrete".
 
 [//]: # (keep in sync with org.heigit.ors.routing.graphhopper.extensions.SurfaceType)

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -958,8 +958,8 @@ class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].containsKey('extras')", is(true))
-                .body("routes[0].extras.surface.values.size()", is(38))
-                .body("routes[0].extras.surface.values[18][1]", is(181))
+                .body("routes[0].extras.surface.values.size()", is(32))
+                .body("routes[0].extras.surface.values[18][1]", is(237))
                 .body("routes[0].extras.suitability.values[18][0]", is(359))
                 .body("routes[0].extras.containsKey('steepness')", is(true))
                 .statusCode(200);

--- a/ors-engine/src/main/java/org/heigit/ors/fastisochrones/partitioning/storage/CellStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/fastisochrones/partitioning/storage/CellStorage.java
@@ -60,7 +60,7 @@ public class CellStorage implements Storable<CellStorage> {
      */
     public CellStorage(int nodeCount, Directory dir, IsochroneNodeStorage isochroneNodeStorage) {
         this.isochroneNodeStorage = isochroneNodeStorage;
-        cells = dir.find("cells");
+        cells = dir.create("cells");
         byteCount = 4;
         this.nodeCount = nodeCount;
     }

--- a/ors-engine/src/main/java/org/heigit/ors/fastisochrones/partitioning/storage/IsochroneNodeStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/fastisochrones/partitioning/storage/IsochroneNodeStorage.java
@@ -39,7 +39,7 @@ public class IsochroneNodeStorage implements Storable<IsochroneNodeStorage> {
     private final IntSet cellIdsSet = new IntHashSet();
 
     public IsochroneNodeStorage(int nodeCount, Directory dir) {
-        isochroneNodes = dir.find("isochronenodes");
+        isochroneNodes = dir.create("isochronenodes");
         this.nodeCount = nodeCount;
         // 5 bytes per node for its cell id.
         // 1 byte for isBordernode,

--- a/ors-engine/src/main/java/org/heigit/ors/fastisochrones/storage/BorderNodeDistanceStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/fastisochrones/storage/BorderNodeDistanceStorage.java
@@ -52,7 +52,7 @@ public class BorderNodeDistanceStorage implements Storable<BorderNodeDistanceSto
     public BorderNodeDistanceStorage(Directory dir, Weighting weighting, IsochroneNodeStorage isochroneNodeStorage, int nodeCount) {
         final String name = FileUtility.weightingToFileName(weighting);
         this.isochroneNodeStorage = isochroneNodeStorage;
-        borderNodes = dir.find("bordernodes_" + name);
+        borderNodes = dir.create("bordernodes_" + name);
         this.weighting = weighting;
         byteCount = 12; //adj bordernode id (int 4B) and distance (double 8B)
         this.nodeCount = nodeCount;

--- a/ors-engine/src/main/java/org/heigit/ors/fastisochrones/storage/EccentricityStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/fastisochrones/storage/EccentricityStorage.java
@@ -58,7 +58,7 @@ public class EccentricityStorage implements Storable<EccentricityStorage> {
         //A map of nodeId to pointer is stored in the first block.
         //The second block stores 2 values for each pointer, full reachability and eccentricity
         final String name = FileUtility.weightingToFileName(weighting);
-        eccentricities = dir.find("eccentricities_" + name);
+        eccentricities = dir.create("eccentricities_" + name);
         this.weighting = weighting;
         this.isochroneNodeStorage = isochroneNodeStorage;
         this.nodeCount = nodeCount;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -67,7 +67,7 @@ public enum SurfaceType {
             case "wood" -> SurfaceType.WOOD;
             case "compacted", "pebblestone" -> SurfaceType.COMPACTED_GRAVEL;
             case "gravel", "fine_gravel" -> SurfaceType.GRAVEL;
-            case "dirt", "earth" -> SurfaceType.DIRT;
+            case "dirt", "earth", "soil" -> SurfaceType.DIRT;
             case "ground", "mud" -> SurfaceType.GROUND;
             case "ice", "snow" -> SurfaceType.ICE;
             case "sand" -> SurfaceType.SAND;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -13,34 +13,47 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions;
 
-public class SurfaceType {
+public enum SurfaceType {
 
     //Keep in sync with documentation: surface.md
 
-    public static final int UNKNOWN = 0;
-    public static final int PAVED = 1;
-    public static final int UNPAVED = 2;
-    public static final int ASPHALT = 3;
-    public static final int CONCRETE = 4;
-    public static final int COBBLESTONE = 5;
-    public static final int METAL = 6;
-    public static final int WOOD = 7;
-    public static final int COMPACTED_GRAVEL = 8;
-    public static final int FINE_GRAVEL = 9;
-    public static final int GRAVEL = 10;
-    public static final int DIRT = 11;
-    public static final int GROUND = 12;
-    public static final int ICE = 13;
-    public static final int PAVING_STONE = 14;
-    public static final int SAND = 15;
-    public static final int WOODCHIPS = 16;
-    public static final int GRASS = 17;
-    public static final int GRASS_PAVER = 18;
+    UNKNOWN(0),
+    PAVED(1),
+    UNPAVED(2),
+    ASPHALT(3),
+    CONCRETE(4),
+    COBBLESTONE(5),
+    METAL(6),
+    WOOD(7),
+    COMPACTED_GRAVEL(8),
+    FINE_GRAVEL(9),
+    GRAVEL(10),
+    DIRT(11),
+    GROUND(12),
+    ICE(13),
+    PAVING_STONE(14),
+    SAND(15),
+    WOODCHIPS(16),
+    GRASS(17),
+    GRASS_PAVER(18);
 
-    private SurfaceType() {
+    private final byte value;
+
+    private static final SurfaceType values[] = values();
+
+    private SurfaceType(int value) {
+        this.value = (byte) value;
     }
 
-    public static int getFromString(String surface) {
+    public byte value() {
+        return value;
+    }
+
+    public static SurfaceType getFromId(int id) {
+        return values[id];
+    }
+
+    public static SurfaceType getFromString(String surface) {
 
         if (surface.contains(";"))
             surface = surface.split(";")[0];

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -59,7 +59,7 @@ public enum SurfaceType {
 
         return switch (surface.toLowerCase()) {
             case "paved" -> SurfaceType.PAVED;
-            case "unpaved", "woodchips" -> SurfaceType.UNPAVED;
+            case "unpaved", "woodchips", "rock", "rocks", "stone", "shells", "salt" -> SurfaceType.UNPAVED;
             case "asphalt" -> SurfaceType.ASPHALT;
             case "concrete" -> SurfaceType.CONCRETE;
             case "paving_stones", "paved_stones", "sett", "cobblestone", "unhewn_cobblestone", "bricks", "brick" -> SurfaceType.PAVING_STONE;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -61,7 +61,7 @@ public enum SurfaceType {
             case "paved" -> SurfaceType.PAVED;
             case "unpaved", "woodchips", "rock", "rocks", "stone", "shells", "salt" -> SurfaceType.UNPAVED;
             case "asphalt", "chipseal", "bitmac", "tarmac" -> SurfaceType.ASPHALT;
-            case "concrete" -> SurfaceType.CONCRETE;
+            case "concrete", "cement" -> SurfaceType.CONCRETE;
             case "paving_stones", "paved_stones", "sett", "cobblestone", "unhewn_cobblestone", "bricks", "brick" -> SurfaceType.PAVING_STONE;
             case "metal" -> SurfaceType.METAL;
             case "wood" -> SurfaceType.WOOD;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -42,7 +42,7 @@ public enum SurfaceType {
         this.value = (byte) value;
     }
 
-    public byte value() {
+    public byte value() {   
         return value;
     }
 
@@ -55,47 +55,51 @@ public enum SurfaceType {
         if (surface.contains(";"))
             surface = surface.split(";")[0];
 
-        if ("paved".equalsIgnoreCase(surface)) {
-            return SurfaceType.PAVED;
-        } else if ("unpaved".equalsIgnoreCase(surface)) {
-            return SurfaceType.UNPAVED;
-        } else if ("asphalt".equalsIgnoreCase(surface)) {
-            return SurfaceType.ASPHALT;
-        } else if ("concrete".equalsIgnoreCase(surface) || "concrete:lanes".equalsIgnoreCase(surface)
-                || "concrete:plates".equalsIgnoreCase(surface)) {
-            return SurfaceType.CONCRETE;
-        } else if ("paving_stones".equalsIgnoreCase(surface) || "paving_stones:20".equalsIgnoreCase(surface) || "paving_stones:30".equalsIgnoreCase(surface) || "paving_stones:50".equalsIgnoreCase(surface) || "paved_stones".equalsIgnoreCase(surface)) {
-            return SurfaceType.PAVING_STONE;
-        } else if ("cobblestone:flattened".equalsIgnoreCase(surface)
-                || "sett".equalsIgnoreCase(surface)) {
-            return SurfaceType.PAVING_STONE;
-        } else if ("cobblestone".equalsIgnoreCase(surface)) {
-            return SurfaceType.PAVING_STONE;
-        } else if ("metal".equalsIgnoreCase(surface)) {
-            return SurfaceType.METAL;
-        } else if ("wood".equalsIgnoreCase(surface)) {
-            return SurfaceType.WOOD;
-        } else if ("compacted".equalsIgnoreCase(surface) || "pebblestone".equalsIgnoreCase(surface)) {
-            return SurfaceType.COMPACTED_GRAVEL;
-        } else if ("fine_gravel".equalsIgnoreCase(surface)) {
-            return SurfaceType.GRAVEL;
-        } else if ("gravel".equalsIgnoreCase(surface)) {
-            return SurfaceType.GRAVEL;
-        } else if ("dirt".equalsIgnoreCase(surface)) {
-            return SurfaceType.DIRT;
-        } else if ("ground".equalsIgnoreCase(surface) || "earth".equalsIgnoreCase(surface)
-                || "mud".equalsIgnoreCase(surface)) {
-            return SurfaceType.GROUND;
-        } else if ("ice".equalsIgnoreCase(surface) || "snow".equalsIgnoreCase(surface)) {
-            return SurfaceType.ICE;
-        } else if ("sand".equalsIgnoreCase(surface)) {
-            return SurfaceType.SAND;
-        } else if ("woodchips".equalsIgnoreCase(surface)) {
-            return SurfaceType.UNPAVED;
-        } else if ("grass".equalsIgnoreCase(surface)) {
-            return SurfaceType.GRASS;
-        } else if ("grass_paver".equalsIgnoreCase(surface)) {
-            return SurfaceType.GRASS_PAVER;
+        switch (surface.toLowerCase()) {
+            case "paved":
+                return SurfaceType.PAVED;
+            case "unpaved", "woodchips":
+                return SurfaceType.UNPAVED;
+            case "asphalt":
+                return SurfaceType.ASPHALT;
+            case "concrete":
+            case "concrete:lanes":
+            case "concrete:plates":
+                return SurfaceType.CONCRETE;
+            case "paving_stones":
+            case "paving_stones:20":
+            case "paving_stones:30":
+            case "paving_stones:50":
+            case "paved_stones":
+            case "cobblestone:flattened":
+            case "sett":
+            case "cobblestone":
+                return SurfaceType.PAVING_STONE;
+            case "metal":
+                return SurfaceType.METAL;
+            case "wood":
+                return SurfaceType.WOOD;
+            case "compacted":
+            case "pebblestone":
+                return SurfaceType.COMPACTED_GRAVEL;
+            case "fine_gravel":
+            case "gravel":
+                return SurfaceType.GRAVEL;
+            case "dirt":
+                return SurfaceType.DIRT;
+            case "ground":
+            case "earth":
+            case "mud":
+                return SurfaceType.GROUND;
+            case "ice":
+            case "snow":
+                return SurfaceType.ICE;
+            case "sand":
+                return SurfaceType.SAND;
+            case "grass":
+                return SurfaceType.GRASS;
+            case "grass_paver":
+                return SurfaceType.GRASS_PAVER;
         }
 
         return SurfaceType.UNKNOWN;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -67,8 +67,8 @@ public enum SurfaceType {
             case "wood" -> SurfaceType.WOOD;
             case "compacted", "pebblestone" -> SurfaceType.COMPACTED_GRAVEL;
             case "gravel", "fine_gravel" -> SurfaceType.GRAVEL;
-            case "dirt" -> SurfaceType.DIRT;
-            case "ground", "earth", "mud" -> SurfaceType.GROUND;
+            case "dirt", "earth" -> SurfaceType.DIRT;
+            case "ground", "mud" -> SurfaceType.GROUND;
             case "ice", "snow" -> SurfaceType.ICE;
             case "sand" -> SurfaceType.SAND;
             case "grass" -> SurfaceType.GRASS;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -22,18 +22,15 @@ public enum SurfaceType {
     UNPAVED(2),
     ASPHALT(3),
     CONCRETE(4),
-    COBBLESTONE(5),
     METAL(6),
     WOOD(7),
     COMPACTED_GRAVEL(8),
-    FINE_GRAVEL(9),
     GRAVEL(10),
     DIRT(11),
     GROUND(12),
     ICE(13),
     PAVING_STONE(14),
     SAND(15),
-    WOODCHIPS(16),
     GRASS(17),
     GRASS_PAVER(18);
 
@@ -73,7 +70,7 @@ public enum SurfaceType {
                 || "sett".equalsIgnoreCase(surface)) {
             return SurfaceType.PAVING_STONE;
         } else if ("cobblestone".equalsIgnoreCase(surface)) {
-            return SurfaceType.COBBLESTONE;
+            return SurfaceType.PAVING_STONE;
         } else if ("metal".equalsIgnoreCase(surface)) {
             return SurfaceType.METAL;
         } else if ("wood".equalsIgnoreCase(surface)) {
@@ -81,7 +78,7 @@ public enum SurfaceType {
         } else if ("compacted".equalsIgnoreCase(surface) || "pebblestone".equalsIgnoreCase(surface)) {
             return SurfaceType.COMPACTED_GRAVEL;
         } else if ("fine_gravel".equalsIgnoreCase(surface)) {
-            return SurfaceType.FINE_GRAVEL;
+            return SurfaceType.GRAVEL;
         } else if ("gravel".equalsIgnoreCase(surface)) {
             return SurfaceType.GRAVEL;
         } else if ("dirt".equalsIgnoreCase(surface)) {
@@ -94,7 +91,7 @@ public enum SurfaceType {
         } else if ("sand".equalsIgnoreCase(surface)) {
             return SurfaceType.SAND;
         } else if ("woodchips".equalsIgnoreCase(surface)) {
-            return SurfaceType.WOODCHIPS;
+            return SurfaceType.UNPAVED;
         } else if ("grass".equalsIgnoreCase(surface)) {
             return SurfaceType.GRASS;
         } else if ("grass_paver".equalsIgnoreCase(surface)) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -62,7 +62,7 @@ public enum SurfaceType {
             case "unpaved", "woodchips" -> SurfaceType.UNPAVED;
             case "asphalt" -> SurfaceType.ASPHALT;
             case "concrete" -> SurfaceType.CONCRETE;
-            case "paving_stones", "paved_stones", "sett", "cobblestone" -> SurfaceType.PAVING_STONE;
+            case "paving_stones", "paved_stones", "sett", "cobblestone", "unhewn_cobblestone", "bricks", "brick" -> SurfaceType.PAVING_STONE;
             case "metal" -> SurfaceType.METAL;
             case "wood" -> SurfaceType.WOOD;
             case "compacted", "pebblestone" -> SurfaceType.COMPACTED_GRAVEL;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -36,13 +36,13 @@ public enum SurfaceType {
 
     private final byte value;
 
-    private static final SurfaceType values[] = values();
+    private static final SurfaceType[] values = values();
 
     private SurfaceType(int value) {
         this.value = (byte) value;
     }
 
-    public byte value() {   
+    public byte value() {
         return value;
     }
 
@@ -54,54 +54,26 @@ public enum SurfaceType {
 
         if (surface.contains(";"))
             surface = surface.split(";")[0];
+        if (surface.contains(":"))
+            surface = surface.split(":")[0];
 
-        switch (surface.toLowerCase()) {
-            case "paved":
-                return SurfaceType.PAVED;
-            case "unpaved", "woodchips":
-                return SurfaceType.UNPAVED;
-            case "asphalt":
-                return SurfaceType.ASPHALT;
-            case "concrete":
-            case "concrete:lanes":
-            case "concrete:plates":
-                return SurfaceType.CONCRETE;
-            case "paving_stones":
-            case "paving_stones:20":
-            case "paving_stones:30":
-            case "paving_stones:50":
-            case "paved_stones":
-            case "cobblestone:flattened":
-            case "sett":
-            case "cobblestone":
-                return SurfaceType.PAVING_STONE;
-            case "metal":
-                return SurfaceType.METAL;
-            case "wood":
-                return SurfaceType.WOOD;
-            case "compacted":
-            case "pebblestone":
-                return SurfaceType.COMPACTED_GRAVEL;
-            case "fine_gravel":
-            case "gravel":
-                return SurfaceType.GRAVEL;
-            case "dirt":
-                return SurfaceType.DIRT;
-            case "ground":
-            case "earth":
-            case "mud":
-                return SurfaceType.GROUND;
-            case "ice":
-            case "snow":
-                return SurfaceType.ICE;
-            case "sand":
-                return SurfaceType.SAND;
-            case "grass":
-                return SurfaceType.GRASS;
-            case "grass_paver":
-                return SurfaceType.GRASS_PAVER;
-        }
-
-        return SurfaceType.UNKNOWN;
+        return switch (surface.toLowerCase()) {
+            case "paved" -> SurfaceType.PAVED;
+            case "unpaved", "woodchips" -> SurfaceType.UNPAVED;
+            case "asphalt" -> SurfaceType.ASPHALT;
+            case "concrete" -> SurfaceType.CONCRETE;
+            case "paving_stones", "paved_stones", "sett", "cobblestone" -> SurfaceType.PAVING_STONE;
+            case "metal" -> SurfaceType.METAL;
+            case "wood" -> SurfaceType.WOOD;
+            case "compacted", "pebblestone" -> SurfaceType.COMPACTED_GRAVEL;
+            case "gravel", "fine_gravel" -> SurfaceType.GRAVEL;
+            case "dirt" -> SurfaceType.DIRT;
+            case "ground", "earth", "mud" -> SurfaceType.GROUND;
+            case "ice", "snow" -> SurfaceType.ICE;
+            case "sand" -> SurfaceType.SAND;
+            case "grass" -> SurfaceType.GRASS;
+            case "grass_paver" -> SurfaceType.GRASS_PAVER;
+            default -> SurfaceType.UNKNOWN;
+        };
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/SurfaceType.java
@@ -60,7 +60,7 @@ public enum SurfaceType {
         return switch (surface.toLowerCase()) {
             case "paved" -> SurfaceType.PAVED;
             case "unpaved", "woodchips", "rock", "rocks", "stone", "shells", "salt" -> SurfaceType.UNPAVED;
-            case "asphalt" -> SurfaceType.ASPHALT;
+            case "asphalt", "chipseal", "bitmac", "tarmac" -> SurfaceType.ASPHALT;
             case "concrete" -> SurfaceType.CONCRETE;
             case "paving_stones", "paved_stones", "sett", "cobblestone", "unhewn_cobblestone", "bricks", "brick" -> SurfaceType.PAVING_STONE;
             case "metal" -> SurfaceType.METAL;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/BordersGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/BordersGraphStorage.java
@@ -106,7 +106,7 @@ public class BordersGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_borders");
+        this.orsEdges = dir.create("ext_borders");
     }
 
     /**
@@ -117,7 +117,7 @@ public class BordersGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
         Directory d = new RAMDirectory();
-        this.orsEdges = d.find("");
+        this.orsEdges = d.create("");
     }
 
     /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/CsvGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/CsvGraphStorage.java
@@ -84,7 +84,7 @@
             if (edgesCount > 0)
                 throw new AssertionError("The ORS storage must be initialized only once.");
 
-            this.orsEdges = dir.find("ext_csv");
+            this.orsEdges = dir.create("ext_csv");
         }
 
         /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/GreenIndexGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/GreenIndexGraphStorage.java
@@ -99,7 +99,7 @@ public class GreenIndexGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_greenindex");
+        this.orsEdges = dir.create("ext_greenindex");
     }
 
     /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
@@ -51,7 +51,7 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ext_hgv storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_hgv");
+        this.orsEdges = dir.create("ext_hgv");
     }
 
     private int nextBlockEntryIndex(int size) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HillIndexGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HillIndexGraphStorage.java
@@ -47,7 +47,7 @@ public class HillIndexGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_hillindex");
+        this.orsEdges = dir.create("ext_hillindex");
     }
 
     public HillIndexGraphStorage create(long initBytes) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/NoiseIndexGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/NoiseIndexGraphStorage.java
@@ -103,7 +103,7 @@ public class NoiseIndexGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_noiselevel");
+        this.orsEdges = dir.create("ext_noiselevel");
     }
 
     /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/OsmIdGraphStorage.java
@@ -25,7 +25,7 @@ public class OsmIdGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_osmids");
+        this.orsEdges = dir.create("ext_osmids");
     }
 
     /**
@@ -36,7 +36,7 @@ public class OsmIdGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
         Directory d = new RAMDirectory();
-        this.orsEdges = d.find("");
+        this.orsEdges = d.create("");
     }
 
     public OsmIdGraphStorage create(long initBytes) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/RoadAccessRestrictionsGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/RoadAccessRestrictionsGraphStorage.java
@@ -49,14 +49,14 @@ public class RoadAccessRestrictionsGraphStorage implements GraphExtension, Warni
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
         Directory d = new RAMDirectory();
-        this.edges = d.find("");
+        this.edges = d.create("");
     }
 
     public void init(Graph graph, Directory dir) {
         if (edgesCount > 0)
             throw new AssertionError("The ext_road_access_restrictions storage must be initialized only once.");
 
-        this.edges = dir.find("ext_road_access_restrictions");
+        this.edges = dir.create("ext_road_access_restrictions");
     }
 
     public void setEdgeValue(int edgeId, int restriction) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/ShadowIndexGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/ShadowIndexGraphStorage.java
@@ -74,7 +74,7 @@ public class ShadowIndexGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_shadowindex");
+        this.orsEdges = dir.create("ext_shadowindex");
     }
 
     /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/SpeedStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/SpeedStorage.java
@@ -27,7 +27,7 @@ public class SpeedStorage implements GraphExtension {
 
     @Override
     public void init(Graph graph, Directory directory) {
-        this.speedData = directory.find("ext_speeds_" + this.flagEncoder.toString());
+        this.speedData = directory.create("ext_speeds_" + this.flagEncoder.toString());
     }
 
     @Override

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TollwaysGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TollwaysGraphStorage.java
@@ -38,7 +38,7 @@ public class TollwaysGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ext_tolls storage must be initialized only once.");
 
-        this.edges = dir.find("ext_tolls");
+        this.edges = dir.create("ext_tolls");
     }
 
     protected final int nextBlockEntryIndex(int size) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrafficGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrafficGraphStorage.java
@@ -441,9 +441,9 @@ public class TrafficGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdgesProperties = dir.find("ext_traffic_edge_properties");
-        this.orsEdgesTrafficLinkLookup = dir.find("ext_traffic_edges_traffic_lookup");
-        this.orsSpeedPatternLookup = dir.find("ext_traffic_pattern_lookup");
+        this.orsEdgesProperties = dir.create("ext_traffic_edge_properties");
+        this.orsEdgesTrafficLinkLookup = dir.create("ext_traffic_edges_traffic_lookup");
+        this.orsSpeedPatternLookup = dir.create("ext_traffic_pattern_lookup");
     }
 
     /**
@@ -454,9 +454,9 @@ public class TrafficGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
         Directory d = new RAMDirectory();
-        this.orsEdgesProperties = d.find("");
-        this.orsEdgesTrafficLinkLookup = d.find("");
-        this.orsSpeedPatternLookup = d.find("");
+        this.orsEdgesProperties = d.create("");
+        this.orsEdgesTrafficLinkLookup = d.create("");
+        this.orsSpeedPatternLookup = d.create("");
     }
 
     /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrailDifficultyScaleGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/TrailDifficultyScaleGraphStorage.java
@@ -39,7 +39,7 @@ public class TrailDifficultyScaleGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ext_traildifficulty storage must be initialized only once.");
 
-        this.edges = dir.find("ext_traildifficulty");
+        this.edges = dir.create("ext_traildifficulty");
     }
 
     protected final int nextBlockEntryIndex(int size) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WayCategoryGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WayCategoryGraphStorage.java
@@ -38,7 +38,7 @@ public class WayCategoryGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_waycategory");
+        this.orsEdges = dir.create("ext_waycategory");
     }
 
     public WayCategoryGraphStorage create(long initBytes) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
@@ -40,7 +40,7 @@ public class WaySurfaceTypeGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_waysurface");
+        this.orsEdges = dir.create("ext_waysurface");
     }
 
     /**
@@ -51,7 +51,7 @@ public class WaySurfaceTypeGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
         Directory d = new RAMDirectory();
-        this.orsEdges = d.find("");
+        this.orsEdges = d.create("");
     }
 
     protected final int nextBlockEntryIndex(int size) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
@@ -17,6 +17,7 @@ import com.graphhopper.storage.DataAccess;
 import com.graphhopper.storage.Directory;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphExtension;
+import org.heigit.ors.routing.graphhopper.extensions.SurfaceType;
 import org.heigit.ors.routing.util.WaySurfaceDescription;
 
 public class WaySurfaceTypeGraphStorage implements GraphExtension {
@@ -93,7 +94,7 @@ public class WaySurfaceTypeGraphStorage implements GraphExtension {
 
         // add entry
         long edgePointer = (long) edgeId * edgeEntryBytes;
-        byteValues[0] = (byte) ((wayDesc.getWayType() << 4) | wayDesc.getSurfaceType() & 0xff);
+        byteValues[0] = (byte) ((wayDesc.getWayType() << 4) | wayDesc.getSurfaceType().ordinal() & 0xff);
         orsEdges.setBytes(edgePointer + efWaytype, byteValues, 1);
     }
 
@@ -105,7 +106,7 @@ public class WaySurfaceTypeGraphStorage implements GraphExtension {
         byte compValue = buffer[0];
         WaySurfaceDescription res = new WaySurfaceDescription();
         res.setWayType((compValue & 0b11110000) >> 4);
-        res.setSurfaceType(compValue & 0b00001111);
+        res.setSurfaceType(SurfaceType.getFromId(compValue & 0b00001111));
 
         return res;
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorage.java
@@ -13,10 +13,7 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions.storages;
 
-import com.graphhopper.storage.DataAccess;
-import com.graphhopper.storage.Directory;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphExtension;
+import com.graphhopper.storage.*;
 import org.heigit.ors.routing.graphhopper.extensions.SurfaceType;
 import org.heigit.ors.routing.util.WaySurfaceDescription;
 
@@ -44,6 +41,17 @@ public class WaySurfaceTypeGraphStorage implements GraphExtension {
             throw new AssertionError("The ORS storage must be initialized only once.");
 
         this.orsEdges = dir.find("ext_waysurface");
+    }
+
+    /**
+     * initializes the extended storage to be empty - required for testing purposes as the ext_storage aren't created
+     * at the time tests are run
+     */
+    public void init() {
+        if (edgesCount > 0)
+            throw new AssertionError("The ORS storage must be initialized only once.");
+        Directory d = new RAMDirectory();
+        this.orsEdges = d.find("");
     }
 
     protected final int nextBlockEntryIndex(int size) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WheelchairAttributesGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/WheelchairAttributesGraphStorage.java
@@ -99,7 +99,7 @@ public class WheelchairAttributesGraphStorage implements GraphExtension {
         if (edgesCount > 0)
             throw new AssertionError("The ORS storage must be initialized only once.");
 
-        this.orsEdges = dir.find("ext_wheelchair");
+        this.orsEdges = dir.create("ext_wheelchair");
     }
 
     public WheelchairAttributesGraphStorage create(long initBytes) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/WaySurfaceTypeGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/WaySurfaceTypeGraphStorageBuilder.java
@@ -60,13 +60,6 @@ public class WaySurfaceTypeGraphStorageBuilder extends AbstractGraphStorageBuild
         waySurfaceDesc.setWayType(wayType);
 
         SurfaceType surfaceType = way.hasTag(TAG_SURFACE) ? SurfaceType.getFromString(way.getTag(TAG_SURFACE)) : SurfaceType.UNKNOWN;
-        if (surfaceType == SurfaceType.UNKNOWN) {
-            if (wayType == WayType.ROAD || wayType == WayType.STATE_ROAD || wayType == WayType.STREET) {
-                surfaceType = SurfaceType.PAVED;
-            } else if (wayType == WayType.PATH) {
-                surfaceType = SurfaceType.UNPAVED;
-            }
-        }
         waySurfaceDesc.setSurfaceType(surfaceType);
 
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/WaySurfaceTypeGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/WaySurfaceTypeGraphStorageBuilder.java
@@ -59,7 +59,7 @@ public class WaySurfaceTypeGraphStorageBuilder extends AbstractGraphStorageBuild
         }
         waySurfaceDesc.setWayType(wayType);
 
-        int surfaceType = way.hasTag(TAG_SURFACE) ? SurfaceType.getFromString(way.getTag(TAG_SURFACE)) : SurfaceType.UNKNOWN;
+        SurfaceType surfaceType = way.hasTag(TAG_SURFACE) ? SurfaceType.getFromString(way.getTag(TAG_SURFACE)) : SurfaceType.UNKNOWN;
         if (surfaceType == SurfaceType.UNKNOWN) {
             if (wayType == WayType.ROAD || wayType == WayType.STATE_ROAD || wayType == WayType.STREET) {
                 surfaceType = SurfaceType.PAVED;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
@@ -438,7 +438,7 @@ public class ExtraInfoProcessor implements PathProcessor {
             WaySurfaceDescription wsd = extWaySurface.getEdgeValue(EdgeIteratorStateHelper.getOriginalEdge(edge), buffer);
 
             if (surfaceInfoBuilder != null)
-                surfaceInfoBuilder.addSegment(wsd.getSurfaceType(), wsd.getSurfaceType(), geom, dist);
+                surfaceInfoBuilder.addSegment(wsd.getSurfaceType().value(), wsd.getSurfaceType().value(), geom, dist);
 
             if (wayTypeInfo != null)
                 wayTypeInfoBuilder.addSegment(wsd.getWayType(), wsd.getWayType(), geom, dist);

--- a/ors-engine/src/main/java/org/heigit/ors/routing/util/WaySurfaceDescription.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/util/WaySurfaceDescription.java
@@ -1,8 +1,10 @@
 package org.heigit.ors.routing.util;
 
+import org.heigit.ors.routing.graphhopper.extensions.SurfaceType;
+
 public class WaySurfaceDescription {
     private byte wayType;
-    private byte surfaceType;
+    private SurfaceType surfaceType;
 
     public byte getWayType() {
         return wayType;
@@ -12,16 +14,16 @@ public class WaySurfaceDescription {
         this.wayType = (byte) wayType;
     }
 
-    public byte getSurfaceType() {
+    public SurfaceType getSurfaceType() {
         return surfaceType;
     }
 
-    public void setSurfaceType(int surfaceType) {
-        this.surfaceType = (byte) surfaceType;
+    public void setSurfaceType(SurfaceType surfaceType) {
+        this.surfaceType = surfaceType;
     }
 
     public void reset() {
         wayType = 0;
-        surfaceType = 0;
+        surfaceType = SurfaceType.UNKNOWN;
     }
 }

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorageTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/storages/WaySurfaceTypeGraphStorageTest.java
@@ -1,0 +1,42 @@
+/*  This file is part of Openrouteservice.
+ *
+ *  Openrouteservice is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+
+ *  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+
+ *  You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, see <https://www.gnu.org/licenses/>.
+ */
+package org.heigit.ors.routing.graphhopper.extensions.storages;
+
+import org.heigit.ors.routing.graphhopper.extensions.SurfaceType;
+import org.heigit.ors.routing.util.WaySurfaceDescription;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WaySurfaceTypeGraphStorageTest {
+    private final WaySurfaceTypeGraphStorage _storage;
+
+    public WaySurfaceTypeGraphStorageTest() {
+        _storage = new WaySurfaceTypeGraphStorage();
+        _storage.init();
+        _storage.create(1);
+    }
+
+    @Test
+    void TestWaySurfaceStorage() {
+        WaySurfaceDescription waySurfaceDescription = new WaySurfaceDescription();
+        byte [] buffer = new byte[1];
+
+        for(SurfaceType surface: SurfaceType.values()) {
+            waySurfaceDescription.setSurfaceType(surface);
+            _storage.setEdgeValue(1, waySurfaceDescription);
+            assertEquals(surface, _storage.getEdgeValue(1, buffer).getSurfaceType());
+        }
+    }
+}


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1779.

### Information about the changes

In order to be able to encode surface categories as 4 bit values their number has been reduced to 16 by removing the following ones:
- **Woodchips**: Not particularly common (0.02%) or relevant for routing on ways, because typical features exhibiting this type of surface are located within playgrouds, parks, etc. Note that this has never been functional because its original value of 16 exceeds the available data type range of 4 bits.
- **Cobblestone**: the OSM tag [`surface=cobblestone`](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dcobblestone) is quite generic as it is used for both `sett` and `unhewn_cobblestone`. As such it is ambiguous, because `sett` is already classified as "Paving Stones".
- **Fine gravel**: ambiguous as according to OSM wiki `surface=fine_gravel` *is used somewhat inconsistently. It may be used to specify fine loose gravel (...), but it is also sometimes used as an alias for compacted.* Therefore, it seems to make sense to marge it with the more generic category for `surface=gravel` which *has very large meaning range. Used for cases ranging from huge gravel pieces like track ballast used as surface, through small pieces of gravel to compacted surface.*

Additionally, the category for `surface=earth` (0.25%) has been changed from "Ground" to "Dirt", and some less common surface types have been assigned to one of the existing categories. All the changes are summarized in 
the table below. It lists the top 50 values of way `surface` tags which have a Wiki entry, with "Special" types of surfaces removed. The values from the **change** column override those from the **current** one.

| value              | count    | %     | current       | change        |
| ------------------ | -------- | ----- | ------------- | ------------- |
| asphalt            | 27299245 | 44.73 | Asphalt       |               |
| unpaved            | 11398669 | 18.68 | Unpaved       |               |
| paved              | 4049616  | 6.64  | Paved         |               |
| concrete           | 3360006  | 5.51  | Concrete      |               |
| paving_stones      | 3306257  | 5.42  | Paving Stones |               |
| ground             | 3209076  | 5.26  | Ground        |               |
| gravel             | 2086265  | 3.42  | Gravel        |               |
| dirt               | 1538632  | 2.52  | Dirt          |               |
| grass              | 1158016  | 1.9   | Grass         |               |
| compacted          | 1027824  | 1.68  | Compacted     |               |
| sand               | 520011   | 0.85  | Sand          |               |
| sett               | 430232   | 0.7   | Paving Stones |               |
| fine_gravel        | 397460   | 0.65  | **~~Fine Gravel~~**   | **Gravel**        |
| wood               | 208923   | 0.34  | Wood          |               |
| concrete:plates    | 177157   | 0.29  | Concrete      |               |
| cobblestone        | 151306   | 0.25  | **~~Cobblestone~~**   | **Paving Stones** |
| earth              | 150580   | 0.25  | Ground        | Dirt          |
| pebblestone        | 121603   | 0.2   | Compacted     |               |
| metal              | 41043    | 0.07  | Metal         |               |
| grass_paver        | 40869    | 0.07  | Grass_Paver   |               |
| unhewn_cobblestone | 31514    | 0.05  |               | Paving Stones |
| mud                | 26101    | 0.04  | Ground        |               |
| concrete:lanes     | 26090    | 0.04  | Concrete      |               |
| rock               | 21325    | 0.03  |               | Unpaved       |
| stone              | 11348    | 0.02  |               | Unpaved       |
| woodchips          | 9924     | 0.02  | **~~Woodchips~~**    | **Unpaved**       |
| soil               | 7045     | 0.01  |               | Dirt          |
| bricks             | 6578     | 0.01  |               | Paving Stones |
| brick              | 6563     | 0.01  |               | Paving Stones |
| trail              | 5499     | 0.01  |               |               |
| chipseal           | 3417     | 0.01  |               | Asphalt       |
| metal_grid         | 2618     | 0     |               |               |
| cement             | 2595     | 0     |               | Concrete      |
| ice                | 2209     | 0     | Ice           |               |
| stepping_stones    | 1850     | 0     |               |               |
| paving_stones:30   | 1636     | 0     | Paving Stones |               |
| shells             | 1108     | 0     |               | Unpaved       |
| rocks              | 923      | 0     |               | Unpaved       |
| bitmac             | 543      | 0     |               | Asphalt       |
| snow               | 365      | 0     | Ice           |               |
| tarmac             | 272      | 0     |               | Asphalt       |
| salt               | 197      | 0     |               | Unpaved       |
| paving_stones:20   | 147      | 0     | Paving Stones |               |

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
