### PR TITLE
feat: efficient many to one matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ RELEASING:
 - document which values of OSM key `surface` are being considered for way surface categories ([#1794](https://github.com/GIScience/openrouteservice/pull/1794))
 ### Changed
 - way surface is now being determined based only on the value of OSM `surface` tag; when the tag is not present the surface is reported as "Unknown" and is no longer being inferred from the way type ([#1794](https://github.com/GIScience/openrouteservice/pull/1794))
+- improved performance of RPHAST matrix queries in the case when the number of sources is higher than the number of destinations
 ### Deprecated
 - soon-to-be removed features.
 ### Removed

--- a/ors-api/src/test/java/org/heigit/ors/apitests/matrix/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/matrix/ResultTest.java
@@ -876,6 +876,31 @@ class ResultTest extends ServiceTest {
     }
 
     @Test
+    void testSwap() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations5"));
+        body.put("sources", new JSONArray(new int[]{0, 1, 4}));
+        body.put("destinations", new JSONArray(new int[]{2, 3}));
+        body.put("metrics", getParameter("metricsDuration"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(jsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when().log().ifValidationFails()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then().log().ifValidationFails()
+                .assertThat()
+                .body("any { it.key == 'durations' }", is(true))
+                .body("durations[0][0]", is(closeTo(726.88, 2)))
+                .body("durations[0][1]", is(closeTo(672.3, 2)))
+                .body("durations[1][0]", is(closeTo(625.37, 2)))
+                .body("durations[1][1]", is(closeTo(570.8, 2)))
+                .statusCode(200);
+    }
+
+    @Test
     void expectTurnRestrictionDurations() {
         JSONObject body = new JSONObject();
         JSONObject options = new JSONObject();

--- a/ors-engine/src/main/java/org/heigit/ors/matrix/TargetGraphBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/matrix/TargetGraphBuilder.java
@@ -2,7 +2,6 @@ package org.heigit.ors.matrix;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.graphhopper.routing.querygraph.QueryRoutingCHGraph;
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.RoutingCHEdgeExplorer;
 import com.graphhopper.storage.RoutingCHEdgeIterator;
 import com.graphhopper.storage.RoutingCHGraph;
@@ -24,9 +23,9 @@ public class TargetGraphBuilder {
      *
      * @param targets the targets that form the seed for target graph building
      */
-    public TargetGraphResults prepareTargetGraph(int[] targets, RoutingCHGraph chGraph, FlagEncoder encoder, boolean swap, int coreNodeLevel) {
+    public TargetGraphResults prepareTargetGraph(int[] targets, RoutingCHGraph chGraph, boolean swap, int coreNodeLevel) {
         PriorityQueue<Integer> localPrioQueue = new PriorityQueue<>(100);
-        ExclusiveDownwardSearchEdgeFilter downwardEdgeFilter = new ExclusiveDownwardSearchEdgeFilter(chGraph, encoder, swap);
+        ExclusiveDownwardSearchEdgeFilter downwardEdgeFilter = new ExclusiveDownwardSearchEdgeFilter(chGraph, swap);
         RoutingCHEdgeExplorer edgeExplorer = swap ? chGraph.createOutEdgeExplorer()
                 : chGraph.createInEdgeExplorer();
         SubGraph targetGraph = new SubGraph(chGraph);

--- a/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/core/CoreMatrixAlgorithm.java
@@ -116,7 +116,7 @@ public class CoreMatrixAlgorithm extends AbstractContractedMatrixAlgorithm {
         }
         this.treeEntrySize = srcData.size();
 
-        TargetGraphBuilder.TargetGraphResults targetGraphResults = new TargetGraphBuilder().prepareTargetGraph(dstData.getNodeIds(), chGraph, encoder, swap, coreNodeLevel);
+        TargetGraphBuilder.TargetGraphResults targetGraphResults = new TargetGraphBuilder().prepareTargetGraph(dstData.getNodeIds(), chGraph, swap, coreNodeLevel);
         targetGraph = targetGraphResults.getTargetGraph();
         coreExitPoints.addAll(targetGraphResults.getCoreExitPoints());
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
@@ -180,7 +180,6 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
                 throw new IllegalStateException("Edge-based behavior not supported");
         }
 
-//        outEdgeExplorer = graph.createOutEdgeExplorer();
         outEdgeExplorer = swap ? graph.createInEdgeExplorer()
                 : graph.createOutEdgeExplorer();
         runUpwardSearch();
@@ -225,7 +224,6 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
                 continue;
 
             edgeWeight = iter.getWeight(swap);
-//            edgeWeight = weighting.calcEdgeWeight(iter, false, 0);
 
             if (!Double.isInfinite(edgeWeight)) {
                 MultiTreeSPEntry ee = shortestWeightMap.get(iter.getAdjNode());
@@ -279,7 +277,6 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
             return;
 
         while (iter.next()) {
-//            edgeWeight = weighting.calcEdgeWeight(iter, false, 0);
             edgeWeight = iter.getWeight(swap);
             if (!Double.isInfinite(edgeWeight)) {
                 MultiTreeSPEntry ee = bestWeightMap.get(iter.getAdjNode());

--- a/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
@@ -36,6 +36,7 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
     private MultiTreeSPEntry currFrom;
     private PriorityQueue<MultiTreeSPEntry> prioQueue;
     private SubGraph targetGraph;
+    private boolean swap;
     private boolean finishedFrom;
     private boolean finishedTo;
     private int visitedCountFrom;
@@ -49,8 +50,11 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
     private double tmpWeight;
 
     public RPHASTAlgorithm(RoutingCHGraph graph, Weighting weighting, TraversalMode traversalMode) {
+        this(graph, weighting, traversalMode, false);
+    }
+    public RPHASTAlgorithm(RoutingCHGraph graph, Weighting weighting, TraversalMode traversalMode, boolean swap) {
         super(graph, weighting, traversalMode);
-
+        this.swap = swap;
         int size = Math.min(Math.max(200, graph.getNodes() / 10), 2000);
 
         initCollections(size);
@@ -84,13 +88,16 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
 
         addNodes(targetGraph, localPrioQueue, targets);
 
+        RoutingCHEdgeExplorer edgeExplorer = swap ? graph.createOutEdgeExplorer()
+                : graph.createInEdgeExplorer();
+
         while (!localPrioQueue.isEmpty()) {
             int node = localPrioQueue.poll();
-            RoutingCHEdgeIterator iter = inEdgeExplorer.setBaseNode(node);
+            RoutingCHEdgeIterator iter = edgeExplorer.setBaseNode(node);
             downwardEdgeFilter.setBaseNode(node);
 
             while (iter.next()) {
-                if (!downwardEdgeFilter.accept(iter))
+                if (!downwardEdgeFilter.accept(iter, swap))
                     continue;
 
                 if (targetGraph.addEdge(node, iter, true))
@@ -175,7 +182,9 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
                 throw new IllegalStateException("Edge-based behavior not supported");
         }
 
-        outEdgeExplorer = graph.createOutEdgeExplorer();
+//        outEdgeExplorer = graph.createOutEdgeExplorer();
+        outEdgeExplorer = swap ? graph.createInEdgeExplorer()
+                : graph.createOutEdgeExplorer();
         runUpwardSearch();
         if (!upwardEdgeFilter.isHighestNodeFound())
             throw new IllegalStateException("First RPHAST phase was not successful.");
@@ -214,10 +223,10 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
         upwardEdgeFilter.setBaseNode(currEdge.getAdjNode());
 
         while (iter.next()) {
-            if (!upwardEdgeFilter.accept(iter))
+            if (!upwardEdgeFilter.accept(iter, swap))
                 continue;
 
-            edgeWeight = iter.getWeight(false);
+            edgeWeight = iter.getWeight(swap);
 //            edgeWeight = weighting.calcEdgeWeight(iter, false, 0);
 
             if (!Double.isInfinite(edgeWeight)) {
@@ -273,7 +282,7 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
 
         while (iter.next()) {
 //            edgeWeight = weighting.calcEdgeWeight(iter, false, 0);
-            edgeWeight = iter.getWeight(false);
+            edgeWeight = iter.getWeight(swap);
             if (!Double.isInfinite(edgeWeight)) {
                 MultiTreeSPEntry ee = bestWeightMap.get(iter.getAdjNode());
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/algorithms/RPHASTAlgorithm.java
@@ -15,7 +15,6 @@ package org.heigit.ors.routing.algorithms;
 
 import com.carrotsearch.hppc.IntObjectMap;
 import com.graphhopper.coll.GHIntObjectHashMap;
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.RoutingCHEdgeExplorer;
@@ -58,10 +57,9 @@ public class RPHASTAlgorithm extends AbstractManyToManyRoutingAlgorithm {
         int size = Math.min(Math.max(200, graph.getNodes() / 10), 2000);
 
         initCollections(size);
-        FlagEncoder encoder = weighting.getFlagEncoder();
 
-        upwardEdgeFilter = new UpwardSearchEdgeFilter(graph, encoder);
-        downwardEdgeFilter = new DownwardSearchEdgeFilter(graph, encoder);
+        upwardEdgeFilter = new UpwardSearchEdgeFilter(graph);
+        downwardEdgeFilter = new DownwardSearchEdgeFilter(graph);
     }
 
     protected void initCollections(int size) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/CHLevelEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/CHLevelEdgeFilter.java
@@ -13,14 +13,12 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions.edgefilters.ch;
 
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.CHEdgeFilter;
 import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 import org.heigit.ors.routing.graphhopper.extensions.util.GraphUtils;
 
 public abstract class CHLevelEdgeFilter implements CHEdgeFilter {
-    protected final FlagEncoder encoder;
     protected final RoutingCHGraph graph;
     protected final int maxNodes;
     protected int highestNode = -1;
@@ -28,10 +26,9 @@ public abstract class CHLevelEdgeFilter implements CHEdgeFilter {
     protected int baseNode;
     protected int baseNodeLevel = -1;
 
-    protected CHLevelEdgeFilter(RoutingCHGraph g, FlagEncoder encoder) {
+    protected CHLevelEdgeFilter(RoutingCHGraph g) {
         graph = g;
         maxNodes = GraphUtils.getBaseGraph(g).getNodes();
-        this.encoder = encoder;
     }
 
     @Override

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
@@ -29,20 +29,14 @@ public class DownwardSearchEdgeFilter extends CHLevelEdgeFilter {
 
     @Override
     public boolean accept(RoutingCHEdgeIteratorState edgeIterState) {
-        int adj = edgeIterState.getAdjNode();
-
-        if (baseNode >= maxNodes || adj >= maxNodes || baseNodeLevel <= graph.getLevel(adj))
-            return isAccessible(edgeIterState, true);
-//            return edgeIterState.getReverse(accessEnc);
-        else
-            return false;
+        return accept(edgeIterState, false);
     }
 
     public boolean accept(RoutingCHEdgeIteratorState edgeIterState, boolean swap) {
         int adj = edgeIterState.getAdjNode();
 
         if (baseNode >= maxNodes || adj >= maxNodes || baseNodeLevel <= graph.getLevel(adj))
-            return swap ? isAccessible(edgeIterState, false) : isAccessible(edgeIterState, true);
+            return isAccessible(edgeIterState, !swap);
         else
             return false;
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
@@ -42,7 +42,7 @@ public class DownwardSearchEdgeFilter extends CHLevelEdgeFilter {
         int adj = edgeIterState.getAdjNode();
 
         if (baseNode >= maxNodes || adj >= maxNodes || baseNodeLevel <= graph.getLevel(adj))
-            return swap ? isAccessible(edgeIterState, true) : isAccessible(edgeIterState, false);
+            return swap ? isAccessible(edgeIterState, false) : isAccessible(edgeIterState, true);
         else
             return false;
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
@@ -13,18 +13,13 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions.edgefilters.ch;
 
-import com.graphhopper.routing.ev.BooleanEncodedValue;
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 
 public class DownwardSearchEdgeFilter extends CHLevelEdgeFilter {
-    protected final BooleanEncodedValue accessEnc;
 
-
-    public DownwardSearchEdgeFilter(RoutingCHGraph g, FlagEncoder encoder) {
-        super(g, encoder);
-        accessEnc = encoder.getAccessEnc();
+    public DownwardSearchEdgeFilter(RoutingCHGraph g) {
+        super(g);
     }
 
     @Override

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/DownwardSearchEdgeFilter.java
@@ -37,4 +37,13 @@ public class DownwardSearchEdgeFilter extends CHLevelEdgeFilter {
         else
             return false;
     }
+
+    public boolean accept(RoutingCHEdgeIteratorState edgeIterState, boolean swap) {
+        int adj = edgeIterState.getAdjNode();
+
+        if (baseNode >= maxNodes || adj >= maxNodes || baseNodeLevel <= graph.getLevel(adj))
+            return swap ? isAccessible(edgeIterState, true) : isAccessible(edgeIterState, false);
+        else
+            return false;
+    }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/UpwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/UpwardSearchEdgeFilter.java
@@ -28,21 +28,14 @@ public class UpwardSearchEdgeFilter extends CHLevelEdgeFilter {
 
     @Override
     public boolean accept(RoutingCHEdgeIteratorState edgeIterState) {
-        int adj = edgeIterState.getAdjNode();
-
-        if (baseNode >= maxNodes || adj >= maxNodes || baseNodeLevel <= graph.getLevel(adj))
-            return isAccessible(edgeIterState, false);
-//			return edgeIterState.get(accessEnc);
-        else
-            return false;
+        return accept(edgeIterState, false);
     }
 
     public boolean accept(RoutingCHEdgeIteratorState edgeIterState, boolean swap) {
         int adj = edgeIterState.getAdjNode();
 
         if (baseNode >= maxNodes || adj >= maxNodes || baseNodeLevel <= graph.getLevel(adj))
-            return swap ? isAccessible(edgeIterState, true) : isAccessible(edgeIterState, false);
-//			return edgeIterState.get(accessEnc);
+            return isAccessible(edgeIterState, swap);
         else
             return false;
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/UpwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/UpwardSearchEdgeFilter.java
@@ -36,4 +36,14 @@ public class UpwardSearchEdgeFilter extends CHLevelEdgeFilter {
         else
             return false;
     }
+
+    public boolean accept(RoutingCHEdgeIteratorState edgeIterState, boolean swap) {
+        int adj = edgeIterState.getAdjNode();
+
+        if (baseNode >= maxNodes || adj >= maxNodes || baseNodeLevel <= graph.getLevel(adj))
+            return swap ? isAccessible(edgeIterState, true) : isAccessible(edgeIterState, false);
+//			return edgeIterState.get(accessEnc);
+        else
+            return false;
+    }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/UpwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/ch/UpwardSearchEdgeFilter.java
@@ -13,17 +13,13 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions.edgefilters.ch;
 
-import com.graphhopper.routing.ev.BooleanEncodedValue;
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 
 public class UpwardSearchEdgeFilter extends CHLevelEdgeFilter {
-    BooleanEncodedValue accessEnc;
 
-    public UpwardSearchEdgeFilter(RoutingCHGraph g, FlagEncoder encoder) {
-        super(g, encoder);
-        this.accessEnc = encoder.getAccessEnc();
+    public UpwardSearchEdgeFilter(RoutingCHGraph g) {
+        super(g);
     }
 
     @Override

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/core/ExclusiveDownwardSearchEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/core/ExclusiveDownwardSearchEdgeFilter.java
@@ -13,7 +13,6 @@
  */
 package org.heigit.ors.routing.graphhopper.extensions.edgefilters.core;
 
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.ch.DownwardSearchEdgeFilter;
@@ -21,12 +20,12 @@ import org.heigit.ors.routing.graphhopper.extensions.edgefilters.ch.DownwardSear
 public class ExclusiveDownwardSearchEdgeFilter extends DownwardSearchEdgeFilter {
     private boolean swap = false;
 
-    public ExclusiveDownwardSearchEdgeFilter(RoutingCHGraph g, FlagEncoder encoder) {
-        super(g, encoder);
+    public ExclusiveDownwardSearchEdgeFilter(RoutingCHGraph g) {
+        super(g);
     }
 
-    public ExclusiveDownwardSearchEdgeFilter(RoutingCHGraph g, FlagEncoder encoder, boolean swap) {
-        this(g, encoder);
+    public ExclusiveDownwardSearchEdgeFilter(RoutingCHGraph g, boolean swap) {
+        this(g);
         this.swap = swap;
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
@@ -2,6 +2,7 @@ package org.heigit.ors.matrix.rphast;
 
 import com.graphhopper.routing.ch.NodeOrderingProvider;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
+import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.TraversalMode;
@@ -9,6 +10,10 @@ import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
+import org.heigit.ors.matrix.MatrixLocations;
+import org.heigit.ors.matrix.MatrixSearchContext;
+import org.heigit.ors.matrix.MatrixSearchContextBuilder;
+import org.heigit.ors.matrix.algorithms.rphast.RPHASTMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.RPHASTAlgorithm;
 import org.heigit.ors.routing.graphhopper.extensions.storages.MultiTreeSPEntry;
 import org.heigit.ors.util.DebugUtility;
@@ -154,6 +159,38 @@ class RPHASTMatrixTest {
         algorithm.prepare(srcIds, dstIds);
         algorithm.setMaxVisitedNodes(33);
         assertThrows(MaxVisitedNodesExceededException.class, () -> algorithm.calcPaths(srcIds, dstIds));
+    }
+
+    @Test
+    void testSwap() {
+        /**
+         * First calculate the distances with sources and destinations swapped (ids are swapped "manually")
+         * After we compare with the non-swapped results.
+         */
+        ToyGraphCreationUtil.createTwoWayGraph(g, encodingManager);
+        PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
+        prepare.doWork();
+
+        RPHASTAlgorithm algorithmSwapped = new RPHASTAlgorithm(routingCHGraph, weighting, TraversalMode.NODE_BASED, true);
+
+        int[] srcIdsSwapped = new int[]{1};
+        int[] dstIdsSwapped = new int[]{2, 3};
+
+        algorithmSwapped.prepare(srcIdsSwapped, dstIdsSwapped);
+
+        MultiTreeSPEntry[] destTreesSwapped = algorithmSwapped.calcPaths(srcIdsSwapped, dstIdsSwapped);
+
+        RPHASTAlgorithm algorithm = new RPHASTAlgorithm(routingCHGraph, weighting, TraversalMode.NODE_BASED, true);
+
+        int[] srcIds = new int[]{2, 3};
+        int[] dstIds = new int[]{1};
+
+        algorithm.prepare(srcIds, dstIds);
+
+        MultiTreeSPEntry[] destTrees = algorithm.calcPaths(srcIds, dstIds);
+
+        // TODO assert that both are equal and take the long way around the one-way-edges.
+//        assertEquals()
     }
 
 

--- a/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
@@ -10,17 +10,17 @@ import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
-import org.heigit.ors.matrix.MatrixLocations;
-import org.heigit.ors.matrix.MatrixSearchContext;
-import org.heigit.ors.matrix.MatrixSearchContextBuilder;
+import org.heigit.ors.matrix.*;
 import org.heigit.ors.matrix.algorithms.rphast.RPHASTMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.RPHASTAlgorithm;
+import org.heigit.ors.routing.graphhopper.extensions.core.CoreTestEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.storages.MultiTreeSPEntry;
 import org.heigit.ors.util.DebugUtility;
 import org.heigit.ors.util.ToyGraphCreationUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -162,19 +162,19 @@ class RPHASTMatrixTest {
     }
 
     @Test
-    void testSwap() {
+    void testSwapRPHASTAlgorithm() {
         /**
          * First calculate the distances with sources and destinations swapped (ids are swapped "manually")
          * After we compare with the non-swapped results.
          */
-        ToyGraphCreationUtil.createTwoWayGraph(g, encodingManager);
+        ToyGraphCreationUtil.createSimpleGraphWithAccessRestrictions(g, encodingManager);
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         prepare.doWork();
 
         RPHASTAlgorithm algorithmSwapped = new RPHASTAlgorithm(routingCHGraph, weighting, TraversalMode.NODE_BASED, true);
 
-        int[] srcIdsSwapped = new int[]{1};
-        int[] dstIdsSwapped = new int[]{2, 3};
+        int[] srcIdsSwapped = new int[]{2};
+        int[] dstIdsSwapped = new int[]{4, 3};
 
         algorithmSwapped.prepare(srcIdsSwapped, dstIdsSwapped);
 
@@ -182,15 +182,15 @@ class RPHASTMatrixTest {
 
         RPHASTAlgorithm algorithm = new RPHASTAlgorithm(routingCHGraph, weighting, TraversalMode.NODE_BASED, false);
 
-        int[] srcIds = new int[]{2, 3};
-        int[] dstIds = new int[]{1};
+        int[] srcIds = new int[]{4, 3};
+        int[] dstIds = new int[]{2};
 
         algorithm.prepare(srcIds, dstIds);
 
         MultiTreeSPEntry[] destTrees = algorithm.calcPaths(srcIds, dstIds);
 
-        // TODO assert that both are equal and take the long way around the one-way-edges.
-//        assertEquals()
+        assertEquals(destTreesSwapped[0].getItem(0).getWeight(), destTrees[0].getItem(0).getWeight());
+        assertEquals(destTreesSwapped[1].getItem(0).getWeight(), destTrees[0].getItem(1).getWeight());
     }
 
 

--- a/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
@@ -180,7 +180,7 @@ class RPHASTMatrixTest {
 
         MultiTreeSPEntry[] destTreesSwapped = algorithmSwapped.calcPaths(srcIdsSwapped, dstIdsSwapped);
 
-        RPHASTAlgorithm algorithm = new RPHASTAlgorithm(routingCHGraph, weighting, TraversalMode.NODE_BASED, true);
+        RPHASTAlgorithm algorithm = new RPHASTAlgorithm(routingCHGraph, weighting, TraversalMode.NODE_BASED, false);
 
         int[] srcIds = new int[]{2, 3};
         int[] dstIds = new int[]{1};

--- a/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/matrix/rphast/RPHASTMatrixTest.java
@@ -2,7 +2,6 @@ package org.heigit.ors.matrix.rphast;
 
 import com.graphhopper.routing.ch.NodeOrderingProvider;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
-import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.TraversalMode;
@@ -10,17 +9,13 @@ import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import org.heigit.ors.exceptions.MaxVisitedNodesExceededException;
-import org.heigit.ors.matrix.*;
-import org.heigit.ors.matrix.algorithms.rphast.RPHASTMatrixAlgorithm;
 import org.heigit.ors.routing.algorithms.RPHASTAlgorithm;
-import org.heigit.ors.routing.graphhopper.extensions.core.CoreTestEdgeFilter;
 import org.heigit.ors.routing.graphhopper.extensions.storages.MultiTreeSPEntry;
 import org.heigit.ors.util.DebugUtility;
 import org.heigit.ors.util.ToyGraphCreationUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/ors-engine/src/test/java/org/heigit/ors/util/ToyGraphCreationUtil.java
+++ b/ors-engine/src/test/java/org/heigit/ors/util/ToyGraphCreationUtil.java
@@ -1,10 +1,13 @@
 package org.heigit.ors.util;
 
+import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
+import org.locationtech.jts.geomgraph.Edge;
 
 public class ToyGraphCreationUtil {
     private static GraphHopperStorage createGHStorage(EncodingManager encodingManager) {
@@ -218,6 +221,40 @@ public class ToyGraphCreationUtil {
                 g.edge(4, 3).setDistance(2),
                 g.edge(5, 1).setDistance(2)
         );
+        return g;
+    }
+
+    public static GraphHopperStorage createSimpleGraphWithAccessRestrictions(GraphHopperStorage g, EncodingManager encodingManager) {
+        // 5--1---2
+        //     \ /|
+        //      0 |
+        //     /  |
+        //    4---3
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        DecimalEncodedValue speedEnc = encodingManager.getEncoder("car").getAverageSpeedEnc();
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        edge0.set(speedEnc, 60);
+
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(1));
+        edge1.set(speedEnc, 60);
+
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 4).setDistance(10));
+        edge2.set(speedEnc, 60);
+
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
+        edge3.set(speedEnc, 60);
+
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(1));
+        edge4.set(speedEnc, 60);
+        edge4.setReverse(speedEnc, 0);
+
+        EdgeIteratorState edge5 = GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 3).setDistance(1));
+        edge5.set(speedEnc, 60);
+
+        EdgeIteratorState edge6 = GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 1).setDistance(1));
+        edge6.set(speedEnc, 60);
+
+
         return g;
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/util/ToyGraphCreationUtil.java
+++ b/ors-engine/src/test/java/org/heigit/ors/util/ToyGraphCreationUtil.java
@@ -7,7 +7,6 @@ import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
-import org.locationtech.jts.geomgraph.Edge;
 
 public class ToyGraphCreationUtil {
     private static GraphHopperStorage createGHStorage(EncodingManager encodingManager) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

### Information about the changes

Improve performance of RPHAST queries in the case the number of sources is higher than the number of destinations, in particular many-to-one queries.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
