### PR TITLE
feat: move profile hash creation outside GH

### DIFF
--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -21,8 +21,12 @@ import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.storage.*;
-import com.graphhopper.util.*;
+import com.graphhopper.storage.ConditionalEdges;
+import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.StorableProperties;
+import com.graphhopper.util.Helper;
+import com.graphhopper.util.PMap;
+import com.graphhopper.util.Parameters;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
 import com.typesafe.config.Config;
@@ -377,7 +381,30 @@ public class RoutingProfile {
         ghConfig.putObject("ext_storages", config.getExtStorages());
         ghConfig.setProfiles(new ArrayList<>(profiles.values()));
 
+        ghConfig.putObject("profile.hash", computeProfileHash(config));
         return ghConfig;
+    }
+
+    static String computeProfileHash(RouteProfileConfiguration rpc) {
+        RoutingProfileHashBuilder hashBuilder = RoutingProfileHashBuilder.builder()
+                .withString(rpc.getName())
+                .withBoolean(rpc.getEnabled())
+                .withString(rpc.getProfiles())
+                .withMapOfMaps(rpc.getExtStorages(), "extStorages")
+                .withMapOfMaps(rpc.getGraphBuilders(), "graphBuilders")
+                .withBoolean(rpc.getInstructions())
+                .withBoolean(rpc.getOptimize())
+                .withInteger(rpc.getEncoderFlagsSize())
+                .withString(rpc.getEncoderOptions())
+                .withObject(rpc.getIsochronePreparationOpts())
+                .withObject(rpc.getPreparationOpts())
+                .withBoolean(rpc.getElevationSmoothing())
+                .withBoolean(rpc.getInterpolateBridgesAndTunnels())
+                .withInteger(rpc.getLocationIndexResolution())
+                .withInteger(rpc.getLocationIndexSearchIterations())
+                .withBoolean(rpc.isTurnCostEnabled())
+                .withBoolean(rpc.isEnforceTurnCosts());
+        return hashBuilder.build();
     }
 
     public boolean hasCHProfile(String profileName) {
@@ -802,54 +829,4 @@ public class RoutingProfile {
     public int hashCode() {
         return mGraphHopper.getGraphHopperStorage().getDirectory().getLocation().hashCode();
     }
-
-    //jh: alternative for hashing ORSGraphHopper TODO remove if hashing ORSGraphHopper is correct
-    void addProfileHash(RouteProfileConfiguration routeProfileConfiguration) {
-        String profileHash = computeProfileHash(routeProfileConfiguration);
-        routeProfileConfiguration.setGraphPath(routeProfileConfiguration.getGraphPath() + "/" + profileHash);
-    }
-
-    //jh: alternative for hashing ORSGraphHopper TODO remove if hashing ORSGraphHopper is correct
-    String computeProfileHash(RouteProfileConfiguration routeProfileConfiguration) {
-        RoutingProfileHashBuilder hashBuilder = RoutingProfileHashBuilder.builder()
-                .withString(routeProfileConfiguration.getName())
-                .withBoolean(routeProfileConfiguration.getEnabled())
-                .withString(routeProfileConfiguration.getProfiles())
-//                .withString(routeProfileConfiguration.getGraphPath())
-                .withMapOfMaps(routeProfileConfiguration.getExtStorages(), "extStorages")
-                .withMapOfMaps(routeProfileConfiguration.getGraphBuilders(), "graphBuilders")
-                .withDouble(routeProfileConfiguration.getMaximumDistance())
-                .withDouble(routeProfileConfiguration.getMaximumDistanceDynamicWeights())
-                .withDouble(routeProfileConfiguration.getMaximumDistanceAvoidAreas())
-                .withDouble(routeProfileConfiguration.getMaximumDistanceAlternativeRoutes())
-                .withDouble(routeProfileConfiguration.getMaximumDistanceRoundTripRoutes())
-                .withDouble(routeProfileConfiguration.getMaximumWayPoints())
-                .withBoolean(routeProfileConfiguration.getInstructions())
-                .withBoolean(routeProfileConfiguration.getOptimize())
-                .withInteger(routeProfileConfiguration.getEncoderFlagsSize())
-                .withString(routeProfileConfiguration.getEncoderOptions())
-                .withString(routeProfileConfiguration.getGtfsFile())
-                .withObject(routeProfileConfiguration.getIsochronePreparationOpts())
-                .withObject(routeProfileConfiguration.getPreparationOpts())
-                .withObject(routeProfileConfiguration.getExecutionOpts())
-                .withString(routeProfileConfiguration.getElevationProvider())
-                .withString(routeProfileConfiguration.getElevationCachePath())
-                .withString(routeProfileConfiguration.getElevationDataAccess())
-                .withBoolean(routeProfileConfiguration.getElevationCacheClear())
-                .withBoolean(routeProfileConfiguration.getElevationSmoothing())
-                .withBoolean(routeProfileConfiguration.getInterpolateBridgesAndTunnels())
-                .withInteger(routeProfileConfiguration.getMaximumSnappingRadius())
-//                .withObject(routeProfileConfiguration.getExtent())
-                .withBoolean(routeProfileConfiguration.hasMaximumSnappingRadius())
-                .withInteger(routeProfileConfiguration.getLocationIndexResolution())
-                .withInteger(routeProfileConfiguration.getLocationIndexSearchIterations())
-                .withDouble(routeProfileConfiguration.getMaximumSpeedLowerBound())
-//                .withInteger(routeProfileConfiguration.getTrafficExpirationMin())
-                .withInteger(routeProfileConfiguration.getMaximumVisitedNodesPT())
-                .withBoolean(routeProfileConfiguration.isTurnCostEnabled())
-                .withBoolean(routeProfileConfiguration.isEnforceTurnCosts());
-
-        return hashBuilder.build();
-    }
-
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -69,7 +69,6 @@ import org.heigit.ors.routing.graphhopper.extensions.storages.builders.HereTraff
 import org.heigit.ors.routing.graphhopper.extensions.util.ORSParameters;
 import org.heigit.ors.routing.graphhopper.extensions.weighting.HgvAccessWeighting;
 import org.heigit.ors.routing.pathprocessors.BordersExtractor;
-import org.heigit.ors.routing.util.RoutingProfileHashBuilder;
 import org.heigit.ors.util.CoordTools;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -181,7 +180,7 @@ public class ORSGraphHopper extends GraphHopperGtfs {
             throw new IllegalStateException("graph is already successfully loaded");
         }
 
-        String hash = createProfileHash();
+        String hash = config.getString("profile.hash", "invalid_profile_hash");
         String vehicleDirAbsPath = getGraphHopperLocation();
         String hashDirAbsPath = extendGraphhopperLocation(hash);
 
@@ -284,29 +283,6 @@ public class ORSGraphHopper extends GraphHopperGtfs {
         this.setGraphHopperLocation(extendedPath);
         LOGGER.info("Extended graphHopperLocation with hash: {}", hash);
         return extendedPath;
-    }
-
-    String createProfileHash() {
-        // File name or hash should not be contained in the hash, same hast should map to different graphs built off different files for the same region/profile pair.
-        Map<String, Object> configWithoutFilePath = config.asPMap().toMap();
-        configWithoutFilePath.remove("datareader.file");
-        configWithoutFilePath.remove("graph.dataaccess");
-        configWithoutFilePath.remove("graph.location");
-        configWithoutFilePath.remove("graph.elevation.provider");
-        configWithoutFilePath.remove("graph.elevation.cache_dir");
-        configWithoutFilePath.remove("graph.elevation.dataaccess");
-        configWithoutFilePath.remove("graph.elevation.clear");
-        RoutingProfileHashBuilder builder = RoutingProfileHashBuilder.builder()
-                .withNamedString("profiles", config.getProfiles().stream().map(Profile::toString).sorted().collect(Collectors.joining()))
-                .withNamedString("chProfiles", config.getCHProfiles().stream().map(CHProfile::toString).sorted().collect(Collectors.joining()))
-                .withNamedString("lmProfiles", config.getLMProfiles().stream().map(LMProfile::toString).sorted().collect(Collectors.joining()))
-                .withMapStringObject(configWithoutFilePath, "pMap");
-        if (config instanceof ORSGraphHopperConfig orsConfig) {
-            builder.withNamedString("coreProfiles", orsConfig.getCoreProfiles().stream().map(CHProfile::toString).sorted().collect(Collectors.joining()))
-                    .withNamedString("coreLMProfiles", orsConfig.getCoreLMProfiles().stream().map(LMProfile::toString).sorted().collect(Collectors.joining()))
-                    .withNamedString("fastisochroneProfiles", orsConfig.getFastisochroneProfiles().stream().map(Profile::toString).sorted().collect(Collectors.joining()));
-        }
-        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
### Information about the changes
- Reason for change:
Move hash creation out of the ORSGraphHopper class to the RoutingProfile class, clean up more by only adding parameters that have graph changing effect