### PR TITLE
fix: dynamically size extra info buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ RELEASING:
 ### Fixed
 ### Security
 
+## [unreleased]
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- allow any number of csv columns ([#1436](https://github.com/GIScience/openrouteservice/issues/1436))
+### Security
+
 ## [8.1.1] - 2024-07-17
 ### Added
 - added danish tranlations ([#1809](https://github.com/GIScience/openrouteservice/pull/1809))

--- a/ors-engine/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
@@ -127,6 +127,9 @@ public class ExtraInfoProcessor implements PathProcessor {
         encoderWithPriority = encoder.supports(PriorityWeighting.class);
         List<String> skippedExtras = new ArrayList<>();
 
+        //Sufficient size for every extra info except csv.
+        int buffer_size = 4;
+
         try {
             PMap params = opts;
             if (params == null) {
@@ -274,6 +277,9 @@ public class ExtraInfoProcessor implements PathProcessor {
                     csvInfo = new RouteExtraInfo("csv");
                     csvInfoBuilder = new AppendableRouteExtraInfoBuilder(csvInfo);
                     csvColumn = extCsvData.columnIndex(params.getString("weighting_#csv#column", ""));
+
+                    //Determine minimal size buffer size, as 4 might not be sufficient.
+                    buffer_size = Math.max(extCsvData.numEntries(), buffer_size);
                 } else {
                     skippedExtras.add("csv");
                 }
@@ -284,7 +290,7 @@ public class ExtraInfoProcessor implements PathProcessor {
         if (!skippedExtras.isEmpty()) {
             skippedExtraInfo = String.join(", ", skippedExtras);
         }
-        buffer = new byte[4];
+        buffer = new byte[buffer_size];
     }
 
     /**


### PR DESCRIPTION
The hardcoded extra_info buffer size of 4 is not sufficient if csv extra info has more than 4 columns.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1436

### Information about the changes

The issue can be triggered by reading a csv file with 5 (or more) columns and requesting `"extra_info": ["csv"]`.
Then, when `ExtraInfoProcessor.processPathEdge` calls `CsvGraphStorage.getEdgeValue`, which in turn calls `RAMDataAccess.getBytes`, the latter tries to write `CsvGraphStorage.numEntries` values into `buffer` - which was only 4 bytes long.


### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
