### PR TITLE
refactor(RoutingProfile): move computeRoundTrip to RoutingRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ RELEASING:
 
 ### Added
 ### Changed
+- refactor: cleanup routing profile management ([#1850](https://github.com/GIScience/openrouteservice/pull/1850)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfileManager.java
@@ -198,7 +198,7 @@ public class RoutingProfileManager {
             bearing = searchParams.getBearings()[0];
         }
 
-        GHResponse gr = rp.computeRoundTripRoute(c0.y, c0.x, bearing, searchParams, req.getGeometrySimplify());
+        GHResponse gr = req.computeRoundTripRoute(c0.y, c0.x, bearing, searchParams, req.getGeometrySimplify(), rp);
 
         if (gr.hasErrors()) {
             if (!gr.getErrors().isEmpty()) {


### PR DESCRIPTION
This commit is part of the larger refactoring of RoutingProfile. All methods `compute*` should be moved into the apropritae Request class in order to enable better encapsulation and polymorphism.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

