### PR TITLE
fix: access to roads where transporting hazardous materials is forbidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ RELEASING:
 ### Deprecated
 ### Removed
 ### Fixed
+- access to roads where transporting hazardous materials is forbidden ([#1853](https://github.com/GIScience/openrouteservice/pull/1853))
 ### Security
 
 ## [8.1.3] - 2024-09-13

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/HeavyVehicleEdgeFilter.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/edgefilters/HeavyVehicleEdgeFilter.java
@@ -130,9 +130,9 @@ public class HeavyVehicleEdgeFilter implements DestinationDependentEdgeFilter {
 
                 if (!destinationEdges.contains(EdgeIteratorStateHelper.getOriginalEdge(edge))) {
                     int vt = gsHeavyVehicles.getEdgeVehicleType(EdgeIteratorStateHelper.getOriginalEdge(edge), buffer);
-                    boolean dstFlag = buffer[1] != 0; // ((buffer[1] >> (vehicleType >> 1)) & 1) == 1
+                    boolean dstFlag = buffer[1] != 0;
 
-                    if (((vt & vehicleType) == vehicleType) && (dstFlag))
+                    if (isVehicleType(vt, vehicleType) && (dstFlag))
                         destinationEdges.add(EdgeIteratorStateHelper.getOriginalEdge(edge));
                 }
 
@@ -148,22 +148,22 @@ public class HeavyVehicleEdgeFilter implements DestinationDependentEdgeFilter {
         int edgeId = EdgeIteratorStateHelper.getOriginalEdge(iter);
 
         int vt = gsHeavyVehicles.getEdgeVehicleType(edgeId, buffer);
-        boolean dstFlag = buffer[1] != 0; // ((buffer[1] >> (vehicleType >> 1)) & 1) == 1
+        boolean dstFlag = buffer[1] != 0;
 
         // if edge has some restrictions
         if (vt != HeavyVehicleAttributes.UNKNOWN) {
             if (mode == MODE_CLOSEST_EDGE) {
                 // current vehicle type is not forbidden
-                boolean edgeRestricted = ((vt & vehicleType) == vehicleType);
+                boolean edgeRestricted = isVehicleType(vt, vehicleType);
                 if ((edgeRestricted || dstFlag) && buffer[1] != vehicleType)
                     return false;
             } else if (mode == MODE_DESTINATION_EDGES) {
                 // Here we are looking for all edges that have destination
-                return dstFlag && ((vt & vehicleType) == vehicleType);
+                return dstFlag && isVehicleType(vt, vehicleType);
             } else {
                 // Check an edge with destination attribute
                 if (dstFlag) {
-                    if ((vt & vehicleType) == vehicleType) {
+                    if (isVehicleType(vt, vehicleType)) {
                         if (destinationEdges != null) {
                             if (!destinationEdges.contains(edgeId))
                                 return false;
@@ -171,7 +171,7 @@ public class HeavyVehicleEdgeFilter implements DestinationDependentEdgeFilter {
                             return false;
                     } else
                         return false;
-                } else if ((vt & vehicleType) == vehicleType)
+                } else if (isVehicleType(vt, vehicleType))
                     return false;
             }
         } else {
@@ -180,7 +180,7 @@ public class HeavyVehicleEdgeFilter implements DestinationDependentEdgeFilter {
             }
         }
 
-        if (hasHazmat && (vt & HeavyVehicleAttributes.HAZMAT) != 0) {
+        if (hasHazmat && isVehicleType(vt, HeavyVehicleAttributes.HAZMAT)) {
             return false;
         }
 
@@ -200,5 +200,9 @@ public class HeavyVehicleEdgeFilter implements DestinationDependentEdgeFilter {
             }
         }
         return true;
+    }
+
+    private boolean isVehicleType(int vt, int vehicleType) {
+        return (vt & vehicleType) == vehicleType;
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/HeavyVehicleAttributesGraphStorage.java
@@ -135,11 +135,11 @@ public class HeavyVehicleAttributesGraphStorage implements GraphExtension {
 
     public int getEdgeVehicleType(int edgeId, byte[] buffer) {
         long edgeBase = (long) edgeId * edgeEntryBytes;
-        orsEdges.getBytes(edgeBase + efVehicleType, buffer, 2);
+        orsEdges.getBytes(edgeBase + efVehicleType, buffer, 1);
 
         int result = buffer[0];
         if (result < 0)
-            result = (byte) (result & 0xff);
+            result = result & 0xFF;
 
         return result;
     }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1813

### Information about the changes
Fixes a phenomenon, where access to ways tagged with both `hazmat=no` and `maxheight` was blocked regardless of the corresponding query flag.

The reason for this bizarre behavior has been that the method which retrieves vehicle type value from the storage has been reading two consecutive bytes into a buffer mis-interpreting the second byte as a special type of destination flag. The flag, however, was removed from the storage a while ago, resulting in the value being set to the first byte of the numerical maxheight restriction. 

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
