### PR TITLE
fix: use a time-dependent algorithm only if the weighting requires it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,13 @@ RELEASING:
 7. Adding the corresponding tag is done when releasing via GitHub.
 -->
 ## [unreleased]
+### Fixed
+- do not enforce a time-dependent routing algorithm unless the weighting requires it ([#1865](https://github.com/GIScience/openrouteservice/pull/1865))
 
 ## [8.2.0] - 2024-10-09
-
 ### Added
-- added Vietnamese tranlations ([#1859](https://github.com/GIScience/openrouteservice/pull/1859))
-- added Finnish tranlations ([#1862](https://github.com/GIScience/openrouteservice/pull/1862))
+- Vietnamese translations ([#1859](https://github.com/GIScience/openrouteservice/pull/1859))
+- Finnish translations ([#1862](https://github.com/GIScience/openrouteservice/pull/1862))
 ### Changed
 - refactor: cleanup routing profile management ([#1850](https://github.com/GIScience/openrouteservice/pull/1850))
 - improved documentation on the configuration of external storages ([#1811](https://github.com/GIScience/openrouteservice/pull/1811))

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingRequest.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingRequest.java
@@ -390,8 +390,10 @@ public class RoutingRequest extends ServiceRequest {
 
             if (TemporaryUtilShelter.supportWeightingMethod(profileType)) {
                 ProfileTools.setWeightingMethod(req.getHints(), weightingMethod, profileType, TemporaryUtilShelter.hasTimeDependentSpeed(searchParams, searchCntx));
-                if (routingProfile.requiresTimeDependentWeighting(searchParams, searchCntx))
+                if (routingProfile.requiresTimeDependentWeighting(searchParams, searchCntx)) {
+                    req.setAlgorithm(Parameters.Algorithms.TD_ASTAR);
                     flexibleMode = ProfileTools.KEY_FLEX_PREPROCESSED;
+                }
                 flexibleMode = TemporaryUtilShelter.getFlexibilityMode(flexibleMode, searchParams, profileType);
             } else
                 throw new IllegalArgumentException("Unsupported weighting " + weightingMethod + " for profile + " + profileType);
@@ -410,8 +412,6 @@ public class RoutingRequest extends ServiceRequest {
                 routingProfile.setSpeedups(req, false, false, true, searchCntx.profileNameCH());
 
             if (searchParams.isTimeDependent()) {
-                req.setAlgorithm(Parameters.Algorithms.TD_ASTAR);
-
                 String key;
                 LocalDateTime time;
                 if (searchParams.hasDeparture()) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1856.

### Information about the changes

Change the logic such that a time-dependent routing algorithm is enforced based on the weighting being time-dependent rather than the presence of `departure`/`arrival` API parameters.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
