### PR TITLE
fix: failing queries that combine departure/arrival parameters with avoid areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ RELEASING:
 ## [unreleased]
 ### Fixed
 - do not enforce a time-dependent routing algorithm unless the weighting requires it ([#1865](https://github.com/GIScience/openrouteservice/pull/1865))
+- failing queries that combined departure/arrival parameters with avoid areas ([#1870](https://github.com/GIScience/openrouteservice/pull/1870))
 
 ## [8.2.0] - 2024-10-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ RELEASING:
 ## [unreleased]
 ### Fixed
 - do not enforce a time-dependent routing algorithm unless the weighting requires it ([#1865](https://github.com/GIScience/openrouteservice/pull/1865))
-- failing queries that combined departure/arrival parameters with avoid areas ([#1870](https://github.com/GIScience/openrouteservice/pull/1870))
+- failing queries that combined departure/arrival parameters with avoid polygons ([#1871](https://github.com/GIScience/openrouteservice/pull/1871))
 
 ## [8.2.0] - 2024-10-09
 ### Added

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -643,14 +643,19 @@ public class RoutingProfile {
         }
     }
 
-    boolean requiresTimeDependentWeighting(RouteSearchParameters searchParams, RouteSearchContext searchCntx) {
+    boolean requiresTimeDependentAlgorithm(RouteSearchParameters searchParams, RouteSearchContext searchCntx) {
         if (!searchParams.isTimeDependent())
             return false;
 
         FlagEncoder flagEncoder = searchCntx.getEncoder();
 
-        return flagEncoder.hasEncodedValue(EncodingManager.getKey(flagEncoder, ConditionalEdges.ACCESS))
-                || flagEncoder.hasEncodedValue(EncodingManager.getKey(flagEncoder, ConditionalEdges.SPEED))
+        if (flagEncoder.hasEncodedValue(EncodingManager.getKey(flagEncoder, ConditionalEdges.ACCESS)))
+            return true;
+
+        if (WeightingMethod.SHORTEST==searchParams.getWeightingMethod())
+            return false;
+
+        return flagEncoder.hasEncodedValue(EncodingManager.getKey(flagEncoder, ConditionalEdges.SPEED))
                 || mGraphHopper.isTrafficEnabled();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
 
         <!-- switch graphhopper versions to enable debugging -->
-        <graphhopper.version>v4.9.3</graphhopper.version>
-        <!--graphhopper.version>v4.9-SNAPSHOT</graphhopper.version-->
+        <graphhopper.version>v4.9.4</graphhopper.version>
+        <!--graphhopper.version>4.9-SNAPSHOT</graphhopper.version-->
         <springdoc-openapi-starter.version>2.6.0</springdoc-openapi-starter.version>
         <swagger-parser.version>2.1.22</swagger-parser.version>
         <snakeyaml.version>2.2</snakeyaml.version>


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes externally reported issue.

**IMPORTANT: requires GH version that includes https://github.com/GIScience/graphhopper/pull/98**

### Information about the changes
- Reason for change: queries that combined routing parameters `departure` or `arrival` with `avoid_areas` failed with

```
[2099] Unable to compute a route
```

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
