### PR TITLE
fix: matrix limit not respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ RELEASING:
 ### Fixed
 - do not enforce a time-dependent routing algorithm unless the weighting requires it ([#1865](https://github.com/GIScience/openrouteservice/pull/1865))
 - failing queries that combined departure/arrival parameters with avoid polygons ([#1871](https://github.com/GIScience/openrouteservice/pull/1871))
+- matrix limit ignored for explicit 'all' value in sources or destinations([#1875](https://github.com/GIScience/openrouteservice/pull/1875))
 
 ## [8.2.0] - 2024-10-09
 ### Added

--- a/ors-api/src/main/java/org/heigit/ors/api/services/MatrixService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/MatrixService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.heigit.ors.api.requests.matrix.MatrixRequest.isFlexibleMode;
 
@@ -55,8 +56,10 @@ public class MatrixService extends ApiService {
                 endpointsProperties.getMatrix().getMaximumVisitedNodes(),
                 endpointsProperties.getMatrix().getUTurnCost());
 
-        int numberOfSources = matrixRequest.getSources() == null ? matrixRequest.getLocations().size() : matrixRequest.getSources().length;
-        int numberODestinations = matrixRequest.getDestinations() == null ? matrixRequest.getLocations().size() : matrixRequest.getDestinations().length;
+        String[] sources = matrixRequest.getSources();
+        int numberOfSources = sources == null || Objects.equals(sources[0], "all") ? matrixRequest.getLocations().size() : sources.length;
+        String[] destinations = matrixRequest.getDestinations();
+        int numberODestinations = destinations == null || Objects.equals(destinations[0], "all") ? matrixRequest.getLocations().size() : destinations.length;
         Coordinate[] locations = convertLocations(matrixRequest.getLocations(), numberOfSources * numberODestinations, endpointsProperties);
 
         coreRequest.setProfileType(convertToMatrixProfileType(matrixRequest.getProfile()));

--- a/ors-api/src/test/java/org/heigit/ors/apitests/matrix/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/matrix/ParamsTest.java
@@ -321,6 +321,26 @@ class ParamsTest extends ServiceTest {
     }
 
     @Test
+    void expect4006004AllAll() {
+
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("maximumLocations"));
+        body.put("sources", getParameter("sourcesAll"));
+        body.put("destinations", getParameter("destinationsAll"));
+
+        given()
+                .headers(jsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then()
+                .assertThat()
+                .body("error.code", Matchers.is(MatrixErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM))
+                .statusCode(400);
+    }
+
+    @Test
     void expectResolveLocations() {
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations"));


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

### Information about the changes
- Key functionality added: fixed matrix 'maximum_route' limit for explicit 'all' in destiantions and/or sources
- Reason for change: matrix requests could circumvent the route limit as 'all' was counted as single entry during the check

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
