### PR TITLE
test: compare dates instead of date.toString()

### DIFF
--- a/ors-api/src/test/java/org/heigit/ors/apitests/ORSStartupTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/ORSStartupTest.java
@@ -8,17 +8,21 @@ import org.heigit.ors.routing.RoutingProfileManager;
 import org.heigit.ors.routing.graphhopper.extensions.manage.GraphInfo;
 import org.junit.jupiter.api.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ORSStartupTest extends ServiceTest {
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+
     @Test
-    void testGraphInfoFilesWrittenCorrectly() {
+    void testGraphInfoFilesWrittenCorrectly() throws ParseException {
         RoutingProfileManager rpm = RoutingProfileManager.getInstance();
         RoutingProfile profile = rpm.getRoutingProfile(EncoderNameEnum.DRIVING_CAR.getName());
         GraphInfo graphInfo = profile.getGraphhopper().getOrsGraphManager().getActiveGraphInfo();
         ProfileProperties profileProperties = graphInfo.getPersistedGraphInfo().getProfileProperties();
-
-        assertEquals("Sun Sep 08 22:21:00 CEST 2024", graphInfo.getPersistedGraphInfo().getOsmDate().toString(), "graph_info should contain OSM data timestamp");
+        assertEquals(dateFormat.parse("2024-09-08T20:21:00+0000"), graphInfo.getPersistedGraphInfo().getOsmDate(), "graph_info should contain OSM data timestamp");
         assertEquals(EncoderNameEnum.DRIVING_CAR, profileProperties.getEncoderName(), "Encoder name should be set in the graph_info");
         assertTrue(profileProperties.getBuild().getElevation(), "Elevation should be set in the graph_info");
         assertNull(profileProperties.getService().getMaximumDistance(), "Maximum distance should not be set in the graph_info");


### PR DESCRIPTION
the latter is flaky because the format depends on local locale, time zone etc.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
