### PR TITLE
fix: Implicit vehicle access handling for ferries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ RELEASING:
 - NPE in error handling ([#1925](https://github.com/GIScience/openrouteservice/pull/1925))
 - Add missing 'build' in documentation for profile
   properties ([#1947](https://github.com/GIScience/openrouteservice/issues//1947))
-- implicit vehicle access handling for ferries
+- Allow vehicles on ferries without explicit access tags ([#1954](https://github.com/GIScience/openrouteservice/pull/1954))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ RELEASING:
 - NPE in error handling ([#1925](https://github.com/GIScience/openrouteservice/pull/1925))
 - Add missing 'build' in documentation for profile
   properties ([#1947](https://github.com/GIScience/openrouteservice/issues//1947))
+- implicit vehicle access handling for ferries
 
 ### Security
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/CarFlagEncoder.java
@@ -81,10 +81,13 @@ public class CarFlagEncoder extends VehicleFlagEncoder {
                 for (String restrictionValue : restrictionValues) {
                     if (restrictedValues.contains(restrictionValue))
                         return EncodingManager.Access.CAN_SKIP;
-                    if (intendedValues.contains(restrictionValue) ||
-                            // implied default is allowed only if foot and bicycle is not specified:
-                            restrictionValue.isEmpty() && !way.hasTag("foot") && !way.hasTag("bicycle"))
+                    if (intendedValues.contains(restrictionValue))
                         return EncodingManager.Access.FERRY;
+                }
+
+                // implied default is allowed only if foot and bicycle is not specified:
+                if (restrictionValues.length == 0 && !way.hasTag("foot") && !way.hasTag("bicycle")) {
+                    return EncodingManager.Access.FERRY;
                 }
             }
             return EncodingManager.Access.CAN_SKIP;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -165,10 +165,10 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
                     if (intendedValues.contains(restrictionValue))
                         return EncodingManager.Access.FERRY;
                 }
-            }
-            // implied default is allowed only if foot and bicycle is not specified:
-            if (restrictionValues.length == 0 && !way.hasTag("foot") && !way.hasTag("bicycle")) {
-                        return EncodingManager.Access.FERRY;
+                // implied default is allowed only if foot and bicycle is not specified:
+                if (restrictionValues.length == 0 && !way.hasTag("foot") && !way.hasTag("bicycle")) {
+                    return EncodingManager.Access.FERRY;
+                }
             }
             return EncodingManager.Access.CAN_SKIP;
         }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -162,11 +162,13 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
                 for (String restrictionValue : restrictionValues) {
                     if (restrictedValues.contains(restrictionValue))
                         return EncodingManager.Access.CAN_SKIP;
-                    if (intendedValues.contains(restrictionValue) ||
-                            // implied default is allowed only if foot and bicycle is not specified:
-                            restrictionValue.isEmpty() && !way.hasTag("foot") && !way.hasTag("bicycle"))
+                    if (intendedValues.contains(restrictionValue))
                         return EncodingManager.Access.FERRY;
                 }
+            }
+            // implied default is allowed only if foot and bicycle is not specified:
+            if (restrictionValues.length == 0 && !way.hasTag("foot") && !way.hasTag("bicycle")) {
+                        return EncodingManager.Access.FERRY;
             }
             return EncodingManager.Access.CAN_SKIP;
         }

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoderTest.java
@@ -1,0 +1,96 @@
+package org.heigit.ors.routing.graphhopper.extensions.flagencoders;
+
+import com.graphhopper.config.Profile;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.WeightingFactory;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.GHUtility;
+import com.graphhopper.util.PMap;
+import org.heigit.ors.routing.graphhopper.extensions.ORSDefaultFlagEncoderFactory;
+import org.heigit.ors.routing.graphhopper.extensions.ORSWeightingFactory;
+import org.heigit.ors.routing.graphhopper.extensions.weighting.LimitedAccessWeighting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HeavyVehicleFlagEncoderTest {
+    private final EncodingManager em = EncodingManager.create(new ORSDefaultFlagEncoderFactory(), FlagEncoderNames.HEAVYVEHICLE + "," + FlagEncoderNames.BIKE_ORS);
+    private ReaderWay way;
+
+    static final double WAY_DISTANCE = 1000;
+    static final double HEAVYVEHICLE_DURATION = 180;
+    static final double BIKE_DURATION = 300;
+
+    @BeforeEach
+    void initWay() {
+        way = new ReaderWay(1);
+    }
+
+    Weighting createWeighting(String vehicle, String weighting) {
+        GraphHopperStorage g = new GraphBuilder(em).create();
+        WeightingFactory weightingFactory = new ORSWeightingFactory(g, em);
+
+        Profile profile = new Profile(vehicle + "_" + weighting).setVehicle(vehicle).setWeighting(weighting);
+
+        return weightingFactory.createWeighting(profile, new PMap(), false);
+    }
+
+    private ReaderWay generateFerryWay() {
+        way.getTags().put("route", "ferry");
+        return way;
+    }
+    @Test
+    void testDestinationTag() {
+        IntsRef relFlags = em.createRelationFlags();
+
+        Weighting hgvFastest = createWeighting(FlagEncoderNames.HEAVYVEHICLE, "fastest");
+        Weighting bikeFastest = createWeighting(FlagEncoderNames.BIKE_ORS, "fastest");
+
+        way.setTag("highway", "road");
+        EncodingManager.AcceptWay acceptWay = new EncodingManager.AcceptWay();
+        assertTrue(em.acceptWay(way, acceptWay));
+        IntsRef edgeFlags = em.handleWayTags(way, acceptWay, relFlags);
+        assertEquals(HEAVYVEHICLE_DURATION, hgvFastest.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(WAY_DISTANCE, edgeFlags), false), 0.1);
+        assertEquals(BIKE_DURATION, bikeFastest.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(WAY_DISTANCE, edgeFlags), false), 0.1);
+
+        way.setTag("motor_vehicle", "destination");
+        edgeFlags = em.handleWayTags(way, acceptWay, relFlags);
+        assertEquals(HEAVYVEHICLE_DURATION * LimitedAccessWeighting.VEHICLE_DESTINATION_FACTOR, hgvFastest.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(WAY_DISTANCE, edgeFlags), false), 0.1);
+        assertEquals(BIKE_DURATION * LimitedAccessWeighting.DEFAULT_DESTINATION_FACTOR, bikeFastest.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(WAY_DISTANCE, edgeFlags), false), 0.1);
+
+        Weighting carShortest = createWeighting(FlagEncoderNames.HEAVYVEHICLE, "shortest");
+        Weighting bikeShortest = createWeighting(FlagEncoderNames.BIKE_ORS, "shortest");
+
+        edgeFlags = em.handleWayTags(way, acceptWay, relFlags);
+        assertEquals(WAY_DISTANCE * LimitedAccessWeighting.VEHICLE_DESTINATION_FACTOR, carShortest.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(WAY_DISTANCE, edgeFlags), false), 0.1);
+        assertEquals(WAY_DISTANCE * LimitedAccessWeighting.DEFAULT_DESTINATION_FACTOR, bikeShortest.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(WAY_DISTANCE, edgeFlags), false), 0.1);
+    }
+
+    @Test
+    void testFerryTag() {
+        way = generateFerryWay();
+        HeavyVehicleFlagEncoder flagEncoder = (HeavyVehicleFlagEncoder) em.getEncoder(FlagEncoderNames.HEAVYVEHICLE);
+        // motor_vehicle = no -> reject
+        way.getTags().put("motor_vehicle", "no");
+        assertTrue(flagEncoder.getAccess(way).canSkip());
+
+        // foot = * -> reject
+        way.getTags().remove("motor_vehicle");
+        way.getTags().put("foot", "no");
+        assertTrue(flagEncoder.getAccess(way).canSkip());
+
+        way.getTags().replace("foot", "yes");
+        assertTrue(flagEncoder.getAccess(way).canSkip());
+
+        // only ferry flag -> accept
+        way.getTags().remove("foot");
+        assertTrue(flagEncoder.getAccess(way).isFerry());
+    }
+
+}


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.


Not sure if there are any cases that would be covered by the `or`-part of the original if-statement that are *not* caught by the new statement…

One would probably have to change `hgv` as well, I think?


### Information about the changes
- Key functionality added: Use ferries that do not have any general or vehicle-specific access tag (such as `foot`, `motorcar`, `access`, …), but only the `route=ferry` tag.
- Reason for change: According to the [tag filtering logic](https://giscience.github.io/openrouteservice/technical-details/tag-filtering) we accept these ways, which I think makes sense.
Whether it makes sense to only do that if `foot` or `bike` are absent, I don't know…

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
[This route](https://classic-maps.openrouteservice.org/directions?n1=58.238978&n2=6.621854&n3=17&a=58.241759,6.631633,58.236431,6.612058&b=0&c=0&k1=en-US&k2=km) using [such a ferry](https://www.openstreetmap.org/way/28251389/) in norway will now be available.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
