### PR TITLE
fix: ORS_CONFIG_LOCATION not logging with wrong paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Releasing is documented in RELEASE.md
 - NPE in error handling ([#1925](https://github.com/GIScience/openrouteservice/pull/1925))
 - Add missing 'build' in documentation for profile properties ([#1947](https://github.com/GIScience/openrouteservice/issues//1947))
 - Allow vehicles on ferries without explicit access tags ([#1954](https://github.com/GIScience/openrouteservice/pull/1954))
+- ORS_CONFIG_LOCATION doesn't log with wrong paths ([#1816](https://github.com/GIScience/openrouteservice/issues/1816))
 
 ## [9.0.0] - 2024-12-02
 ### Added

--- a/ors-api/src/main/java/org/heigit/ors/api/ORSEnvironmentPostProcessor.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/ORSEnvironmentPostProcessor.java
@@ -12,6 +12,7 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.FileSystemResource;
 
 import java.io.IOException;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -42,8 +43,18 @@ public class ORSEnvironmentPostProcessor implements EnvironmentPostProcessor {
             log.info("Configuration file set by program argument.");
         }
         if (configLocations.isEmpty() && !StringUtility.isNullOrEmpty(System.getenv(ORS_CONFIG_LOCATION_ENV))) {
-            configLocations.add(System.getenv(ORS_CONFIG_LOCATION_ENV));
-            log.info("Configuration file set by environment variable.");
+            String configPath = System.getenv(ORS_CONFIG_LOCATION_ENV);
+            File configFile = new File(configPath);
+            // Check if the file exists and log the appropriate message
+            if (configFile.exists()) {
+                log.info("ORS config file found at: " + configFile.getAbsolutePath());
+                configLocations.add(configPath);
+                log.info("Configuration file set by environment variable.");
+            } else {
+                // Add it anyway to provoke error and stop ORS
+                configLocations.add(configPath);
+                log.error("ORS config file not found at: " + configPath);
+            }
         }
         if (configLocations.isEmpty()) {
             String home = System.getProperty("user.home");

--- a/ors-test-scenarios/src/test/java/integrationtests/ConfigEnvironmentTest.java
+++ b/ors-test-scenarios/src/test/java/integrationtests/ConfigEnvironmentTest.java
@@ -215,7 +215,7 @@ public class ConfigEnvironmentTest extends ContainerInitializer {
                 Assertions.assertTrue(logs.contains("ORS config file not found at: nonexistent/ors-config.yaml"));
 
             } catch (ContainerLaunchException e) {
-
+                // Pass when throwing this exception since the container is supposed to fail when the config path is wrong.
             } catch (Exception e) {
                 Assertions.fail("Container startup failed with exception: " + e.getMessage());
             } finally {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Closes #1816 .

### Information about the changes
- Key functionality added: When a wrong path is set as ORS_CONFIG_LOCATION, this is now no longer silently ignored, but logged.
- Reason for change: Better logging.

The WAR_CONTAINER test is still failing because `ors.config.location` is set in the `war.Dockerfile`:
https://github.com/GIScience/openrouteservice/blob/a0bc59b9b9eaf4eca6785a9ee56b89def30fa3ae/ors-test-scenarios/src/test/resources/war.Dockerfile#L16

I am yet to figure out how to fix this.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
- None

### Required changes to ors config (if applicable)
- None

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
