### PR TITLE
docs: add release documentation to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,56 @@ This is how a Changelog entry should look like:
 - in case of vulnerabilities. (Use for vulnerability fixes)
 
 RELEASING:
-1. Change unreleased to new release number
-2. Add today's Date
-3. Change unreleased link to compare new release:
-[unreleased]: https://github.com/GIScience/openrouteservice/compare/vnew...HEAD
-4. Add new compare link below
-[new]: https://github.com/GIScience/openrouteservice/compare/vlast...vnew
-5. Double check issue links are valid
-6. Add [unreleased] section with all subsections as above
-7. Adding the corresponding tag is done when releasing via GitHub.
+1. Check that
+   - all relevant PRs are merged
+   - documentation is up-to-date
+   - CHANGELOG is up-to-date
+   - if major version release: release notes for announcement/blog is ready
+2. Create a Release branch named releases/vX.X.X and
+   a. Update CHANGELOG.md as follows:
+      1. Change unreleased to new release number
+      2. Add today's Date
+      3. Change unreleased link to compare new release:
+         [unreleased]: https://github.com/GIScience/openrouteservice/compare/vnew...HEAD
+      4. Add new compare link below
+         [new]: https://github.com/GIScience/openrouteservice/compare/vlast...vnew
+      5. Double check issue links are valid
+      6. Add [unreleased] section with all subsections as above
+   b. Update version numbers in POM using
+      mvn versions:set -DnewVersion=X.X.X
+      or setting it manually in the main and all child POMs
+   c. Commit changes as chore or build, and push
+   d. Open and merge PR as
+      chore: release vX.X.X
+3. Draft a new release on Github
+   Generate release notes automagically and curate by hand
+   This also creates the new vX.X.X tag.
+4. Check that the following assests exists, after the workflows have finished:
+   - docker-compose.yml (using the new version)
+   - ors-config.env
+   - ors-config.yml
+   - ors.jar
+   - ors.war
+   - Source code (zip)
+   - Source code (tar.gz)
+5. Check that docker images were created correctly:
+   - vX.X.X should now exist
+   - latest should point to the new image
+   - v<major> should point to the new image
+6. Change latest and v<major> tags:
+   a. Delete tags on github
+   b. Delete tags locally:
+      - git tag -d latest
+      - git tag -d v<major>
+   c. Re-create tags locally on the new main HEAD
+      - git tag latest
+      - git tag v<major>
+   d. Push new tags
+      - git push origin tag latest
+      - git push origin tag v<major>
+7. Update version in POMs to X.Y.Z-SNAPSHOT using
+   mvn versions:set -DnewVersion=X.Y.Z-SNAPSHOT
+8. Check whether outreach, announcement, … is necessary and do so.
 -->
 ## [unreleased]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,56 +22,7 @@ This is how a Changelog entry should look like:
 - in case of vulnerabilities. (Use for vulnerability fixes)
 
 RELEASING:
-1. Check that
-   - all relevant PRs are merged
-   - documentation is up-to-date
-   - CHANGELOG is up-to-date
-   - if major version release: release notes for announcement/blog is ready
-2. Create a Release branch named releases/vX.X.X and
-   a. Update CHANGELOG.md as follows:
-      1. Change unreleased to new release number
-      2. Add today's Date
-      3. Change unreleased link to compare new release:
-         [unreleased]: https://github.com/GIScience/openrouteservice/compare/vnew...HEAD
-      4. Add new compare link below
-         [new]: https://github.com/GIScience/openrouteservice/compare/vlast...vnew
-      5. Double check issue links are valid
-      6. Add [unreleased] section with all subsections as above
-   b. Update version numbers in POM using
-      mvn versions:set -DnewVersion=X.X.X
-      or setting it manually in the main and all child POMs
-   c. Commit changes as chore or build, and push
-   d. Open and merge PR as
-      chore: release vX.X.X
-3. Draft a new release on Github
-   Generate release notes automagically and curate by hand
-   This also creates the new vX.X.X tag.
-4. Check that the following assests exists, after the workflows have finished:
-   - docker-compose.yml (using the new version)
-   - ors-config.env
-   - ors-config.yml
-   - ors.jar
-   - ors.war
-   - Source code (zip)
-   - Source code (tar.gz)
-5. Check that docker images were created correctly:
-   - vX.X.X should now exist
-   - latest should point to the new image
-   - v<major> should point to the new image
-6. Change latest and v<major> tags:
-   a. Delete tags on github
-   b. Delete tags locally:
-      - git tag -d latest
-      - git tag -d v<major>
-   c. Re-create tags locally on the new main HEAD
-      - git tag latest
-      - git tag v<major>
-   d. Push new tags
-      - git push origin tag latest
-      - git push origin tag v<major>
-7. Update version in POMs to X.Y.Z-SNAPSHOT using
-   mvn versions:set -DnewVersion=X.Y.Z-SNAPSHOT
-8. Check whether outreach, announcement, … is necessary and do so.
+Releasing is documented in RELEASE.md
 -->
 ## [unreleased]
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,50 @@
+1. Check that
+   - all relevant PRs are merged
+   - documentation is up-to-date
+   - CHANGELOG is up-to-date
+   - if major version release: release notes for announcement/blog is ready
+2. Create a Release branch named releases/vX.X.X and
+   a. Update CHANGELOG.md as follows:
+      1. Change unreleased to new release number
+      2. Add today's Date
+      3. Change unreleased link to compare new release:
+         [unreleased]: https://github.com/GIScience/openrouteservice/compare/vnew...HEAD
+      4. Add new compare link below
+         [new]: https://github.com/GIScience/openrouteservice/compare/vlast...vnew
+      5. Double check issue links are valid
+      6. Add [unreleased] section with all subsections as above
+   b. Update version numbers in POM using
+      mvn versions:set -DnewVersion=X.X.X
+      or setting it manually in the main and all child POMs
+   c. Commit changes as chore or build, and push
+   d. Open and merge PR as
+      chore: release vX.X.X
+3. Draft a new release on Github
+   Generate release notes automagically and curate by hand
+   This also creates the new vX.X.X tag.
+4. Check that the following assests exists, after the workflows have finished:
+   - docker-compose.yml (using the new version)
+   - ors-config.env
+   - ors-config.yml
+   - ors.jar
+   - ors.war
+   - Source code (zip)
+   - Source code (tar.gz)
+5. Check that docker images were created correctly:
+   - vX.X.X should now exist
+   - latest should point to the new image
+   - v<major> should point to the new image
+6. Change latest and v<major> tags:
+   a. Delete tags on github
+   b. Delete tags locally:
+      - git tag -d latest
+      - git tag -d v<major>
+   c. Re-create tags locally on the new main HEAD
+      - git tag latest
+      - git tag v<major>
+   d. Push new tags
+      - git push origin tag latest
+      - git push origin tag v<major>
+7. Update version in POMs to X.Y.Z-SNAPSHOT using
+   mvn versions:set -DnewVersion=X.Y.Z-SNAPSHOT
+8. Check whether outreach, announcement, … is necessary and do so.


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
