### PR TITLE
fix: Repair broken integration tests with by pining buildkit 0.15

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,6 +53,8 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.15.0 # Fix to v0.15.0. Testcontainers has issues with the latest version.
       - name: Prepare the maven cache dependencies
         run: |
           echo "Sync the maven dependencies"
@@ -151,6 +153,8 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.15.0 # Fix to v0.15.0. Testcontainers has issues with the latest version.
       - name: inject maven-build-cache into docker
         uses: reproducible-containers/buildkit-cache-dance@v3.1.2
         with:
@@ -194,5 +198,6 @@ jobs:
           docker image ls -a
           # Run only a subset for now
           mvn -pl ors-test-scenarios -Dtest=${{ matrix.test-class }} test \
+            -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4 \
             -Dcontainer.run.scenario=${{ matrix.test-scenario }} \
             -Dcontainer.builder.use_prebuild=true -q

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -5,10 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    paths:
-      - pom.xml
-      - '**/pom.xml'
-      - Dockerfile
   schedule:
     - cron: '0 0 * * MON'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Releasing is documented in RELEASE.md
 ### Removed
 
 ### Fixed
+- fix: Repair broken integration tests with by pining buildkit 0.15 ([#2003](https://github.com/GIScience/openrouteservice/pull/2003))
 
 ### Security
 

--- a/ors-test-scenarios/src/test/java/integrationtests/ConfigLookupTest.java
+++ b/ors-test-scenarios/src/test/java/integrationtests/ConfigLookupTest.java
@@ -1,7 +1,6 @@
 package integrationtests;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -265,32 +264,6 @@ public class ConfigLookupTest extends ContainerInitializer {
             ).toArray(new String[0])));
             container.start();
             OrsApiHelper.assertProfilesLoaded(container, Map.of("cycling-road", true));
-            container.stop();
-        }
-
-        /**
-         * ors-config-location-to-nonexisting-file.sh
-         * The profile configured as run argument should be preferred over environment variable.
-         * The default yml file should not be used when ORS_CONFIG_LOCATION is set,
-         * even if the file does not exist. Fallback to default ors-config.yml is not desired!
-         */
-        @Disabled
-        @MethodSource("utils.ContainerInitializer#ContainerTestImageBareImageStream")
-        @ParameterizedTest(name = "{0}")
-        @Execution(ExecutionMode.CONCURRENT)
-        void testOrsConfigLocationToNonExistingFile(ContainerInitializer.ContainerTestImageBare targetImage) {
-            GenericContainer<?> container = initContainer(targetImage, false, "testOrsConfigLocationToNonExistingFile");
-            container.setCommand(targetImage.getCommand("200M").toArray(new String[0]));
-            container.addEnv("ORS_CONFIG_LOCATION", "/home/ors/openrouteservice/ors-config-that-does-not-exist.yml");
-            container.waitingFor(waitStrategyWithLogMessage(List.of(
-                    "Configuration lookup started.",
-                    "Configuration file set by environment variable.",
-                    "Config file '/home/ors/openrouteservice/ors-config-that-does-not-exist.yml' not found.",
-                    "Configuration lookup finished.",
-                    "No profiles configured. Exiting."
-            ).toArray(new String[0])));
-            container.start();
-            Assertions.assertTrue(container.isRunning());
             container.stop();
         }
     }

--- a/ors-test-scenarios/src/test/java/utils/ContainerInitializer.java
+++ b/ors-test-scenarios/src/test/java/utils/ContainerInitializer.java
@@ -41,7 +41,7 @@ public abstract class ContainerInitializer {
     // @formatter:on
 
     private static final Path hostSharedGraphPath = Path.of("./graphs-integrationtests/").resolve("sharedGraphMount");
-    public static Duration defaultStartupTimeout = Duration.ofSeconds(100);
+    public static Duration defaultStartupTimeout = Duration.ofSeconds(180);
     private static boolean shareGraphsWithContainer = true;
     private static List<ContainerTestImageDefaults> selectedDefaultContainers = List.of();
     private static List<ContainerTestImageBare> selectedBareContainers = List.of();
@@ -55,7 +55,6 @@ public abstract class ContainerInitializer {
         parentLogger.info("Container scenario: {}", containerValue);
         shareGraphsWithContainer = Boolean.parseBoolean(System.getProperty("container.run.share_graphs", "true"));
         parentLogger.info("Share graphs with container: {}", shareGraphsWithContainer);
-        if (shareGraphsWithContainer) defaultStartupTimeout = Duration.ofSeconds(50);
         switch (containerValue) {
             case "war":
                 selectedDefaultContainers = List.of(ContainerTestImageDefaults.WAR_CONTAINER);
@@ -183,6 +182,7 @@ public abstract class ContainerInitializer {
                 .withEnv(defaultEnv)
                 .withExposedPorts(8080)
                 .withStartupTimeout(startupTimeout)
+                .withStartupAttempts(3)
                 .waitingFor(healthyOrsWaitStrategy());
         // @formatter:on
 
@@ -211,13 +211,63 @@ public abstract class ContainerInitializer {
     }
 
     static void buildBuilderImages() {
-        initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_BUILDER);
-        // Asynchronous start the rest and wait at the end until all are finished.
-        CompletableFuture<Void> warFuture = CompletableFuture.runAsync(() -> initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_WAR_BUILDER));
-        CompletableFuture<Void> jarFuture = CompletableFuture.runAsync(() -> initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_JAR_BUILDER));
-        CompletableFuture<Void> mavenFuture = CompletableFuture.runAsync(() -> initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_MAVEN_BUILDER));
-        // Wait for all
-        CompletableFuture.allOf(warFuture, jarFuture, mavenFuture).join();
+        parentLogger.info("Starting builder image initialization");
+        try {
+            // Initialize the base builder first
+            parentLogger.info("Initializing base builder image");
+            initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_BUILDER);
+
+            // Create a list to store all futures for better tracking
+            List<CompletableFuture<Void>> buildFutures = new ArrayList<>();
+
+            // Asynchronous start the rest with proper error handling for each
+            CompletableFuture<Void> warFuture = CompletableFuture
+                    .runAsync(() -> {
+                        parentLogger.info("Starting WAR builder image initialization");
+                        initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_WAR_BUILDER);
+                        parentLogger.info("WAR builder image initialized successfully");
+                    })
+                    .exceptionally(ex -> {
+                        parentLogger.error("Failed to initialize WAR builder image: {}", ex.getMessage(), ex);
+                        throw new RuntimeException("WAR builder initialization failed", ex);
+                    });
+            buildFutures.add(warFuture);
+
+            CompletableFuture<Void> jarFuture = CompletableFuture
+                    .runAsync(() -> {
+                        parentLogger.info("Starting JAR builder image initialization");
+                        initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_JAR_BUILDER);
+                        parentLogger.info("JAR builder image initialized successfully");
+                    })
+                    .exceptionally(ex -> {
+                        parentLogger.error("Failed to initialize JAR builder image: {}", ex.getMessage(), ex);
+                        throw new RuntimeException("JAR builder initialization failed", ex);
+                    });
+            buildFutures.add(jarFuture);
+
+            CompletableFuture<Void> mavenFuture = CompletableFuture
+                    .runAsync(() -> {
+                        parentLogger.info("Starting MAVEN builder image initialization");
+                        initBuilderImage(ContainterBuildStage.ORS_TEST_SCENARIO_MAVEN_BUILDER);
+                        parentLogger.info("MAVEN builder image initialized successfully");
+                    })
+                    .exceptionally(ex -> {
+                        parentLogger.error("Failed to initialize MAVEN builder image: {}", ex.getMessage(), ex);
+                        throw new RuntimeException("MAVEN builder initialization failed", ex);
+                    });
+            buildFutures.add(mavenFuture);
+
+            // Wait for all with a timeout
+            CompletableFuture
+                    .allOf(buildFutures.toArray(new CompletableFuture[0]))
+                    .orTimeout(5, java.util.concurrent.TimeUnit.MINUTES)
+                    .join();
+
+            parentLogger.info("All builder images initialized successfully");
+        } catch (Exception e) {
+            parentLogger.error("Failed to initialize builder images: {}", e.getMessage(), e);
+            throw new RuntimeException("Builder images initialization failed", e);
+        }
     }
 
     @BeforeAll

--- a/ors-test-scenarios/src/test/resources/junit-platform.properties
+++ b/ors-test-scenarios/src/test/resources/junit-platform.properties
@@ -2,4 +2,4 @@ junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.config.fixed.parallelism=1

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <jupiter.version>5.11.4</jupiter.version>
         <mockito.version>5.12.0</mockito.version>
         <rest-assured.version>5.5.0</rest-assured.version>
-        <testcontainers.version>1.20.4</testcontainers.version>
+        <testcontainers.version>1.20.6</testcontainers.version>
         <mockito-core-version>3.12.4</mockito-core-version>
         <javax.ws.rs-api-version>2.1.1</javax.ws.rs-api-version>
         <jsr311-api-version>1.1.1</jsr311-api-version>


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].


### Information about the changes
- Key functionality added: Fix buildkit version for testcontainers run to 0.15
- Reason for change: Testcontainers cannot handle the current buildkit version 0.20 at the moment. Therefore the ors-test-scenarios were failing.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
