### PR TITLE
fix: make gpx response adhere to standard and set version to 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Releasing is documented in RELEASE.md
 - pass extra_info when querying round_trip ([#1976](https://github.com/GIScience/openrouteservice/issues/1976))
 - repair broken integration tests with by pining buildkit 0.15 ([#2003](https://github.com/GIScience/openrouteservice/pull/2003))
 - elevation set to false not taken into account ([#1967](https://github.com/GIScience/openrouteservice/issues/1967))
+- make gpx response adhere to standard and set version to 1.1 ([#2004](https://github.com/GIScience/openrouteservice/issues/2004))
 
 ### Security
 

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXBounds.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXBounds.java
@@ -17,10 +17,12 @@ package org.heigit.ors.api.responses.routing.gpx;
 
 import com.graphhopper.util.shapes.BBox;
 import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.heigit.ors.api.responses.common.boundingbox.BoundingBox;
 import org.heigit.ors.api.responses.common.boundingbox.BoundingBoxBase;
 import org.heigit.ors.util.FormatUtility;
 
+@XmlRootElement
 public class GPXBounds extends BoundingBoxBase implements BoundingBox {
     public GPXBounds() {
         super();
@@ -31,25 +33,25 @@ public class GPXBounds extends BoundingBoxBase implements BoundingBox {
     }
 
     @Override
-    @XmlAttribute(name = "minLat")
+    @XmlAttribute(name = "minlat")
     public double getMinLat() {
         return FormatUtility.roundToDecimals(this.minLat, COORDINATE_DECIMAL_PLACES);
     }
 
     @Override
-    @XmlAttribute(name = "minLon")
+    @XmlAttribute(name = "minlon")
     public double getMinLon() {
         return FormatUtility.roundToDecimals(this.minLon, COORDINATE_DECIMAL_PLACES);
     }
 
     @Override
-    @XmlAttribute(name = "maxLat")
+    @XmlAttribute(name = "maxlat")
     public double getMaxLat() {
         return FormatUtility.roundToDecimals(this.maxLat, COORDINATE_DECIMAL_PLACES);
     }
 
     @Override
-    @XmlAttribute(name = "maxLon")
+    @XmlAttribute(name = "maxlon")
     public double getMaxLon() {
         return FormatUtility.roundToDecimals(this.maxLon, COORDINATE_DECIMAL_PLACES);
     }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponse.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class GPXRouteResponse extends RouteResponse {
 
     @XmlAttribute(name = "version")
-    private static final String GPX_VERSION = "1.0";
+    private static final String GPX_VERSION = "1.1";
 
     @XmlAttribute(name = "creator")
     private static final String GPX_CREATOR = "openrouteservice";

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponse.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
 import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.config.SystemMessageProperties;
 import org.heigit.ors.api.requests.routing.RouteRequest;
@@ -32,6 +33,7 @@ import java.util.List;
 
 @XmlRootElement(name = "gpx")
 @Schema(name = "gpx")
+@Getter
 public class GPXRouteResponse extends RouteResponse {
 
     @XmlAttribute(name = "version")
@@ -73,5 +75,17 @@ public class GPXRouteResponse extends RouteResponse {
 
     public List<GPXRouteElement> getGpxRouteElements() {
         return routes;
+    }
+
+    public static String getGpxVersion() {
+        return GPX_VERSION;
+    }
+
+    public static String getGpxCreator() {
+        return GPX_CREATOR;
+    }
+
+    public static String getXmlnsLink() {
+        return XMLNS_LINK;
     }
 }

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
@@ -64,5 +64,7 @@ class GPXRouteResponseTest {
         assertEquals("openrouteservice", response.getGpxCreator());
 
         assertEquals("https://raw.githubusercontent.com/GIScience/openrouteservice-schema/main/gpx/v2/ors-gpx.xsd", response.getXmlnsLink());
+
+        assertEquals("1.1", response.getGpxVersion());
     }
 }

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
@@ -1,0 +1,68 @@
+package org.heigit.ors.api.responses.routing.gpx;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import org.heigit.ors.api.APIEnums;
+import org.heigit.ors.api.config.EndpointsProperties;
+import org.heigit.ors.api.config.SystemMessageProperties;
+import org.heigit.ors.api.requests.routing.RouteRequest;
+import org.heigit.ors.api.responses.common.boundingbox.BoundingBox;
+import org.heigit.ors.routing.RouteResult;
+import org.heigit.ors.util.mockuputil.RouteResultMockup;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class GPXRouteResponseTest {
+
+    @Autowired
+    private EndpointsProperties endpointsProperties;
+
+    @Autowired
+    private SystemMessageProperties systemMessageProperties;
+
+    @Test
+    void TestGetGpxRouteElements() throws Exception {
+
+        RouteResult[] result = RouteResultMockup.create(RouteResultMockup.routeResultProfile.STANDARD_HEIDELBERG);
+        List<List<Double>> coordinates = List.of(
+                Arrays.asList(49.3988, 8.6724),
+                Arrays.asList(49.399, 8.673)
+        );
+        RouteRequest request = new RouteRequest(coordinates);
+        request.setProfile(APIEnums.Profile.DRIVING_CAR);
+        request.setResponseType(APIEnums.RouteResponseType.GPX);
+
+        GPXRouteResponse response = new GPXRouteResponse(result, request, systemMessageProperties, endpointsProperties);
+
+        assertEquals(response.getGpxRouteElements().toArray().length, result.length);
+
+        BoundingBox bounds = response.getMetadata().getBounds();
+
+        JAXBContext context = JAXBContext.newInstance(GPXBounds.class);
+        Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+        StringWriter writer = new StringWriter();
+        marshaller.marshal(bounds, writer);
+
+        String xmlBounds = writer.toString();
+        assertTrue(xmlBounds.contains("minlat="), "minlat should appear with correct capitalization.");
+        assertTrue(xmlBounds.contains("maxlat="), "maxlat should appear with correct capitalization.");
+        assertTrue(xmlBounds.contains("minlon="), "minlon should appear with correct capitalization.");
+        assertTrue(xmlBounds.contains("maxlon="), "maxlon should appear with correct capitalization.");
+
+        assertEquals("openrouteservice", response.getGpxCreator());
+
+        assertEquals("https://raw.githubusercontent.com/GIScience/openrouteservice-schema/main/gpx/v2/ors-gpx.xsd", response.getXmlnsLink());
+    }
+}

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -596,10 +596,10 @@ class ResultTest extends ServiceTest {
                     <xs:complexType name="boundsType">
                         <xs:simpleContent>
                             <xs:extension base="xs:string">
-                                <xs:attribute type="xs:string" name="minLat"/>
-                                <xs:attribute type="xs:string" name="minLon"/>
-                                <xs:attribute type="xs:string" name="maxLat"/>
-                                <xs:attribute type="xs:string" name="maxLon"/>
+                                <xs:attribute type="xs:string" name="minlat"/>
+                                <xs:attribute type="xs:string" name="minlon"/>
+                                <xs:attribute type="xs:string" name="maxlat"/>
+                                <xs:attribute type="xs:string" name="maxlon"/>
                             </xs:extension>
                         </xs:simpleContent>
                     </xs:complexType>


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2004 .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
