### PR TITLE
fix: return waytype instead of waytypes for extra info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Releasing is documented in RELEASE.md
 - repair broken integration tests with by pining buildkit 0.15 ([#2003](https://github.com/GIScience/openrouteservice/pull/2003))
 - elevation set to false not taken into account ([#1967](https://github.com/GIScience/openrouteservice/issues/1967))
 - make gpx response adhere to standard and set version to 1.1 ([#2004](https://github.com/GIScience/openrouteservice/issues/2004))
+- return correct extra info label for 'waytype' ([#1579](https://github.com/GIScience/openrouteservice/issues/1579))
 
 ### Security
 

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -1309,7 +1309,7 @@ class ResultTest extends ServiceTest {
                 .body("routes[0].extras.containsKey('suitability')", is(true))
                 .body("routes[0].extras.containsKey('surface')", is(true))
                 .body("routes[0].extras.containsKey('waycategory')", is(true))
-                .body("routes[0].extras.containsKey('waytypes')", is(true))
+                .body("routes[0].extras.containsKey('waytype')", is(true))
                 .body("routes[0].extras.containsKey('traildifficulty')", is(true))
                 .body("routes[0].extras.containsKey('green')", is(true))
                 .body("routes[0].extras.containsKey('noise')", is(true))

--- a/ors-engine/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/pathprocessors/ExtraInfoProcessor.java
@@ -164,11 +164,11 @@ public class ExtraInfoProcessor implements PathProcessor {
                         surfaceInfoBuilder = new AppendableRouteExtraInfoBuilder(surfaceInfo);
                     }
                     if (includeExtraInfo(extraInfo, RouteExtraInfoFlag.WAY_TYPE)) {
-                        wayTypeInfo = new RouteExtraInfo("waytypes");
+                        wayTypeInfo = new RouteExtraInfo("waytype");
                         wayTypeInfoBuilder = new AppendableRouteExtraInfoBuilder(wayTypeInfo);
                     }
                 } else {
-                    skippedExtras.add("surface/waytypes");
+                    skippedExtras.add("surface/waytype");
                 }
             }
 


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1579 .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
