### PR TITLE
fix: graph build date missing in case route is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Releasing is documented in RELEASE.md
 
 ### Fixed
 - fix outdated dockerfile base images and add a more robust native golang base image ([#2027](https://github.com/GIScience/openrouteservice/pull/2027))
+- graph build date missing in case route is not found ([#2020](https://github.com/GIScience/openrouteservice/pull/2020))
 - fix github action build default builder image failing ([#2032](https://github.com/GIScience/openrouteservice/issues/2032)) 
 - fix wrong example in docs of extra-info 'waycategory' ([#1797](https://github.com/GIScience/openrouteservice/issues/1797))
 - fix population data link in docs ([#1624](https://github.com/GIScience/openrouteservice/issues/1624))

--- a/ors-api/src/main/java/org/heigit/ors/api/Application.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/Application.java
@@ -5,7 +5,7 @@ import org.apache.log4j.Logger;
 import org.heigit.ors.api.config.ApiEngineProperties;
 import org.heigit.ors.api.services.GraphService;
 import org.heigit.ors.api.servlet.listeners.ORSInitContextListener;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.routing.RoutingProfileManagerStatus;
 import org.heigit.ors.util.StringUtility;
 import org.springframework.boot.SpringApplication;

--- a/ors-api/src/main/java/org/heigit/ors/api/config/OpenAPIConfig.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/config/OpenAPIConfig.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.heigit.ors.api.util.AppInfo.VERSION;
+import static org.heigit.ors.util.AppInfo.VERSION;
 
 
 @Configuration

--- a/ors-api/src/main/java/org/heigit/ors/api/controllers/StatusAPI.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/controllers/StatusAPI.java
@@ -19,7 +19,7 @@ import com.graphhopper.routing.ev.EncodedValue;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.heigit.ors.api.config.EndpointsProperties;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.config.profile.ProfileProperties;
 import org.heigit.ors.localization.LocalizationManager;
 import org.heigit.ors.routing.RoutingProfile;

--- a/ors-api/src/main/java/org/heigit/ors/api/errors/CommonResponseEntityExceptionHandler.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/errors/CommonResponseEntityExceptionHandler.java
@@ -17,7 +17,7 @@ package org.heigit.ors.api.errors;
 
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import org.apache.log4j.Logger;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.exceptions.ParameterValueException;
 import org.heigit.ors.exceptions.StatusCodeException;
 import org.heigit.ors.exceptions.UnknownParameterException;

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
@@ -19,18 +19,18 @@ public class EngineInfo {
     public EngineInfo(JSONObject infoIn) {
         version = infoIn.getString("version");
         buildDate = infoIn.getString("build_date");
-        graphDate = "0000-00-00T00:00:00Z";
+
+        if (infoIn.has("graph_date")) {
+            graphDate = infoIn.getString("graph_date");
+        } else {
+            graphDate = "0000-00-00T00:00:00Z";
+        }
     }
 
     public String getVersion() {
         return version;
     }
-
     public String getBuildDate() {
         return buildDate;
-    }
-
-    public void setGraphDate(String graphDate) {
-        this.graphDate = graphDate;
     }
 }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/isochrones/IsochronesResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/isochrones/IsochronesResponseInfo.java
@@ -73,9 +73,4 @@ public class IsochronesResponseInfo {
         this.systemMessage = SystemMessage.getSystemMessage(request, systemMessageProperties);
     }
 
-    @JsonIgnore
-    public void setGraphDate(String graphDate) {
-        engineInfo.setGraphDate(graphDate);
-    }
-
 }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/isochrones/IsochronesResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/isochrones/IsochronesResponseInfo.java
@@ -24,7 +24,7 @@ import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.config.SystemMessageProperties;
 import org.heigit.ors.api.requests.isochrones.IsochronesRequest;
 import org.heigit.ors.api.responses.common.engineinfo.EngineInfo;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.api.util.SystemMessage;
 
 @Schema(name = "IsochronesResponseInfo", description = "Information about the request")

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/isochrones/geojson/GeoJSONIsochronesResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/isochrones/geojson/GeoJSONIsochronesResponse.java
@@ -53,7 +53,6 @@ public class GeoJSONIsochronesResponse extends IsochronesResponse {
         this.isochroneResults = new ArrayList<>();
         for (IsochroneMap isoMap : isoMaps.getIsochroneMaps()) {
             this.isochroneResults.addAll(new GeoJSONIsochronesMap(isoMap).buildGeoJSONIsochrones());
-            responseInformation.setGraphDate(isoMap.getGraphDate());
         }
 
         if (request.hasIntersections() && request.getIntersections()) {

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/matrix/MatrixResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/matrix/MatrixResponseInfo.java
@@ -24,7 +24,7 @@ import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.config.SystemMessageProperties;
 import org.heigit.ors.api.requests.matrix.MatrixRequest;
 import org.heigit.ors.api.responses.common.engineinfo.EngineInfo;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.api.util.SystemMessage;
 
 @Schema(description = "Information about the request")

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/matrix/MatrixResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/matrix/MatrixResponseInfo.java
@@ -73,11 +73,6 @@ public class MatrixResponseInfo {
         this.systemMessage = SystemMessage.getSystemMessage(request, systemMessageProperties);
     }
 
-    @JsonIgnore
-    public void setGraphDate(String graphDate) {
-        engineInfo.setGraphDate(graphDate);
-    }
-
     public String getAttribution() {
         return attribution;
     }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/matrix/json/JSONMatrixResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/matrix/json/JSONMatrixResponse.java
@@ -29,7 +29,6 @@ import org.heigit.ors.matrix.MatrixResult;
 public class JSONMatrixResponse extends MatrixResponse {
     public JSONMatrixResponse(MatrixResult result, MatrixRequest request, SystemMessageProperties systemMessageProperties, EndpointsProperties endpointsProperties) {
         super(result, request, systemMessageProperties, endpointsProperties);
-        responseInformation.setGraphDate(result.getGraphDate());
     }
 
     @JsonProperty("matrix")

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/RouteResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/RouteResponseInfo.java
@@ -72,10 +72,4 @@ public class RouteResponseInfo {
 
         this.systemMessage = SystemMessage.getSystemMessage(request, systemMessageProperties);
     }
-
-    @JsonIgnore
-    public void setGraphDate(String graphDate) {
-        engineInfo.setGraphDate(graphDate);
-    }
-
 }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/RouteResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/RouteResponseInfo.java
@@ -24,7 +24,7 @@ import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.config.SystemMessageProperties;
 import org.heigit.ors.api.requests.routing.RouteRequest;
 import org.heigit.ors.api.responses.common.engineinfo.EngineInfo;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.api.util.SystemMessage;
 
 @Schema(description = "Information about the request")

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONRouteResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONRouteResponse.java
@@ -51,7 +51,6 @@ public class GeoJSONRouteResponse extends RouteResponse {
 
         for (RouteResult result : routeResults) {
             this.routeResults.add(new GeoJSONIndividualRouteResponse(result, request));
-            responseInformation.setGraphDate(result.getGraphDate());
         }
 
         List<BBox> bboxes = new ArrayList<>();

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXExtensions.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/gpx/GPXExtensions.java
@@ -18,7 +18,7 @@ package org.heigit.ors.api.responses.routing.gpx;
 import com.graphhopper.util.Helper;
 import jakarta.xml.bind.annotation.XmlElement;
 import org.heigit.ors.api.requests.routing.RouteRequest;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.api.APIEnums;
 
 public class GPXExtensions {

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/json/JSONRouteResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/json/JSONRouteResponse.java
@@ -43,7 +43,6 @@ public class JSONRouteResponse extends RouteResponse {
         for (RouteResult result : routeResults) {
             this.routeResults.add(new JSONIndividualRouteResponse(result, request));
             bboxes.add(result.getSummary().getBBox());
-            responseInformation.setGraphDate(result.getGraphDate());
         }
 
         BBox bounding = GeomUtility.generateBoundingFromMultiple(bboxes.toArray(new BBox[0]));

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/SnappingResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/SnappingResponseInfo.java
@@ -9,7 +9,7 @@ import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.config.SystemMessageProperties;
 import org.heigit.ors.api.requests.snapping.SnappingApiRequest;
 import org.heigit.ors.api.responses.common.engineinfo.EngineInfo;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.api.util.SystemMessage;
 
 @Schema(description = "Information about the request")

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/SnappingResponseInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/SnappingResponseInfo.java
@@ -50,10 +50,4 @@ public class SnappingResponseInfo {
 
         this.systemMessage = SystemMessage.getSystemMessage(request, systemMessageProperties);
     }
-
-    @JsonIgnore
-    public void setGraphDate(String graphDate) {
-        engineInfo.setGraphDate(graphDate);
-    }
-
 }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/geojson/GeoJSONSnappingResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/geojson/GeoJSONSnappingResponse.java
@@ -69,6 +69,5 @@ public class GeoJSONSnappingResponse extends SnappingResponse {
         }
 
         responseInformation = new SnappingResponseInfo(request, systemMessageProperties, endpointsProperties);
-        responseInformation.setGraphDate(result.getGraphDate());
     }
 }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/json/JsonSnappingResponse.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/snapping/json/JsonSnappingResponse.java
@@ -28,7 +28,6 @@ public class JsonSnappingResponse extends SnappingResponse {
         super(result);
         locations = constructLocations(result);
         responseInformation = new SnappingResponseInfo(request, systemMessageProperties, endpointsProperties);
-        responseInformation.setGraphDate(result.getGraphDate());
     }
 
     private List<JSONLocation> constructLocations(SnappingResult result) {

--- a/ors-api/src/main/java/org/heigit/ors/api/services/GraphService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/GraphService.java
@@ -1,7 +1,7 @@
 package org.heigit.ors.api.services;
 
 import org.apache.log4j.Logger;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.config.EngineProperties;
 import org.heigit.ors.routing.RoutingProfile;
 import org.heigit.ors.routing.RoutingProfileManager;

--- a/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/servlet/listeners/ORSInitContextListener.java
@@ -26,7 +26,7 @@ import lombok.AllArgsConstructor;
 import org.apache.juli.logging.LogFactory;
 import org.apache.log4j.Logger;
 import org.heigit.ors.api.services.GraphService;
-import org.heigit.ors.api.util.AppInfo;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.config.EngineProperties;
 import org.heigit.ors.isochrones.statistics.StatisticsProviderFactory;
 import org.heigit.ors.routing.RoutingProfile;

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -180,6 +180,18 @@ class ResultTest extends ServiceTest {
         // 8.691891431808473, 49.41331858818114
 
 
+        JSONArray unreachableCoords = new JSONArray();
+        JSONArray unreachableCoord1 = new JSONArray();
+        unreachableCoord1.put(6.929281);
+        unreachableCoord1.put(45.707362);
+        unreachableCoords.put(unreachableCoord1);
+        JSONArray unreachableCoord2 = new JSONArray();
+        unreachableCoord2.put(6.92281);
+        unreachableCoord2.put(45.507362);
+        unreachableCoords.put(unreachableCoord2);
+        addParameter("unreachableCoords", unreachableCoords);
+
+
         JSONArray extraInfo = new JSONArray();
         extraInfo.put("surface");
         extraInfo.put("suitability");
@@ -779,6 +791,30 @@ class ResultTest extends ServiceTest {
                 .body("metadata.engine.containsKey('graph_date')", is(true))
                 .body("metadata.containsKey('system_message')", is(true))
                 .statusCode(200);
+    }
+
+    @Test
+    void testCompleteEngineInfoOnRouteNotFound() {
+        JSONObject body = new JSONObject();
+        body.put("coordinates", getParameter("unreachableCoords"));
+        body.put("id", "request123");
+        given()
+            .headers(CommonHeaders.geoJsonContent)
+            .pathParam("profile", getParameter("carProfile"))
+            .body(body.toString())
+            .when()
+            .post(getEndPointPath() + "/{profile}/geojson")
+            .then()
+            .assertThat()
+            .body("any {it.key == 'info'}", is(true))
+            .body("any {it.key == 'error'}", is(true))
+            .body("error.containsKey('code')", is(true))
+            .body("error.containsKey('message')", is(true))
+            .body("info.engine.containsKey('version')", is(true))
+            .body("info.engine.containsKey('build_date')", is(true))
+            .body("info.engine.containsKey('graph_date')", is(true))
+            .body("info.containsKey('timestamp')", is(true))
+            .statusCode(404);
     }
 
     @Test

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/IsochroneMap.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/IsochroneMap.java
@@ -24,7 +24,6 @@ public class IsochroneMap {
     private final Envelope envelope;
     private final List<Isochrone> isochrones;
     private final Coordinate center;
-    private String graphDate;
 
     public IsochroneMap(int travellerId, Coordinate center) {
         this.travellerId = travellerId;
@@ -64,13 +63,5 @@ public class IsochroneMap {
 
     public Envelope getEnvelope() {
         return envelope;
-    }
-
-    public String getGraphDate() {
-        return graphDate;
-    }
-
-    public void setGraphDate(String graphDate) {
-        this.graphDate = graphDate;
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -65,8 +65,6 @@ public class ConcaveBallsIsochroneMapBuilder extends AbstractIsochroneMapBuilder
 
         IsochroneMap isochroneMap = new IsochroneMap(parameters.getTravellerId(), loc);
 
-        isochroneMap.setGraphDate(graphdate);
-
         if (LOGGER.isDebugEnabled()) {
             sw.stop();
 

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/builders/concaveballs/ConcaveBallsIsochroneMapBuilder.java
@@ -51,9 +51,6 @@ public class ConcaveBallsIsochroneMapBuilder extends AbstractIsochroneMapBuilder
             sw.start();
         }
 
-        GraphHopperStorage graph = searchContext.getGraphHopper().getGraphHopperStorage();
-        String graphdate = graph.getProperties().get("datareader.import.date");
-
         double maxSpeed = determineMaxSpeed();
         double meanSpeed = determineMeanSpeed(maxSpeed);
 

--- a/ors-engine/src/main/java/org/heigit/ors/matrix/MatrixResult.java
+++ b/ors-engine/src/main/java/org/heigit/ors/matrix/MatrixResult.java
@@ -17,7 +17,6 @@ public class MatrixResult {
     private final float[][] tables;
     private ResolvedLocation[] destinations;
     private ResolvedLocation[] sources;
-    private String graphDate;
 
     public MatrixResult(ResolvedLocation[] sources, ResolvedLocation[] destinations) {
         tables = new float[6][];
@@ -51,13 +50,5 @@ public class MatrixResult {
 
     public void setSources(ResolvedLocation[] locations) {
         sources = locations;
-    }
-
-    public void setGraphDate(String graphDate) {
-        this.graphDate = graphDate;
-    }
-
-    public String getGraphDate() {
-        return graphDate;
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
+++ b/ors-engine/src/main/java/org/heigit/ors/matrix/algorithms/rphast/RPHASTMatrixAlgorithm.java
@@ -104,9 +104,6 @@ public class RPHASTMatrixAlgorithm extends AbstractMatrixAlgorithm {
 
         MatrixResult mtxResult = new MatrixResult(srcData.getLocations(), dstData.getLocations());
 
-        if (graphHopper != null)
-            mtxResult.setGraphDate(graphHopper.getGraphHopperStorage().getProperties().get("datareader.import.date"));
-
         if (MatrixMetricsType.isSet(metrics, MatrixMetricsType.DURATION))
             mtxResult.setTable(MatrixMetricsType.DURATION, times);
         if (MatrixMetricsType.isSet(metrics, MatrixMetricsType.DISTANCE))

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RouteResult.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RouteResult.java
@@ -31,7 +31,6 @@ public class RouteResult {
     private final List<RouteLeg> legs;
     private List<RouteExtraInfo> extraInfo;
     private PointList pointlist;
-    private String graphDate = "";
     private final List<Integer> wayPointsIndices;
     private final List<RouteWarning> routeWarnings;
     private final RouteSummary summary;
@@ -190,14 +189,6 @@ public class RouteResult {
             if (path.getFare() != null)
                 summary.setFare(path.getFare().intValue());
         }
-    }
-
-    public String getGraphDate() {
-        return graphDate;
-    }
-
-    public void setGraphDate(String graphDate) {
-        this.graphDate = graphDate;
     }
 
     public boolean hasDepartureAndArrival() {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RouteResultBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RouteResultBuilder.java
@@ -94,7 +94,6 @@ public class RouteResultBuilder {
             }
 
             result.addSegment(createRouteSegment(path, request, getNextResponseFirstStepPoints(responses, ri)));
-            result.setGraphDate(response.getHints().getString("data.date", "0000-00-00T00:00:00Z"));
         }
 
         result.calculateRouteSummary(request);
@@ -147,7 +146,6 @@ public class RouteResultBuilder {
                 result.resetSegments();
             }
 
-            result.setGraphDate(response.getHints().getString("data.date", "0000-00-00T00:00:00Z"));
             resultSet[response.getAll().indexOf(path)] = result;
 
             if (request.getSearchParameters().isTimeDependent()) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -61,6 +61,7 @@ import org.heigit.ors.routing.graphhopper.extensions.storages.builders.GraphStor
 import org.heigit.ors.routing.graphhopper.extensions.storages.builders.HereTrafficGraphStorageBuilder;
 import org.heigit.ors.routing.graphhopper.extensions.util.ORSParameters;
 import org.heigit.ors.routing.graphhopper.extensions.weighting.HgvAccessWeighting;
+import org.heigit.ors.util.AppInfo;
 import org.heigit.ors.util.CoordTools;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -172,6 +173,7 @@ public class ORSGraphHopper extends GraphHopperGtfs {
         }
 
         ORSGraphHopper gh = (ORSGraphHopper) super.importOrLoad();
+        AppInfo.GRAPH_DATE = gh.getGraphHopperStorage().getProperties().get("datareader.import.date");
 
         writeOrsGraphBuildInfoFileIfNotExists(gh);
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -173,7 +173,7 @@ public class ORSGraphHopper extends GraphHopperGtfs {
         }
 
         ORSGraphHopper gh = (ORSGraphHopper) super.importOrLoad();
-        AppInfo.GRAPH_DATE = gh.getGraphHopperStorage().getProperties().get("datareader.import.date");
+        AppInfo.setGraphDate(gh.getGraphHopperStorage().getProperties().get("datareader.import.date"));
 
         writeOrsGraphBuildInfoFileIfNotExists(gh);
 

--- a/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
+++ b/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
@@ -60,6 +60,7 @@ public class AppInfo {
     public static final String BUILD_DATE;
     public static final boolean SNAPSHOT;
     public static final String GRAPH_VERSION;
+    public static String GRAPH_DATE;
 
     static {
         String version = "0.0";
@@ -119,6 +120,11 @@ public class AppInfo {
         json.put("version", VERSION);
         json.put("build_date", BUILD_DATE);
         json.put("graph_version", GRAPH_VERSION);
+
+        if (GRAPH_DATE != null){
+            json.put("graph_date", GRAPH_DATE);
+        }
+        
         return json;
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
+++ b/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
@@ -18,7 +18,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.heigit.ors.api.util;
+package org.heigit.ors.util;
 
 import org.apache.log4j.Logger;
 import org.json.JSONObject;

--- a/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
+++ b/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
@@ -60,7 +60,8 @@ public class AppInfo {
     public static final String BUILD_DATE;
     public static final boolean SNAPSHOT;
     public static final String GRAPH_VERSION;
-    public static String GRAPH_DATE;
+
+    private static String graphDate;
 
     static {
         String version = "0.0";
@@ -121,10 +122,14 @@ public class AppInfo {
         json.put("build_date", BUILD_DATE);
         json.put("graph_version", GRAPH_VERSION);
 
-        if (GRAPH_DATE != null){
-            json.put("graph_date", GRAPH_DATE);
+        if (graphDate != null){
+            json.put("graph_date", graphDate);
         }
         
         return json;
+    }
+
+    public static void setGraphDate(String graphDate) {
+        AppInfo.graphDate = graphDate;
     }
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1191 

### Information about the changes
The graph date is added to the response in case ORS failed to snap to a node for the given coordinate(s).  
This is done by adding setting the static `GRAPH_DATE` variable of `AppInfo` when reading the graph. To be able to access `AppInfo` when reading the graph the class was moved to `core`.
Furthermore the graph date property of `EngineInfo` is now read from `AppInfo` instead of being set by every endpoint individually.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
