### PR TITLE
fix: accept upper and lower case booleans for REBUILD_GRAPHS within the docker setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Releasing is documented in RELEASE.md
 - fix github action build default builder image failing ([#2032](https://github.com/GIScience/openrouteservice/issues/2032)) 
 - fix wrong example in docs of extra-info 'waycategory' ([#1797](https://github.com/GIScience/openrouteservice/issues/1797))
 - fix population data link in docs ([#1624](https://github.com/GIScience/openrouteservice/issues/1624))
+- accept upper and lower case booleans for REBUILD_GRAPHS within the docker setup ([#2028](https://github.com/GIScience/openrouteservice/pull/2028))
 
 ### Security
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -107,6 +107,7 @@ set_log_level
 jar_file=/ors.jar
 BUILD_GRAPHS=${BUILD_GRAPHS:-"false"}
 REBUILD_GRAPHS=${REBUILD_GRAPHS:-"false"}
+REBUILD_GRAPHS=$(echo "$REBUILD_GRAPHS" | tr '[:upper:]' '[:lower:]') # Convert to lowercase
 # If BUILD_GRAPHS is set to true, we need to set ors_rebuild_graphs to true and print an info about migration to REBUILD_GRAPHS
 if [ "${BUILD_GRAPHS}" = "true" ]; then
   ors_rebuild_graphs="true"


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2011

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
