### PR TITLE
ci: fix broken tests due to missing unittest profile

### DIFF
--- a/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.ActiveProfiles;
 class GPXRouteResponseTest {
 
     @Autowired
-    private EndpointsProperties endpointsProperties;
+    private final EndpointsProperties endpointsProperties = new EndpointsProperties();
 
     @Autowired
     private final SystemMessageProperties systemMessageProperties = new SystemMessageProperties();

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
@@ -63,10 +63,10 @@ class GPXRouteResponseTest {
         assertTrue(xmlBounds.contains("minlon="), "minlon should appear with correct capitalization.");
         assertTrue(xmlBounds.contains("maxlon="), "maxlon should appear with correct capitalization.");
 
-        assertEquals("openrouteservice", response.getGpxCreator());
+        assertEquals("openrouteservice", GPXRouteResponse.getGpxCreator());
 
-        assertEquals("https://raw.githubusercontent.com/GIScience/openrouteservice-schema/main/gpx/v2/ors-gpx.xsd", response.getXmlnsLink());
+        assertEquals("https://raw.githubusercontent.com/GIScience/openrouteservice-schema/main/gpx/v2/ors-gpx.xsd", GPXRouteResponse.getXmlnsLink());
 
-        assertEquals("1.1", response.getGpxVersion());
+        assertEquals("1.1", GPXRouteResponse.getGpxVersion());
     }
 }

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
@@ -28,7 +28,7 @@ class GPXRouteResponseTest {
     private EndpointsProperties endpointsProperties;
 
     @Autowired
-    private SystemMessageProperties systemMessageProperties;
+    private final SystemMessageProperties systemMessageProperties = new SystemMessageProperties();
 
     @Test
     void TestGetGpxRouteElements() throws Exception {

--- a/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/responses/routing/gpx/GPXRouteResponseTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("unittest")
 class GPXRouteResponseTest {
 
     @Autowired


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2044 .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
