### PR TITLE
feat: add access = permit to known access restiction types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Releasing is documented in RELEASE.md
 
 ### Added
 - add hint to use yaml editor in docs ([#1836](https://github.com/GIScience/openrouteservice/issues/1836))
+- access = permit as known access restriction type ([#2013](https://github.com/GIScience/openrouteservice/issues/2013))
 
 ### Changed
 

--- a/docs/api-reference/endpoints/directions/extra-info/road-access-restrictions.md
+++ b/docs/api-reference/endpoints/directions/extra-info/road-access-restrictions.md
@@ -9,14 +9,15 @@ $.routes[*].extras.roadaccessrestrictions.values
 Provides information about possible restrictions on roads.
 Explanation of the values can be found in the [list of possible values in the OSM Wiki](https://wiki.openstreetmap.org/wiki/Key:access)
 
-| Value |             Encoding              |
-|:-----:|:---------------------------------:|
-|   0   | None (there are no restrictions)  |
-|   1   |                No                 |
-|   2   |             Customers             |
-|   4   |            Destination            |
-|   8   |             Delivery              |
-|  16   |              Private              |
-|  32   |            Permissive             |
+| Value |             Encoding             |
+|:-----:|:--------------------------------:|
+|   0   | None (there are no restrictions) |
+|   1   |                No                |
+|   2   |            Customers             |
+|   4   |           Destination            |
+|   8   |             Delivery             |
+|  16   |             Private              |
+|  32   |            Permissive            |
+|  64   |              Permit              |
 
 [//]: # (keep in sync with org.heigit.ors.routing.graphhopper.extensions.AccessRestrictionType.class)

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/AccessRestrictionType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/AccessRestrictionType.java
@@ -24,6 +24,7 @@ public abstract class AccessRestrictionType {
     public static final int DELIVERY = 8;
     public static final int PRIVATE = 16;
     public static final int PERMISSIVE = 32;
+    public static final int PERMIT = 64;
 
     private AccessRestrictionType() {
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
@@ -78,9 +78,9 @@ public class RoadAccessRestrictionsGraphStorageBuilder extends AbstractGraphStor
      * @return The RoadAccessRestrictionStorage object created as part of the initialisation
      * @throws Exception
      */
-    public GraphExtension init(GraphHopper graphhopper, int profileType) throws Exception {
+    public GraphExtension init(GraphHopper graphhopper, int profileType) throws IllegalStateException {
         if (storage != null)
-            throw new Exception("GraphStorageBuilder has been already initialized.");
+            throw new IllegalStateException("GraphStorageBuilder has been already initialized.");
 
         ExtendedStorageProperties parameters;
         parameters = this.parameters;
@@ -102,9 +102,9 @@ public class RoadAccessRestrictionsGraphStorageBuilder extends AbstractGraphStor
      * @return The RoadAccessRestrictionStorage object created as part of the initialisation
      * @throws Exception
      */
-    public GraphExtension init(GraphHopper graphhopper) throws Exception {
+    public GraphExtension init(GraphHopper graphhopper) throws IllegalStateException {
         if (storage != null)
-            throw new Exception("GraphStorageBuilder has been already initialized.");
+            throw new IllegalStateException("GraphStorageBuilder has been already initialized.");
 
         ExtendedStorageProperties parameters;
         parameters = this.parameters;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
@@ -61,6 +61,7 @@ public class RoadAccessRestrictionsGraphStorageBuilder extends AbstractGraphStor
         restrictedValues.add("customers");
         restrictedValues.add("emergency");
         restrictedValues.add("permissive");
+        restrictedValues.add("delivery");
         restrictedValues.add("permit");
 
         permissiveValues.add("yes");

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
@@ -61,6 +61,7 @@ public class RoadAccessRestrictionsGraphStorageBuilder extends AbstractGraphStor
         restrictedValues.add("customers");
         restrictedValues.add("emergency");
         restrictedValues.add("permissive");
+        restrictedValues.add("permit");
 
         permissiveValues.add("yes");
         permissiveValues.add("designated");
@@ -230,6 +231,7 @@ public class RoadAccessRestrictionsGraphStorageBuilder extends AbstractGraphStor
                 case "permissive" -> res |= AccessRestrictionType.PERMISSIVE;
                 case "delivery" -> res |= AccessRestrictionType.DELIVERY;
                 case "customers" -> res |= AccessRestrictionType.CUSTOMERS;
+                case "permit" -> res |= AccessRestrictionType.PERMIT;
                 default -> {
                 }
             }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilder.java
@@ -168,6 +168,8 @@ public class RoadAccessRestrictionsGraphStorageBuilder extends AbstractGraphStor
                 restrictions = isAccessAllowed(way, VAL_BICYCLE) ? 0 : getRestrictionType(way, VAL_BICYCLE);
             if (RoutingProfileType.isPedestrian(profileType))
                 restrictions = isAccessAllowed(way, "foot") ? 0 : getRestrictionType(way, "foot");
+            if (profileType == RoutingProfileType.UNKNOWN)
+                restrictions = getRestrictionType(way, VAL_ACCESS);
         }
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/RoadAccessRestrictionsGraphStorageBuilderTest.java
@@ -31,6 +31,43 @@ class RoadAccessRestrictionsGraphStorageBuilderTest {
     }
 
     @Test
+    void testAccessTypes() throws Exception {
+        initBuilder(RoutingProfileType.UNKNOWN);
+
+        ReaderWay way = new ReaderWay(1);
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.NONE, builder.getRestrictions());
+
+        way.setTag("access", "no");
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.NO, builder.getRestrictions());
+
+        way.setTag("access", "customers");
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.CUSTOMERS, builder.getRestrictions());
+
+        way.setTag("access", "destination");
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.DESTINATION, builder.getRestrictions());
+
+        way.setTag("access", "delivery");
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.DELIVERY, builder.getRestrictions());
+
+        way.setTag("access", "private");
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.PRIVATE, builder.getRestrictions());
+
+        way.setTag("access", "permissive");
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.PERMISSIVE, builder.getRestrictions());
+
+        way.setTag("access", "permit");
+        builder.processWay(way);
+        assertEquals(AccessRestrictionType.PERMIT, builder.getRestrictions());
+    }
+
+    @Test
     void testCarWayCreation() throws Exception {
         initBuilder(RoutingProfileType.DRIVING_CAR);
         ReaderWay way = new ReaderWay(1);


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [x] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [x] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [x] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2013.

### Information about the changes
- Key functionality added: Access restrictions with the type "permit" will now be considered during graph building. 
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
