### PR TITLE
feat: include OSM data version in the API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Releasing is documented in RELEASE.md
 ## [unreleased]
 
 ### Added
-
+- include OSM data version (`osm_date`) in the API response ([#1192](https://github.com/GIScience/openrouteservice/issues/1192))
 ### Changed
 
 ### Deprecated

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
@@ -15,6 +15,8 @@ public class EngineInfo {
     @Schema(description = "The date that the graph data was last updated", example = "2019-02-07T14:28:11Z")
     @JsonProperty("graph_date")
     private String graphDate;
+    @JsonProperty("osm_date")
+    private String osmDate;
 
     public EngineInfo(JSONObject infoIn) {
         version = infoIn.getString("version");
@@ -24,6 +26,12 @@ public class EngineInfo {
             graphDate = infoIn.getString("graph_date");
         } else {
             graphDate = "0000-00-00T00:00:00Z";
+        }
+
+        if (infoIn.has("osm_date")) {
+            osmDate = infoIn.getString("osm_date");
+        } else {
+            osmDate = "0000-00-00T00:00:00Z";
         }
     }
 

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
@@ -32,11 +32,4 @@ public class EngineInfo {
             osmDate = infoIn.getString("osm_date");
         }
     }
-
-    public String getVersion() {
-        return version;
-    }
-    public String getBuildDate() {
-        return buildDate;
-    }
 }

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
@@ -16,6 +16,7 @@ public class EngineInfo {
     @Schema(description = "The date that the graph data was last updated", example = "2019-02-07T14:28:11Z")
     @JsonProperty("graph_date")
     private String graphDate = DEFAULT_DATE;
+    @Schema(description = "Timestamp of the OSM data the graph was built from", example = "2019-02-07T14:28:11Z")
     @JsonProperty("osm_date")
     private String osmDate = DEFAULT_DATE;
 

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/common/engineinfo/EngineInfo.java
@@ -6,6 +6,7 @@ import org.json.JSONObject;
 
 @Schema(description = "Information about the openrouteservice engine used")
 public class EngineInfo {
+    private static final String DEFAULT_DATE = "0000-00-00T00:00:00Z";
     @Schema(description = "The backend version of the openrouteservice that was queried", example = "8.0")
     @JsonProperty("version")
     private final String version;
@@ -14,9 +15,9 @@ public class EngineInfo {
     private final String buildDate;
     @Schema(description = "The date that the graph data was last updated", example = "2019-02-07T14:28:11Z")
     @JsonProperty("graph_date")
-    private String graphDate;
+    private String graphDate = DEFAULT_DATE;
     @JsonProperty("osm_date")
-    private String osmDate;
+    private String osmDate = DEFAULT_DATE;
 
     public EngineInfo(JSONObject infoIn) {
         version = infoIn.getString("version");
@@ -24,14 +25,10 @@ public class EngineInfo {
 
         if (infoIn.has("graph_date")) {
             graphDate = infoIn.getString("graph_date");
-        } else {
-            graphDate = "0000-00-00T00:00:00Z";
         }
 
         if (infoIn.has("osm_date")) {
             osmDate = infoIn.getString("osm_date");
-        } else {
-            osmDate = "0000-00-00T00:00:00Z";
         }
     }
 

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -789,6 +789,7 @@ class ResultTest extends ServiceTest {
                 .body("metadata.engine.containsKey('version')", is(true))
                 .body("metadata.engine.containsKey('build_date')", is(true))
                 .body("metadata.engine.containsKey('graph_date')", is(true))
+                .body("metadata.engine.containsKey('osm_date')", is(true))
                 .body("metadata.containsKey('system_message')", is(true))
                 .statusCode(200);
     }
@@ -813,6 +814,7 @@ class ResultTest extends ServiceTest {
             .body("info.engine.containsKey('version')", is(true))
             .body("info.engine.containsKey('build_date')", is(true))
             .body("info.engine.containsKey('graph_date')", is(true))
+            .body("info.engine.containsKey('osm_date')", is(true))
             .body("info.containsKey('timestamp')", is(true))
             .statusCode(404);
     }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -174,6 +174,7 @@ public class ORSGraphHopper extends GraphHopperGtfs {
 
         ORSGraphHopper gh = (ORSGraphHopper) super.importOrLoad();
         AppInfo.setGraphDate(gh.getGraphHopperStorage().getProperties().get("datareader.import.date"));
+        AppInfo.setOsmDate(gh.getGraphHopperStorage().getProperties().get("datareader.data.date"));
 
         writeOrsGraphBuildInfoFileIfNotExists(gh);
 

--- a/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
+++ b/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
@@ -62,6 +62,7 @@ public class AppInfo {
     public static final String GRAPH_VERSION;
 
     private static String graphDate;
+    private static String osmDate;
 
     static {
         String version = "0.0";
@@ -125,11 +126,19 @@ public class AppInfo {
         if (graphDate != null){
             json.put("graph_date", graphDate);
         }
+
+        if(osmDate != null){
+            json.put("osm_date", osmDate);
+        }
         
         return json;
     }
 
     public static void setGraphDate(String graphDate) {
         AppInfo.graphDate = graphDate;
+    }
+
+    public static void setOsmDate(String osmDate) {
+        AppInfo.osmDate = osmDate;
     }
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1192
