### PR TITLE
fix: hazmat false considered as defined profileParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Releasing is documented in RELEASE.md
 - fix http pooling for matrix generation requests ([#2059](https://github.com/GIScience/openrouteservice/pull/2059))
 - bump deprecated CodeQL and failing Grype scan GitHub actions to their current versions ([#2061](https://github.com/GIScience/openrouteservice/pull/2061))
 - avoid routing on roads with access reserved to customers ([#2060](https://github.com/GIScience/openrouteservice/pull/2060))
+- required dynamic weights for driving-hgv with `hazmat` `false` or other default Vehicle init values ([#2071](https://github.com/GIScience/openrouteservice/pull/2071))
 
 ### Security
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RouteSearchParameters.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RouteSearchParameters.java
@@ -319,7 +319,7 @@ public class RouteSearchParameters {
                 || hasAvoidCountries()
                 || getConsiderTurnRestrictions()
                 || hasNonDefaultVehicleType()
-                || isProfileTypeDriving() && hasParameters(VehicleParameters.class)
+                || isProfileTypeDriving() && hasParameters(VehicleParameters.class) && ((VehicleParameters)profileParams).hasAttributes()
                 || hasMaximumSpeed()
                 || hasFlexibleMode();
     }

--- a/ors-engine/src/test/java/org/heigit/ors/routing/RouteSearchParametersTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/RouteSearchParametersTest.java
@@ -1,6 +1,7 @@
 package org.heigit.ors.routing;
 
 import org.heigit.ors.routing.graphhopper.extensions.HeavyVehicleAttributes;
+import org.heigit.ors.routing.graphhopper.extensions.VehicleLoadCharacteristicsFlags;
 import org.heigit.ors.routing.parameters.VehicleParameters;
 import org.heigit.ors.routing.pathprocessors.BordersExtractor;
 import org.junit.jupiter.api.Test;
@@ -229,6 +230,13 @@ class RouteSearchParametersTest {
         routeSearchParameters = new RouteSearchParameters();
         routeSearchParameters.setProfileType(RoutingProfileType.DRIVING_HGV);
         routeSearchParameters.setProfileParams(new VehicleParameters());
+        assertFalse(routeSearchParameters.requiresDynamicPreprocessedWeights(), "profile param");
+
+        routeSearchParameters = new RouteSearchParameters();
+        routeSearchParameters.setProfileType(RoutingProfileType.DRIVING_HGV);
+        VehicleParameters vehicleParams = new VehicleParameters();
+        vehicleParams.setLoadCharacteristics(VehicleLoadCharacteristicsFlags.HAZMAT);
+        routeSearchParameters.setProfileParams(vehicleParams);
         assertTrue(routeSearchParameters.requiresDynamicPreprocessedWeights(), "profile param");
     }
 }


### PR DESCRIPTION
maps.openrouteservice.org passes
options.profile_params.restrictions.hazmat: false
by default which resulted in
requiresDynamicPreprocessedWeights always returning returning true as it only checked for existence of the profile_params object.

This has been changed to also check if the the passed values actually differ from the default inits with the previously unused hasAttributes function.

test: adjusted to check for above change

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2066.

### Information about the changes
- Key functionality added: dynamicWeights not required for default VehicleParams (hazmat false or any restriction on 0.0)
- Reason for change: inconsistency to matrix and how the API should handle parameters

### Examples and reasons for differences between live ORS routes, and those generated from this pull request


### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
