### PR TITLE
fix: decouple vehicle parameters from vehicle type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Releasing is documented in RELEASE.md
 - bump deprecated CodeQL and failing Grype scan GitHub actions to their current versions ([#2061](https://github.com/GIScience/openrouteservice/pull/2061))
 - avoid routing on roads with access reserved to customers ([#2060](https://github.com/GIScience/openrouteservice/pull/2060))
 - required dynamic weights for driving-hgv with `hazmat` `false` or other default Vehicle init values ([#2071](https://github.com/GIScience/openrouteservice/pull/2071))
+- enable setting vehicle parameters without the need of specifying vehicle type ([#2073](https://github.com/GIScience/openrouteservice/pull/2073))
 
 ### Security
 

--- a/ors-api/src/main/java/org/heigit/ors/api/services/ApiService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/ApiService.java
@@ -223,12 +223,9 @@ public class ApiService {
         }
 
         if (options.getProfileParams().hasRestrictions()) {
-
             RequestProfileParamsRestrictions restrictions = options.getProfileParams().getRestrictions();
-            APIEnums.VehicleType vehicleType = options.getVehicleType();
-
             validateRestrictionsForProfile(restrictions, profileType);
-            params = convertSpecificProfileParameters(profileType, restrictions, vehicleType);
+            params = convertSpecificProfileParameters(profileType, restrictions);
         }
 
         if (options.getProfileParams().hasWeightings()) {
@@ -247,28 +244,26 @@ public class ApiService {
         return params;
     }
 
-    protected ProfileParameters convertSpecificProfileParameters(int profileType, RequestProfileParamsRestrictions restrictions, APIEnums.VehicleType vehicleType) {
+    protected ProfileParameters convertSpecificProfileParameters(int profileType, RequestProfileParamsRestrictions restrictions) {
         ProfileParameters params = new ProfileParameters();
         if (RoutingProfileType.isHeavyVehicle(profileType))
-            params = convertHeavyVehicleParameters(restrictions, vehicleType);
+            params = convertHeavyVehicleParameters(restrictions);
         if (RoutingProfileType.isWheelchair(profileType))
             params = convertWheelchairParamRestrictions(restrictions);
         return params;
     }
 
-    private VehicleParameters convertHeavyVehicleParameters(RequestProfileParamsRestrictions restrictions, APIEnums.VehicleType vehicleType) {
+    private VehicleParameters convertHeavyVehicleParameters(RequestProfileParamsRestrictions restrictions) {
 
         VehicleParameters params = new VehicleParameters();
 
-        if (vehicleType != null && vehicleType != APIEnums.VehicleType.UNKNOWN) {
-            setLengthParam(restrictions, params);
-            setWidthParam(restrictions, params);
-            setHeightParam(restrictions, params);
-            setWeightParam(restrictions, params);
-            setAxleLoadParam(restrictions, params);
+        setLengthParam(restrictions, params);
+        setWidthParam(restrictions, params);
+        setHeightParam(restrictions, params);
+        setWeightParam(restrictions, params);
+        setAxleLoadParam(restrictions, params);
 
-            setLoadCharacteristicsParam(restrictions, params);
-        }
+        setLoadCharacteristicsParam(restrictions, params);
 
         return params;
     }

--- a/ors-api/src/test/java/org/heigit/ors/api/services/APIServiceTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/api/services/APIServiceTest.java
@@ -193,7 +193,7 @@ class APIServiceTest {
     void convertSpecificProfileParameters() {
         RequestProfileParamsRestrictions restrictions = new RequestProfileParamsRestrictions();
         restrictions.setHeight(10.0f);
-        ProfileParameters params = apiService.convertSpecificProfileParameters(2, restrictions, APIEnums.VehicleType.HGV);
+        ProfileParameters params = apiService.convertSpecificProfileParameters(2, restrictions);
         assertTrue(params instanceof VehicleParameters);
         assertEquals(10.0f, ((VehicleParameters) params).getHeight(), 0.0);
     }

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -1217,7 +1217,6 @@ class ResultTest extends ServiceTest {
         params.put("restrictions", restrictions);
         JSONObject options = new JSONObject();
         options.put("profile_params", params);
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
         body.put("continue_straight", false);
 
@@ -1676,7 +1675,6 @@ class ResultTest extends ServiceTest {
         body.put("units", "m");
 
         JSONObject options = new JSONObject();
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
 
         // Test that buses are not allowed on Neue Schlossstraße (https://www.openstreetmap.org/way/150549948)
@@ -1718,7 +1716,6 @@ class ResultTest extends ServiceTest {
         body.put("units", "m");
 
         JSONObject options = new JSONObject();
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
 
         given()
@@ -1763,7 +1760,6 @@ class ResultTest extends ServiceTest {
         params.put("restrictions", restrictions);
         JSONObject options = new JSONObject();
         options.put("profile_params", params);
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
 
         given()
@@ -1786,7 +1782,6 @@ class ResultTest extends ServiceTest {
         params.put("restrictions", restrictions);
         options = new JSONObject();
         options.put("profile_params", params);
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
 
         given()
@@ -1818,7 +1813,6 @@ class ResultTest extends ServiceTest {
         params.put("restrictions", restrictions);
         JSONObject options = new JSONObject();
         options.put("profile_params", params);
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
 
         given()
@@ -1841,7 +1835,6 @@ class ResultTest extends ServiceTest {
         params.put("restrictions", restrictions);
         options = new JSONObject();
         options.put("profile_params", params);
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
 
         given()
@@ -1873,7 +1866,6 @@ class ResultTest extends ServiceTest {
         params.put("restrictions", restrictions);
         JSONObject options = new JSONObject();
         options.put("profile_params", params);
-        options.put("vehicle_type", "hgv");
         body.put("options", options);
 
         given()


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2072.

### Information about the changes
- Key functionality added: enable setting vehicle parameters without the need of specifying vehicle type.
- Reason for change: vehicle parameters were not taken into account unless vehicle type has been set. However, the latter shouldn't be required as of https://github.com/GIScience/openrouteservice/pull/1126 which sets the vehicle type to the default "hgv" value.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request

In the original [example](https://maps.openrouteservice.org/#/directions/Kurf%C3%BCrsten-Anlage%2019%2F1,Heidelberg,BW,Germany/Hausackerweg%202,Heidelberg,BW,Germany/data/55,130,32,198,15,97,4,224,38,9,96,59,2,24,5,192,166,6,113,0,184,64,14,0,232,3,103,192,118,1,25,240,160,6,50,1,97,162,178,5,96,25,159,0,105,232,19,144,199,136,81,239,141,133,0,76,45,241,143,204,88,128,110,34,100,199,211,19,74,91,122,100,104,243,22,76,183,62,244,43,17,230,88,141,118,148,199,49,9,196,4,0,14,169,224,68,77,135,40,0,94,80,2,218,230,55,96,237,1,0,6,111,0,3,110,139,130,11,13,15,0,6,228,128,14,96,11,64,1,100,159,27,98,4,30,130,30,141,14,136,134,5,23,136,89,3,227,228,91,14,139,13,152,236,234,238,234,4,26,17,30,128,15,160,236,141,12,131,236,210,8,89,138,135,22,8,214,235,138,6,156,137,227,230,139,130,48,10,238,128,11,230,182,180,0,0) from the issue the tunnel tagged with `hazmat:E = no` is now correctly avoided once the box `Hazardous goods` is checked.

![image](https://github.com/user-attachments/assets/ddedcfd4-aa16-4b8d-abc6-15b0ce3a6bbc)


[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
