### PR TITLE
refactor: store core node ID map using DataAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Releasing is documented in RELEASE.md
 - include `graph_date` and `osm_date` in the GPX response ([#2055](https://github.com/GIScience/openrouteservice/issues/2055))
 
 ### Changed
+- refactor: core node ID map using DataAccess ([#2074](https://github.com/GIScience/openrouteservice/pull/2074))
 
 ### Deprecated
 

--- a/ors-engine/pom.xml
+++ b/ors-engine/pom.xml
@@ -38,7 +38,7 @@
     <name>ors-engine</name>
 
     <properties>
-        <project.graphVersion>1</project.graphVersion>
+        <project.graphVersion>2</project.graphVersion>
     </properties>
 
     <build>

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLMPreparationHandler.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLMPreparationHandler.java
@@ -19,7 +19,6 @@ import com.graphhopper.routing.lm.LandmarkSuggestion;
 import com.graphhopper.routing.lm.PrepareLandmarks;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.RoutingCHGraph;
-import org.apache.log4j.Logger;
 import org.heigit.ors.routing.graphhopper.extensions.ORSGraphHopperConfig;
 import org.heigit.ors.routing.graphhopper.extensions.ORSGraphHopperStorage;
 import org.heigit.ors.routing.graphhopper.extensions.util.GraphUtils;
@@ -39,8 +38,6 @@ import java.util.List;
  * @author Andrzej Oles
  */
 public class CoreLMPreparationHandler extends LMPreparationHandler {
-    private static final Logger logger = Logger.getLogger(CoreLandmarkStorage.class);
-
     private final CoreLMOptions coreLMOptions = new CoreLMOptions();
 
     public CoreLMPreparationHandler() {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLMPreparationHandler.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLMPreparationHandler.java
@@ -28,7 +28,6 @@ import org.heigit.ors.routing.graphhopper.extensions.util.ORSParameters.CoreLand
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This class implements the A*, landmark and triangulation (ALT) decorator for Core.
@@ -73,10 +72,6 @@ public class CoreLMPreparationHandler extends LMPreparationHandler {
 
             String lmConfigName = coreLMConfig.getSuperName();
 
-            RoutingCHGraph core = ((ORSGraphHopperStorage) ghStorage).getCoreGraph(lmConfigName);
-            Map<Integer, Integer> coreNodeIdMap = createCoreNodeIdMap(core);
-            logger.info("Created core node ID map for " + coreLMConfig.getName() + " of size " + coreNodeIdMap.size());
-
             Double maximumWeight = getMaximumWeights().get(lmConfigName);
             if (maximumWeight == null)
                 throw new IllegalStateException("""
@@ -85,7 +80,7 @@ public class CoreLMPreparationHandler extends LMPreparationHandler {
                         """ + lmConfigName + " in " + getMaximumWeights());
 
             PrepareLandmarks tmpPrepareLM = new PrepareCoreLandmarks(ghStorage.getDirectory(), ghStorage,
-                    coreLMConfig, getLandmarks(), coreNodeIdMap).
+                    coreLMConfig, getLandmarks()).
                     setLandmarkSuggestions(lmSuggestions).
                     setMaximumWeight(maximumWeight).
                     setLogDetails(getLogDetails());

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -86,17 +86,12 @@ public class CoreLandmarkStorage extends LandmarkStorage {
         long maxBytes = maxNode * CORE_MAP_ROW_LENGTH;
         coreNodeIdDA.create(maxBytes);
         coreNodeIdDA.ensureCapacity(maxBytes);
-        for (long pointer = 0; pointer < maxBytes; pointer += CORE_MAP_ROW_LENGTH) {
-            coreNodeIdDA.setInt(pointer, 0);
-        }
 
-        int coreNodeLevel = maxNode;
         int index = 0;
         for (int i = 0; i < maxNode; i++) {
-            if (core.getLevel(i) < coreNodeLevel)
-                continue;
-            coreNodeIdDA.setInt(i * CORE_MAP_ROW_LENGTH, index);
-            index++;
+            boolean isCoreNode = core.getLevel(i) >= maxNode;
+            coreNodeIdDA.setInt(i * CORE_MAP_ROW_LENGTH, isCoreNode ? index : 0);
+            if (isCoreNode) index++;
         }
     }
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -481,7 +481,7 @@ public class CoreLandmarkStorage extends LandmarkStorage {
 
     @Override
     public void close() {
-        super.flush();
+        super.close();
         coreNodeIdDA.close();
     }
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -87,11 +87,8 @@ public class CoreLandmarkStorage extends LandmarkStorage {
         coreNodeIdDA.create(maxBytes);
         coreNodeIdDA.ensureCapacity(maxBytes);
 
-        int index = 0;
-        for (int i = 0; i < maxNode; i++) {
-            boolean isCoreNode = core.getLevel(i) >= maxNode;
-            coreNodeIdDA.setInt(i * CORE_MAP_ROW_LENGTH, isCoreNode ? index : 0);
-            if (isCoreNode) index++;
+        for (int index = 0, i = 0; i < maxNode; i++) {
+            coreNodeIdDA.setInt(i * CORE_MAP_ROW_LENGTH, core.getLevel(i) >= maxNode ? index++ : 0);
         }
     }
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/CoreLandmarkStorage.java
@@ -54,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Andrzej Oles
  */
 public class CoreLandmarkStorage extends LandmarkStorage {
-    private static final long CORE_MAP_ROW_LENGTH = 4L; // 4 bytes for the core node id
+    private static final long CORE_MAP_ROW_LENGTH = Integer.BYTES; // 4 bytes for the core node id
 
     private static final Logger logger = Logger.getLogger(CoreLandmarkStorage.class);
     private final RoutingCHGraphImpl core;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/PrepareCoreLandmarks.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/core/PrepareCoreLandmarks.java
@@ -22,8 +22,6 @@ import com.graphhopper.util.PMap;
 import org.heigit.ors.routing.graphhopper.extensions.ORSGraphHopperStorage;
 import org.heigit.ors.routing.graphhopper.extensions.edgefilters.core.LMEdgeFilterSequence;
 
-import java.util.Map;
-
 /**
  * This class does the preprocessing for the ALT algorithm (A* , landmark, triangle inequality) in the core.
  * <p>
@@ -37,11 +35,9 @@ import java.util.Map;
 public class PrepareCoreLandmarks extends PrepareLandmarks {
     private final LMEdgeFilterSequence landmarksFilter;
 
-    public PrepareCoreLandmarks(Directory dir, GraphHopperStorage graph, CoreLMConfig lmConfig, int landmarks, Map<Integer, Integer> coreNodeIdMap) {
+    public PrepareCoreLandmarks(Directory dir, GraphHopperStorage graph, CoreLMConfig lmConfig, int landmarks) {
         super(dir, graph, lmConfig, landmarks);
         this.landmarksFilter = lmConfig.getEdgeFilter();
-        CoreLandmarkStorage coreLandmarkStorage = (CoreLandmarkStorage) getLandmarkStorage();
-        coreLandmarkStorage.setCoreNodeIdMap(coreNodeIdMap);
     }
 
     @Override

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/corelm/CoreLandmarkStorageTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/corelm/CoreLandmarkStorageTest.java
@@ -35,9 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
 
-import static org.heigit.ors.routing.graphhopper.extensions.core.CoreLMPreparationHandler.createCoreNodeIdMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -134,10 +132,8 @@ class CoreLandmarkStorageTest {
     }
 
     private CoreLandmarkStorage createLandmarks(LMEdgeFilterSequence lmEdgeFilter) {
-        HashMap<Integer, Integer> coreNodeIdMap = createCoreNodeIdMap(routingCHGraph);
         CoreLMConfig coreLMConfig = new CoreLMConfig(encoder.toString(), weighting).setEdgeFilter(lmEdgeFilter);
         CoreLandmarkStorage storage = new CoreLandmarkStorage(dir, graph, routingCHGraph, coreLMConfig, 2);
-        storage.setCoreNodeIdMap(coreNodeIdMap);
         storage.setMinimumNodes(2);
         storage.createLandmarks();
         return storage;

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/corelm/PrepareCoreLandmarksTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/corelm/PrepareCoreLandmarksTest.java
@@ -42,12 +42,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
 
 import static com.graphhopper.util.GHUtility.updateDistancesFor;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;
-import static org.heigit.ors.routing.graphhopper.extensions.core.CoreLMPreparationHandler.createCoreNodeIdMap;
 import static org.heigit.ors.routing.graphhopper.extensions.core.PrepareCoreTest.contractGraph;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -107,7 +109,6 @@ class PrepareCoreLandmarksTest
         }
 
         RoutingCHGraph core = contractGraph(graph, chConfig, new AllCoreEdgeFilter());
-        HashMap<Integer, Integer> coreNodeIdMap = createCoreNodeIdMap(core);
         Directory dir = new RAMDirectory();
         LocationIndexTree index = new LocationIndexTree(graph, dir);
         index.prepareIndex();
@@ -116,7 +117,6 @@ class PrepareCoreLandmarksTest
         Weighting weighting = new FastestWeighting(encoder);
         CoreLMConfig coreLMConfig = new CoreLMConfig("car", weighting).setEdgeFilter(new LMEdgeFilterSequence());
         CoreLandmarkStorage store = new CoreLandmarkStorage(dir, graph, core, coreLMConfig, lm);
-        store.setCoreNodeIdMap(coreNodeIdMap);
         store.setMinimumNodes(2);
         store.createLandmarks();
 
@@ -152,7 +152,7 @@ class PrepareCoreLandmarksTest
         // TODO should better select 0 and 224?
         assertEquals(Arrays.asList(224, 70), list);
 
-        PrepareLandmarks prepare = new PrepareCoreLandmarks(new RAMDirectory(), graph, coreLMConfig, 4, coreNodeIdMap);
+        PrepareLandmarks prepare = new PrepareCoreLandmarks(new RAMDirectory(), graph, coreLMConfig, 4);
         prepare.setMinimumNodes(2);
         prepare.doWork();
 
@@ -205,12 +205,11 @@ class PrepareCoreLandmarksTest
         CoreTestEdgeFilter restrictedEdges = new CoreTestEdgeFilter();
         restrictedEdges.add(0);
         restrictedEdges.add(1);
-        RoutingCHGraph core = contractGraph(graph, chConfig, restrictedEdges);
-        Map<Integer, Integer> coreNodeIdMap = createCoreNodeIdMap(core);
+        contractGraph(graph, chConfig, restrictedEdges);
 
         Directory dir = new RAMDirectory(fileStr, true).create();
         CoreLMConfig coreLMConfig = new CoreLMConfig("car", weighting).setEdgeFilter(new LMEdgeFilterSequence());
-        PrepareCoreLandmarks plm = new PrepareCoreLandmarks(dir, graph, coreLMConfig, 2, coreNodeIdMap);
+        PrepareCoreLandmarks plm = new PrepareCoreLandmarks(dir, graph, coreLMConfig, 2);
         plm.setMinimumNodes(2);
         plm.doWork();
 
@@ -222,7 +221,7 @@ class PrepareCoreLandmarksTest
         assertEquals(4800, Math.round(plm.getLandmarkStorage().getFromWeight(0, 1) * expectedFactor));
 
         dir = new RAMDirectory(fileStr, true);
-        plm = new PrepareCoreLandmarks(dir, graph, coreLMConfig, 2, coreNodeIdMap);
+        plm = new PrepareCoreLandmarks(dir, graph, coreLMConfig, 2);
         assertTrue(plm.loadExisting());
         assertEquals(expectedFactor, plm.getLandmarkStorage().getFactor(), 1e-6);
         assertEquals(Arrays.toString(new int[]{


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes  #2064.

### Information about the changes
- Reason for change:
Using DataAccess to store the core node ID map for CoreLM makes sure the data can be accessed using MMAP.