### PR TITLE
fix: missing boundaries warning

### DIFF
--- a/ors-engine/src/main/java/org/heigit/ors/config/profile/ExtendedStorageProperties.java
+++ b/ors-engine/src/main/java/org/heigit/ors/config/profile/ExtendedStorageProperties.java
@@ -61,7 +61,7 @@ public class ExtendedStorageProperties {
     @JsonIgnore
     private Path openborders;
     @JsonIgnore
-    private Boolean preprocessed = false;
+    private Boolean preprocessed;
 
     // Relevant for RoadAccessRestrictions
     @JsonProperty("use_for_warnings")
@@ -98,6 +98,7 @@ public class ExtendedStorageProperties {
         outputLog = ofNullable(this.outputLog).orElse(other.outputLog);
         logLocation = ofNullable(this.logLocation).orElse(other.logLocation);
         maximumSlope = ofNullable(this.maximumSlope).orElse(other.maximumSlope);
+        preprocessed = ofNullable(this.preprocessed).orElse(other.preprocessed);
         boundaries = ofNullable(this.boundaries).orElse(other.boundaries);
         ids = ofNullable(this.ids).orElse(other.ids);
         openborders = ofNullable(this.openborders).orElse(other.openborders);
@@ -134,6 +135,9 @@ public class ExtendedStorageProperties {
         }
         if (!excludedProperties.contains("maximum_slope")) {
             this.maximumSlope = null;
+        }
+        if (!excludedProperties.contains("preprocessed")) {
+            this.preprocessed = null;
         }
         if (!excludedProperties.contains("boundaries")) {
             this.boundaries = null;
@@ -230,9 +234,14 @@ public class ExtendedStorageProperties {
 
     private void initializeBorders(ArrayList<String> nonNullableProperties, ExtendedStorageName storageName) {
         final Path emptyPath = Path.of("");
+        if (preprocessed == null) {
+            this.preprocessed = false;
+        }
         if (boundaries == null || boundaries.equals(emptyPath)) {
-            LOGGER.warn("Storage %s is missing boundaries. Disabling storage.".formatted(storageName));
-            enabled = false;
+            if (!preprocessed) {
+                LOGGER.warn("Storage %s is missing boundaries. Disabling storage.".formatted(storageName));
+                enabled = false;
+            }
             boundaries = Path.of("");
         } else {
             boundaries = boundaries.toAbsolutePath();
@@ -251,6 +260,7 @@ public class ExtendedStorageProperties {
         } else {
             openborders = openborders.toAbsolutePath();
         }
+        nonNullableProperties.add("preprocessed");
         nonNullableProperties.add("boundaries");
         nonNullableProperties.add("ids");
         nonNullableProperties.add("openborders");

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
@@ -57,7 +57,6 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
     private BordersGraphStorage storage;
     private CountryBordersReader cbReader;
     private boolean preprocessed;
-
     private final GeometryFactory gf;
 
     public static final String BUILDER_NAME = "Borders";

--- a/ors-engine/src/test/java/org/heigit/ors/config/ExtendedStoragePropertiesTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/config/ExtendedStoragePropertiesTest.java
@@ -70,6 +70,11 @@ class ExtendedStoragePropertiesTest {
         } else {
             assertNotNull(storage.getMaximumSlope(), "maximum_slope should not be null");
         }
+        if (!nonNullFields.contains("preprocessed")) {
+            assertNull(storage.getPreprocessed(), "preprocessed should be null");
+        } else {
+            assertNotNull(storage.getPreprocessed(), "preprocessed should not be null");
+        }
         if (!nonNullFields.contains("boundaries")) {
             assertNull(storage.getBoundaries(), "boundaries should be null");
         } else {
@@ -134,6 +139,8 @@ class ExtendedStoragePropertiesTest {
         storage.setBoundaries(Paths.get(""));
         assertEquals(Path.of(""), storage.getBoundaries());
     }
+
+
 
     @Test
     void testSetIds() {

--- a/ors-engine/src/test/java/org/heigit/ors/config/ExtendedStoragePropertiesTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/config/ExtendedStoragePropertiesTest.java
@@ -428,16 +428,18 @@ class ExtendedStoragePropertiesTest {
 
     // Same for borders
     @ParameterizedTest
-    @CsvSource({"'', '', ''", // All paths null
-            "'/custom/path.csv', '', ''", // Only boundaries set
-            "'', '/custom/path.csv', ''", // Only ids set
-            "'', '', '/custom/path.csv'", // Only openborders set
-            "'/custom/path.csv', '/custom/path.csv', ''", // boundaries and ids set
-            "'/custom/path.csv', '', '/custom/path.csv'", // boundaries and openborders set
-            "'', '/custom/path.csv', '/custom/path.csv'", // ids and openborders set
-            "'/custom/path.csv', '/custom/path.csv', '/custom/path.csv'" // All paths set -> Enabled!
+    @CsvSource({"'','', '', '', ''", // All paths null
+            "'','/custom/path.csv', '', ''", // Only boundaries set
+            "'','', '/custom/path.csv', ''", // Only ids set
+            "'','', '', '/custom/path.csv'", // Only openborders set
+            "'','/custom/path.csv', '/custom/path.csv', ''", // boundaries and ids set
+            "'','/custom/path.csv', '', '/custom/path.csv'", // boundaries and openborders set
+            "'','', '/custom/path.csv', '/custom/path.csv'", // ids and openborders set
+            "'true','', '/custom/path.csv', '/custom/path.csv'",
+            "'','/custom/path.csv', '/custom/path.csv', '/custom/path.csv'", // All paths set -> Enabled!
+            "'true','/custom/path.csv', '/custom/path.csv', '/custom/path.csv'"
     })
-    void assertSetBordersPathLogic(String boundaries, String ids, String openborders) {
+    void assertSetBordersPathLogic(String preprocessed, String boundaries, String ids, String openborders) {
         ExtendedStorageProperties storage;
         // Test null values
         storage = new ExtendedStorageProperties();
@@ -446,13 +448,15 @@ class ExtendedStoragePropertiesTest {
 
         // Create JSON string based on parameters
         storage = new ExtendedStorageProperties();
+        var isPreprocessed = Boolean.parseBoolean(preprocessed);
+        storage.setPreprocessed(isPreprocessed);
         storage.setBoundaries(Path.of(boundaries));
         storage.setIds(Path.of(ids));
         storage.setOpenborders(Path.of(openborders));
         storage.initialize(ExtendedStorageName.BORDERS);
 
         // Check if storage is enabled or disabled based on paths
-        boolean shouldBeEnabled = !boundaries.isEmpty() && !ids.isEmpty() && !openborders.isEmpty();
+        boolean shouldBeEnabled = (isPreprocessed || !boundaries.isEmpty()) && !ids.isEmpty() && !openborders.isEmpty();
         assertEquals(shouldBeEnabled, storage.getEnabled(), "initialize should disable storage if one of the paths is null");
 
         // Check paths
@@ -478,6 +482,7 @@ class ExtendedStoragePropertiesTest {
         // Assert everything else was set to null
         testStorageObjectIsEmpty(storage, new ArrayList<>() {{
             add("enabled");
+            add("preprocessed");
             add("boundaries");
             add("ids");
             add("openborders");


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

### Information about the changes

Addresses issues with logic of handling the new config parameter `ors.engine.profiles.<PROFILE-NAME>.build.ext_storages.Borders.preprocessed`  introduced in https://github.com/GIScience/openrouteservice/pull/1753 which resulted in the following  warning at startup:

```
2025-06-06 14:04:25 WARN                                              ORS-Init [ o.h.o.c.p.ExtendedStorageProperties      ]   Storage Borders is missing boundaries. Disabling storage.
```


[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
