### PR TITLE
chore: update OpenJDK due to numerous CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Releasing is documented in RELEASE.md
 ### Fixed
 
 ### Security
+- update OpenJDK to 21.0.8 due to [CVE-2025-30749](https://nvd.nist.gov/vuln/detail/CVE-2025-30749), [CVE-2025-30754](https://nvd.nist.gov/vuln/detail/CVE-2025-30754), [CVE-2025-50059](https://nvd.nist.gov/vuln/detail/CVE-2025-50059), [CVE-2025-50106](https://nvd.nist.gov/vuln/detail/CVE-2025-50106), [CVE-2025-21587](https://nvd.nist.gov/vuln/detail/CVE-2025-21587), [CVE-2025-30691](https://nvd.nist.gov/vuln/detail/CVE-2025-30691), [CVE-2025-30698](https://nvd.nist.gov/vuln/detail/CVE-2025-30698)
 
 
 ## [9.3.0] - 2025-06-06

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image is reused in the workflow builds for master and the latest version
-FROM docker.io/maven:3.9.9-amazoncorretto-21-alpine AS build
+FROM docker.io/maven:3.9.10-amazoncorretto-21-alpine AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3002
@@ -31,7 +31,7 @@ FROM docker.io/golang:1.24.2-alpine3.21 AS build-go
 RUN GO111MODULE=on go install github.com/mikefarah/yq/v4@v4.45.1
 
 # build final image, just copying stuff inside
-FROM docker.io/amazoncorretto:21.0.6-alpine3.21 AS publish
+FROM docker.io/amazoncorretto:21.0.8-alpine3.21 AS publish
 
 # Build ARGS
 ARG UID=1000


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Original PR https://github.com/GIScience/openrouteservice/pull/2092.
Fixes https://github.com/GIScience/openrouteservice/issues/2091.

### Information about the changes
- Key functionality added: OpenJDK update
- Reason for change: stay secure

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
