### PR TITLE
fix: borders storage initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Releasing is documented in RELEASE.md
 ### Removed
 
 ### Fixed
+- country borders storage initialization ([#2095](https://github.com/GIScience/openrouteservice/pull/2095))
 
 ### Security
 - update OpenJDK to 21.0.8 due to [CVE-2025-30749](https://nvd.nist.gov/vuln/detail/CVE-2025-30749), [CVE-2025-30754](https://nvd.nist.gov/vuln/detail/CVE-2025-30754), [CVE-2025-50059](https://nvd.nist.gov/vuln/detail/CVE-2025-50059), [CVE-2025-50106](https://nvd.nist.gov/vuln/detail/CVE-2025-50106), [CVE-2025-21587](https://nvd.nist.gov/vuln/detail/CVE-2025-21587), [CVE-2025-30691](https://nvd.nist.gov/vuln/detail/CVE-2025-30691), [CVE-2025-30698](https://nvd.nist.gov/vuln/detail/CVE-2025-30698)

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
@@ -91,14 +91,16 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
             String countryIdsFile = "";
             String openBordersFile = "";
 
-            preprocessed = parameters.getPreprocessed();
+            preprocessed = Boolean.TRUE.equals(parameters.getPreprocessed());
 
-            if (parameters.getBoundaries() != null)
-                bordersFile = parameters.getBoundaries().toString();
-            else if (!preprocessed) {
-                ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_BOUNDARIES);
-                // We cannot continue without the information
-                throw new MissingResourceException("An OSM file enriched with country tags or a boundary geometry file is needed to use the borders extended storage!", BordersGraphStorage.class.getName(), PARAM_KEY_BOUNDARIES);
+            if (!preprocessed) {
+                if (parameters.getBoundaries() != null) {
+                    bordersFile = parameters.getBoundaries().toString();
+                } else {
+                    ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_BOUNDARIES);
+                    // We cannot continue without the information
+                    throw new MissingResourceException("An OSM file enriched with country tags or a boundary geometry file is needed to use the borders extended storage!", BordersGraphStorage.class.getName(), PARAM_KEY_BOUNDARIES);
+                }
             }
 
             if (parameters.getIds() != null)
@@ -119,8 +121,8 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
             cbReader = CountryBordersReader.deserialize(expectedStorageFileLocation2);
         }
         storage = new BordersGraphStorage();
-        return storage;
 
+        return storage;
     }
 
     /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
@@ -18,7 +18,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.storage.GraphExtension;
 import com.graphhopper.util.EdgeIteratorState;
 import org.apache.log4j.Logger;
-import org.heigit.ors.config.profile.ExtendedStorageProperties;
 import org.heigit.ors.routing.graphhopper.extensions.reader.borders.CountryBordersPolygon;
 import org.heigit.ors.routing.graphhopper.extensions.reader.borders.CountryBordersReader;
 import org.heigit.ors.routing.graphhopper.extensions.storages.BordersGraphStorage;
@@ -28,6 +27,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,42 +79,11 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
         if (storage != null)
             throw new Exception("GraphStorageBuilder has been already initialized.");
 
-        ExtendedStorageProperties parameters;
-        parameters = this.parameters;
-
         File expectedStorageFileLocation1 = Path.of(graphhopper.getGraphHopperLocation() + "/ext_borders").toFile();
         File expectedStorageFileLocation2 = Path.of(graphhopper.getGraphHopperLocation() + "/ext_borders_cbr").toFile();
+
         if (this.cbReader == null && (!expectedStorageFileLocation1.exists() || !expectedStorageFileLocation2.exists())) {
-            // Read the border shapes from the file
-            // First check if parameters are present
-            String bordersFile = "";
-            String countryIdsFile = "";
-            String openBordersFile = "";
-
-            preprocessed = Boolean.TRUE.equals(parameters.getPreprocessed());
-
-            if (!preprocessed) {
-                if (parameters.getBoundaries() != null) {
-                    bordersFile = parameters.getBoundaries().toString();
-                } else {
-                    ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_BOUNDARIES);
-                    // We cannot continue without the information
-                    throw new MissingResourceException("An OSM file enriched with country tags or a boundary geometry file is needed to use the borders extended storage!", BordersGraphStorage.class.getName(), PARAM_KEY_BOUNDARIES);
-                }
-            }
-
-            if (parameters.getIds() != null)
-                countryIdsFile = parameters.getIds().toString();
-            else
-                ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_IDS);
-
-            if (parameters.getOpenborders() != null)
-                openBordersFile = parameters.getOpenborders().toString();
-            else
-                ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_OPEN_BORDERS);
-
-            // Read the file containing all of the country border polygons
-            cbReader = new CountryBordersReader(bordersFile, countryIdsFile, openBordersFile);
+            cbReader = createCountryBordersReader();
             cbReader.serialize(expectedStorageFileLocation2);
         }
         if (cbReader == null && expectedStorageFileLocation2.exists()) {
@@ -125,8 +94,39 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
         return storage;
     }
 
+    private CountryBordersReader createCountryBordersReader() throws IOException {
+        String bordersFile = "";
+        String countryIdsFile = "";
+        String openBordersFile = "";
+
+        preprocessed = Boolean.TRUE.equals(parameters.getPreprocessed());
+
+        if (!preprocessed) {
+            if (parameters.getBoundaries() != null) {
+                bordersFile = parameters.getBoundaries().toString();
+            } else {
+                ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_BOUNDARIES);
+                // We cannot continue without the information
+                throw new MissingResourceException("An OSM file enriched with country tags or a boundary geometry file is needed to use the borders extended storage!", BordersGraphStorage.class.getName(), PARAM_KEY_BOUNDARIES);
+            }
+        }
+
+        if (parameters.getIds() != null)
+            countryIdsFile = parameters.getIds().toString();
+        else
+            ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_IDS);
+
+        if (parameters.getOpenborders() != null)
+            openBordersFile = parameters.getOpenborders().toString();
+        else
+            ErrorLoggingUtility.logMissingConfigParameter(BordersGraphStorageBuilder.class, PARAM_KEY_OPEN_BORDERS);
+
+        // Read the file containing all the country border polygons
+        return new CountryBordersReader(bordersFile, countryIdsFile, openBordersFile);
+    }
+
     /**
-     * COverwrite the current reader with a custom built CountryBordersReader.
+     * Overwrite the current reader with a custom-built CountryBordersReader.
      *
      * @param cbr The CountryBordersReader object to be used
      */


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

### Information about the changes
- Key functionality added: ignore obsolete boundaries file in case OSM data has been enriched with country ids in preprocessing.
- Reason for change: failing borders graph storage builder in case both `preprocessed: true` and `boundaries` config parameters to `ors.engine.profiles.<profile>.build.ext_storages.Borders` were set. 

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
