### PR TITLE
fix: do not attempt connecting to a database if data store url is empty

### DIFF
--- a/ors-api/src/main/java/org/heigit/ors/api/services/DynamicDataService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/DynamicDataService.java
@@ -5,6 +5,7 @@ import org.heigit.ors.config.EngineProperties;
 import org.heigit.ors.routing.RoutingProfile;
 import org.heigit.ors.routing.RoutingProfileManager;
 import org.heigit.ors.routing.RoutingProfileManagerStatus;
+import org.heigit.ors.util.StringUtility;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
@@ -99,6 +100,8 @@ public class DynamicDataService {
     }
 
     private void fetchDynamicData(RoutingProfile profile) {
+        if (StringUtility.isNullOrEmpty(storeURL))
+            return;
         String graphDate = profile.getGraphhopper().getGraphHopperStorage().getProperties().get("datareader.data.date");
         profile.getDynamicDatasets().forEach(key -> {
             LOGGER.debug("Fetching dynamic data for profile '" + profile.name() + "', dataset '" + key + "', graph date '" + graphDate + "'.");


### PR DESCRIPTION
Avoid exceptions `java.sql.SQLException: No suitable driver found for` being thrown in `DynamicDataService`.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].


### Information about the changes
- Reason for change: Avoid the following exceptions being thrown on startup of the test instance.

```
2025-09-16 18:16:34 ERROR                                                 main [ o.h.o.a.s.DynamicDataService             ]   Error during dynamic data update: No suitable driver found for 
java.sql.SQLException: No suitable driver found for 
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:707) ~[java.sql:?]
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:230) ~[java.sql:?]
	at org.heigit.ors.api.services.DynamicDataService.lambda$fetchDynamicData$3(DynamicDataService.java:105) ~[classes/:?]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) ~[?:?]
	at org.heigit.ors.api.services.DynamicDataService.fetchDynamicData(DynamicDataService.java:103) ~[classes/:?]
	at org.heigit.ors.api.services.DynamicDataService.lambda$initialize$2(DynamicDataService.java:79) ~[classes/:?]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) ~[?:?]
	at org.heigit.ors.api.services.DynamicDataService.initialize(DynamicDataService.java:74) ~[classes/:?]
	at org.heigit.ors.api.services.DynamicDataService.<init>(DynamicDataService.java:42) ~[classes/:?]
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[?:?]
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[?:?]
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[?:?]
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:210) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:146) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:318) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:309) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1395) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:569) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:529) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:339) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:373) [spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:337) [spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) [spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.instantiateSingleton(DefaultListableBeanFactory.java:1222) [spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingleton(DefaultListableBeanFactory.java:1188) [spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:1123) [spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:987) [spring-context-6.2.10.jar:6.2.10]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627) [spring-context-6.2.10.jar:6.2.10]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) [spring-boot-3.4.9.jar:3.4.9]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752) [spring-boot-3.4.9.jar:3.4.9]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439) [spring-boot-3.4.9.jar:3.4.9]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318) [spring-boot-3.4.9.jar:3.4.9]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361) [spring-boot-3.4.9.jar:3.4.9]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350) [spring-boot-3.4.9.jar:3.4.9]
	at org.heigit.ors.api.Application.main(Application.java:35) [classes/:?]
```

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
