### PR TITLE
docs: add unit information about duration parameter for matrix requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Releasing is documented in RELEASE.md
 
 ### Changed
 - transition from extended storage to encoded values for storing way type and surface ([#2113](https://github.com/GIScience/openrouteservice/pull/2113), [#2115](https://github.com/GIScience/openrouteservice/pull/2115))
+- add unit information about duration parameter for matrix requests to documentation ([#2130](https://github.com/GIScience/openrouteservice/pull/2130))
 
 ### Deprecated
 

--- a/docs/api-reference/endpoints/matrix/index.md
+++ b/docs/api-reference/endpoints/matrix/index.md
@@ -24,7 +24,7 @@ To specify, from which to which of these locations the metric should be calculat
 ```
 
 The numbers in both parameter value arrays represent the index of the locations array in the same request. 
-In the example above, the duration from the first (0) and second (1) location to the third (2) and fourth (3) location will be calculated: 
+In the example above, the duration in seconds from the first (0) and second (1) location to the third (2) and fourth (3) location will be calculated: 
 
     0 -> 2
     0 -> 3
@@ -37,11 +37,11 @@ and the second array contains the duration from the second source (1) to both de
 
 ```json
   "durations": [
-    [            // durations from first source to each destination
+    [            // durations in seconds from first source to each destination
       448.82,    //     0 -> 2
       553.01     //     0 -> 3
     ],
-    [            // durations from second source to each destination
+    [            // durations in seconds from second source to each destination
       142.68,    //     1 -> 2
       246.88     //     1 -> 3
     ]
@@ -53,8 +53,8 @@ If for example the locations array has 5 entries,
 the sources array has only one entry `[0]`, 
 and `destinations` is missing, then duration are calculated from location 0 to all locations in the location list.
 
-The first entry in the result `durations` list represents the duration from location 0 to itself and is `0`. 
+The first entry in the result `durations` list represents the duration in seconds from location 0 to itself and is `0`.
 
-To specify whether distances or duration (or both) are to be calculated, the `metrics` parameter can be set accordingly.
+To specify whether distances or duration (or both) are to be calculated, the `metrics` parameter can be set accordingly. The unit of distances can be meter, kilometer or miles. The unit of duration is always in seconds.
 
 For details about all request parameters and the response type, see the [API Playground](https://openrouteservice.org/dev/#/api-docs/matrix_service).


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
