### PR TITLE
ci: fix workflow runs for external PRs [testing - DO NOT MERGE]

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -11,6 +11,9 @@ jobs:
   label:
     name: Add PR title conventional type to PR labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull_requests: write
     steps:
       - name: Add conventional release labels
         uses: bcoe/conventional-release-labels@v1

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -11,9 +11,6 @@ jobs:
   label:
     name: Add PR title conventional type to PR labels
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull_requests: write
     steps:
       - name: Add conventional release labels
         uses: bcoe/conventional-release-labels@v1

--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ For questions please use our [community forum](https://ask.openrouteservice.org)
 ## Translations
 
 If you notice anything wrong with translations, or you want to add a new language to the openrouteservice instructions, we have some instructions in our [backend documentation](https://GIScience.github.io/openrouteservice/contributing/contributing-translations) about how you can submit an update. You can also look over at our [maps client GitHub](https://github.com/GIScience/ors-map-client/#add-language) if you want to contribute the language to there as well (adding or editing the language in the openrouteservice GitHub repo only affects the instructions - any new language also needs adding to the client).
+

--- a/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
+++ b/ors-engine/src/main/java/org/heigit/ors/util/AppInfo.java
@@ -26,6 +26,7 @@ import org.json.JSONObject;
 import java.io.InputStream;
 import java.util.Properties;
 
+
 public class AppInfo {
     private static final Logger LOGGER = Logger.getLogger(AppInfo.class.getName());
     /**


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
