### PR TITLE
ci: use separate SonarQube scan action

### DIFF
--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -6,7 +6,7 @@ name: Java CI with Maven
 on:
   push:
     branches: [ "main" ]
-  pull_request_target:
+  pull_request:
     branches: [ "**" ]
 
 jobs:
@@ -35,18 +35,15 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Download maven dependencies
-        run: ./mvnw package -Dmaven.test.skip=true -B dependency:go-offline dependency:resolve-plugins dependency:resolve -q
+        run: ./mvnw install -Dmaven.test.skip=true -B dependency:go-offline dependency:resolve-plugins dependency:resolve -q
       - name: run unit tests
         run: ./mvnw -B verify -Papitests -T $(nproc) -DCI=true
       - name: Run the unit tests a second time with jacoco
         run: |
           # Ensure test stability across graph reloads.
           ./mvnw -B verify -Papitests -T $(nproc) jacoco:report
-      - name: Scan results with Sonar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./mvnw -B org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar
+      - name: 'Prepare Sonar analysis'
+        uses: evaristegalois11/sonar-fork-analysis@v1
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@1.1.1
         env:

--- a/.github/workflows/sonarcube-scan.yml
+++ b/.github/workflows/sonarcube-scan.yml
@@ -1,0 +1,22 @@
+name: 'Sonar'
+on:
+  workflow_run:
+    workflows: [ 'Java CI with Maven' ]
+    types:
+      - completed
+jobs:
+  sonar:
+    name: 'SonarCube Analysis'
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read # Required to download artifacts
+    steps:
+      - name: 'Sonar analysis'
+        uses: evaristegalois11/sonar-fork-analysis@v1
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          project-key: 'GIScience_openrouteservice'


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

### Information about the changes
- Key functionality added: separate the upload of SonarQube code scan results to Sonar Cloud into a dedicated workflow in order to circumvent issues with missing `SONAR_TOKEN` for external PRs
- Reason for change: SonarQube code scan stopped working after workflow trigger has been switched from `pull_request` to `pull_request_target`.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
