### PR TITLE
feat: accept sac_scale=strolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Releasing is documented in RELEASE.md
 ## [unreleased]
 
 ### Added
+- accept [`sac_scale=strolling`](https://wiki.openstreetmap.org/wiki/Key:sac_scale)
 
 ### Changed
 

--- a/docs/technical-details/tag-filtering.md
+++ b/docs/technical-details/tag-filtering.md
@@ -90,7 +90,7 @@ _intendedValues_ = `[yes, designated, permissive, official]`
 
 | Tag combination                                                                                                                                                                                                         |       Reject       | Accept |    Conditional     |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------:|:------:|:------------------:|
-| `sac_scale != hiking`                                                                                                                                                                                                   | :heavy_check_mark: |        |                    |
+| `sac_scale != [hiking,strolling]`                                                                                                                                                                                       | :heavy_check_mark: |        |                    |
 | `foot = ` _intendedValues_                                                                                                                                                                                              |                    |        | :heavy_check_mark: |
 | _restrictions_ = _restrictedValues_                                                                                                                                                                                     |                    |        | :heavy_check_mark: |
 | `sidewalk = [yes, both, left, right]`                                                                                                                                                                                   |                    |        | :heavy_check_mark: |
@@ -116,9 +116,9 @@ The following are applicable only when no highway tag has been provided for the 
 
 Same as [Foot](#foot) except for different `sac_scale` check with existing `highway` tag.
 
-| Tag combination                                                                    |       Reject       | Accept | Conditional |
-|------------------------------------------------------------------------------------|:------------------:|:------:|:-----------:|
-| `sac_scale != [hiking, mountain_hiking, demanding_mountain_hiking, alpine_hiking]` | :heavy_check_mark: |        |             |
+| Tag combination                                                                               |       Reject       | Accept | Conditional |
+|-----------------------------------------------------------------------------------------------|:------------------:|:------:|:-----------:|
+| `sac_scale != [strolling, hiking, mountain_hiking, demanding_mountain_hiking, alpine_hiking]` | :heavy_check_mark: |        |             |
 
 
 ## Wheelchair

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HikingFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HikingFlagEncoder.java
@@ -40,6 +40,7 @@ public class HikingFlagEncoder extends FootFlagEncoder {
         routeMap.put(LOCAL, VERY_NICE.getValue());
 
         suitableSacScales.addAll(Arrays.asList(
+                "strolling",
                 "hiking",
                 "mountain_hiking",
                 "demanding_mountain_hiking",

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoder.java
@@ -28,6 +28,7 @@ public class PedestrianFlagEncoder extends FootFlagEncoder {
     private PedestrianFlagEncoder(int speedBits, double speedFactor) {
         super(speedBits, speedFactor);
 
+        suitableSacScales.add("strolling");
         suitableSacScales.add("hiking");
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HikingFlagEncoderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HikingFlagEncoderTest.java
@@ -61,6 +61,13 @@ class HikingFlagEncoderTest {
     }
 
     @Test
+    void acceptSimpleSacScale() {
+        way = generateHikeWay();
+        way.setTag("sac_scale", "strolling");
+        assertTrue(flagEncoder.getAccess(way).isWay());
+    }
+
+    @Test
     void testAddPriorityFromRelation() {
         way = generateHikeWay();
         assertEquals(PriorityCode.AVOID_AT_ALL_COSTS.getValue(), flagEncoder.handlePriority(way, 1));

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoderTest.java
@@ -77,6 +77,13 @@ class PedestrianFlagEncoderTest {
     }
 
     @Test
+    void acceptSimpleSacScale() {
+        way = generatePedestrianWay();
+        way.setTag("sac_scale", "strolling");
+        assertTrue(flagEncoder.getAccess(way).isWay());
+    }
+
+    @Test
     void testRejectWay() {
         assertTrue(flagEncoder.getAccess(way).canSkip());
     }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
