### PR TITLE
fix: docker compose image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "8080:8082"  # Expose the ORS API on port 8080
       - "9001:9001"  # Expose additional port for monitoring (optional)
-    image: local/openrouteservice:latest
+    image: openrouteservice/openrouteservice:latest
     # Advanced option! If you different ids to 0:0 and 1000:1000, you have to rebuild the container with the build args UID,GID.
     # The user command is useful if you want easier bind mount access or better security.
     #user: "1000:1000" # Run "mkdir -p ors-docker/config ors-docker/elevation_cache ors-docker/files ors-docker/graphs ors-docker/logs && sudo chown -R 1000:1000 ors" before starting the container!


### PR DESCRIPTION
A user reported that OpenRouteService was not working when deployed via Coolify.

The issue was traced to the Docker Compose file, which referenced the wrong image:
`local/openrouteservice:latest` instead of the correct public image `openrouteservice/openrouteservice:latest`.

<img width="1630" height="329" alt="image" src="https://github.com/user-attachments/assets/0909310f-4cec-4fdf-afac-b589e62cc441" />

This PR Fixes deployment issues for users following the Compose example (including on Coolify)