### PR TITLE
chore: reduce Container Image and Spring Boot vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Releasing is documented in RELEASE.md
 - config parameter `maximum_distance_avoid_areas` is only applied to requests that involve avoid polygons ([#2165](https://github.com/GIScience/openrouteservice/pull/2165))
 
 ### Security
+- reduce Container Image and Spring Boot vulnerabilities to almost 0 by updating dependencies ([#2170](https://github.com/GIScience/openrouteservice/pull/2170))
 
 
 ## [9.5.0] - 2025-10-31

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image is reused in the workflow builds for master and the latest version
-FROM docker.io/maven:3.9.10-amazoncorretto-21-alpine AS build
+FROM docker.io/maven:3.9.11-amazoncorretto-21-alpine AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3002
@@ -26,12 +26,12 @@ COPY ors-engine /tmp/ors/ors-engine
 RUN ./mvnw -pl 'ors-api,ors-engine' \
     -q clean package -DskipTests -Dmaven.test.skip=true
 
-FROM docker.io/golang:1.24.2-alpine3.21 AS build-go
+FROM docker.io/golang:1.25.4-alpine3.22 AS build-go
 # Setup the target system with the right user and folders.
-RUN GO111MODULE=on go install github.com/mikefarah/yq/v4@v4.45.1
+RUN GO111MODULE=on go install github.com/mikefarah/yq/v4@v4.48.1
 
 # build final image, just copying stuff inside
-FROM docker.io/amazoncorretto:21.0.8-alpine3.21 AS publish
+FROM docker.io/amazoncorretto:21.0.9-alpine3.22 AS publish
 
 # Build ARGS
 ARG UID=1000

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
 
-        <jupiter.version>5.11.4</jupiter.version>
+        <jupiter.version>5.12.2</jupiter.version>
         <mockito.version>5.12.0</mockito.version>
         <rest-assured.version>5.5.1</rest-assured.version>
         <testcontainers.version>1.21.0</testcontainers.version>
@@ -481,15 +481,11 @@
             </dependency>
 
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${jupiter.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${jupiter.version}</version>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.12.2</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.10</version>
+        <version>3.5.7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -46,7 +46,7 @@
 
         <!-- switch graphhopper versions to enable debugging -->
         <graphhopper.version>v4.10.0</graphhopper.version>
-<!--        <graphhopper.version>4.10-SNAPSHOT</graphhopper.version>-->
+        <!--        <graphhopper.version>4.10-SNAPSHOT</graphhopper.version>-->
         <lombok.version>1.18.34</lombok.version>
         <slf4j.version>2.0.13</slf4j.version>
         <log4j.version>2.22.1</log4j.version>


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].


**New CVE Load: 0 critical, 0 high, 0 medium, 6 low, 0 negligible**

NAME           INSTALLED   TYPE  VULNERABILITY   SEVERITY  EPSS          RISK   
busybox        1.37.0-r19  apk   CVE-2025-46394  Low       < 0.1% (1st)  < 0.1  
busybox-binsh  1.37.0-r19  apk   CVE-2025-46394  Low       < 0.1% (1st)  < 0.1  
ssl_client     1.37.0-r19  apk   CVE-2025-46394  Low       < 0.1% (1st)  < 0.1  
busybox        1.37.0-r19  apk   CVE-2024-58251  Low       < 0.1% (3rd)  < 0.1  
busybox-binsh  1.37.0-r19  apk   CVE-2024-58251  Low       < 0.1% (3rd)  < 0.1  
ssl_client     1.37.0-r19  apk   CVE-2024-58251  Low       < 0.1% (3rd)  < 0.1

**Old CVE Load: 0 critical, 7 high, 10 medium, 7 low, 0 negligible**

NAME               INSTALLED   FIXED IN         TYPE          VULNERABILITY        SEVERITY  EPSS           RISK   
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-61723       High      < 0.1% (22nd)  < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-61725       High      < 0.1% (22nd)  < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-58186       Medium    < 0.1% (17th)  < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-61724       Medium    < 0.1% (17th)  < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-47912       Medium    < 0.1% (16th)  < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-58188       High      < 0.1% (8th)   < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-58189       Medium    < 0.1% (12th)  < 0.1  
stdlib             go1.24.2    1.23.12, 1.24.6  go-module     CVE-2025-47907       High      < 0.1% (4th)   < 0.1  
stdlib             go1.24.2    1.23.12, 1.24.6  go-module     CVE-2025-47906       Medium    < 0.1% (5th)   < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-58185       Medium    < 0.1% (6th)   < 0.1  
golang.org/x/net   v0.33.0     0.38.0           go-module     GHSA-vvgc-356p-c3xw  Medium    < 0.1% (6th)   < 0.1  
tomcat-embed-core  10.1.46     10.1.47          java-archive  GHSA-hgrr-935x-pq79  Low       < 0.1% (13th)  < 0.1  
stdlib             go1.24.2    1.24.9, 1.25.3   go-module     CVE-2025-58187       High      < 0.1% (2nd)   < 0.1  
golang.org/x/net   v0.33.0     0.36.0           go-module     GHSA-qxp5-gwg8-xv66  Medium    < 0.1% (3rd)   < 0.1  
stdlib             go1.24.2    1.24.4           go-module     CVE-2025-22874       High      < 0.1% (0th)   < 0.1  
stdlib             go1.24.2    1.24.8, 1.25.2   go-module     CVE-2025-58183       Medium    < 0.1% (2nd)   < 0.1  
stdlib             go1.24.2    1.23.11, 1.24.5  go-module     CVE-2025-4674        High      < 0.1% (0th)   < 0.1  
stdlib             go1.24.2    1.23.10, 1.24.4  go-module     CVE-2025-4673        Medium    < 0.1% (0th)   < 0.1  
busybox            1.37.0-r13                   apk           CVE-2025-46394       Low       < 0.1% (1st)   < 0.1  
busybox-binsh      1.37.0-r13                   apk           CVE-2025-46394       Low       < 0.1% (1st)   < 0.1  
ssl_client         1.37.0-r13                   apk           CVE-2025-46394       Low       < 0.1% (1st)   < 0.1  
busybox            1.37.0-r13                   apk           CVE-2024-58251       Low       < 0.1% (3rd)   < 0.1  
busybox-binsh      1.37.0-r13                   apk           CVE-2024-58251       Low       < 0.1% (3rd)   < 0.1  
ssl_client         1.37.0-r13                   apk           CVE-2024-58251       Low       < 0.1% (3rd)   < 0.1



### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
