### PR TITLE
fix: allow minio repo client usage without access_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Releasing is documented in RELEASE.md
 ### Changed
 - enable ALT routing for custom models ([#2165](https://github.com/GIScience/openrouteservice/pull/2165))
 - the configuration parameter `maximum_distance_dynamic_weights` now only applies to scenarios that allow altering of edge weights across the entire routing graph and does not cover cases anymore where only a fixed subset of edges is dynamically weighted ([#2165](https://github.com/GIScience/openrouteservice/pull/2165))
+- allow minio repo client to run without authentication ([#2172](https://github.com/GIScience/openrouteservice/pull/2172))
 
 ### Deprecated
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/remote/MinioGraphRepoClient.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/remote/MinioGraphRepoClient.java
@@ -144,10 +144,12 @@ public class MinioGraphRepoClient extends AbstractGraphRepoClient implements ORS
         }
         try {
             if (minioClient == null) {
-                this.minioClient = MinioClient.builder()
-                        .endpoint(managementProps.getRepoBaseUri().replaceAll("minio:", ""))
-                        .credentials(managementProps.getRepoUser(), managementProps.getRepoPass())
-                        .build();
+                MinioClient.Builder builder = MinioClient.builder()
+                        .endpoint(managementProps.getRepoBaseUri().replace("minio:", ""));
+                if (!isNullOrEmpty(managementProps.getRepoUser()) && !isNullOrEmpty(managementProps.getRepoPass())) {
+                    builder.credentials(managementProps.getRepoUser(), managementProps.getRepoPass());
+                }
+                minioClient = builder.build();
             }
             minioClient.downloadObject(
                     DownloadObjectArgs.builder()


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].


### Information about the changes
- Key functionality added:
public minio repo can be accessed without a key