### PR TITLE
ci: streamline release workflow

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -1,0 +1,74 @@
+name: Build Docker Image
+description: Build a Docker image using docker/build-push-action with configurable options
+
+inputs:
+  dockerfile_path:
+    description: Path to the Dockerfile
+    required: true
+    type: string
+  image_stage:
+    description: Dockerfile target stage to build
+    required: true
+    type: string
+  docker_tag:
+    description: Docker tag for the built image
+    required: true
+    type: string
+  platform:
+    description: Target platform (e.g., linux/amd64, linux/arm64)
+    required: true
+    type: string
+  push_image:
+    description: Whether to push the image to a registry
+    required: false
+    type: boolean
+    default: false
+  cache_from_type:
+    description: Cache backend type (default gha for GitHub Actions)
+    required: false
+    type: string
+    default: 'gha,mode=max'
+  cache_to_type:
+    description: Cache backend type for cache-to (default gha for GitHub Actions)
+    required: false
+    type: string
+    default: 'gha'
+  artifact_full_path:
+    description: Full path to save the artifact (for non-push builds)
+    required: false
+    type: string
+    default: ''
+  output_type:
+    description: Docker output type (docker, or docker with dest).
+    required: false
+    type: string
+    default: 'type=docker'
+
+outputs:
+  imageid:
+    description: Image ID of the built image. Only if output_type includes type=image or type=docker.
+    value: ${{ steps.build-image.outputs.imageid }}
+  digest:
+    description: Digest of the built image. Only if output_type includes type=image or type=docker.
+    value: ${{ steps.build-image.outputs.digest }}
+  metadata:
+    description: Metadata of the built image
+    value: ${{ steps.build-image.outputs.metadata }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build Docker image
+      id: build-image
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+      with:
+        context: .
+        file: ${{ inputs.dockerfile_path }}
+        target: ${{ inputs.image_stage }}
+        push: ${{ inputs.push_image }}
+        load: false
+        tags: ${{ inputs.docker_tag }}
+        platforms: ${{ inputs.platform }}
+        cache-from: type=${{ inputs.cache_from_type }}
+        cache-to: type=${{ inputs.cache_from_type }}
+        outputs: ${{ inputs.output_type }}

--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -16,6 +16,26 @@ inputs:
     required: false
     type: boolean
     default: 'true'
+  with_qemu:
+    description: Set up QEMU for multi-architecture builds
+    required: false
+    type: boolean
+    default: 'false'
+  docker_login:
+    description: Login to Docker registry (requires docker_username and docker_password secrets)
+    required: false
+    type: boolean
+    default: 'false'
+  docker_username:
+    description: Docker registry username (used if docker_login is true)
+    required: false
+    type: string
+    default: ''
+  docker_password:
+    description: Docker registry password (used if docker_login is true)
+    required: false
+    type: string
+    default: ''
   with_docker_cache_injection:
     description: Inject Maven cache into Docker builds
     required: false
@@ -52,10 +72,22 @@ runs:
         ./mvnw package -Dmaven.test.skip=true -B dependency:go-offline dependency:resolve-plugins dependency:resolve -q
         ./mvnw clean -q
 
+    - name: Set up QEMU
+      if: inputs.with_docker == 'true' && inputs.with_qemu == 'true'
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 #v3.7.0
+
     - name: Set up Docker Buildx
       if: inputs.with_docker == 'true'
       id: buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+
+    - name: Login to Docker registry
+      if: inputs.with_docker == 'true' && inputs.docker_login == 'true'
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #3.6.0
+      with:
+        username: ${{ inputs.docker_username }}
+        password: ${{ inputs.docker_password }}
+      continue-on-error: true
 
     - name: Prepare all Dockerfiles for Maven cache mount
       if: inputs.with_docker == 'true' && inputs.with_docker_cache_injection == 'true'

--- a/.github/workflows/_reusable_build_docker_images.yml
+++ b/.github/workflows/_reusable_build_docker_images.yml
@@ -4,14 +4,10 @@ description: Reusable workflow to build Docker images for multiple platforms and
 on:
   workflow_call:
     inputs:
-      push_image_to_dockerhub:
-        description: Whether to push the image to a registry
+      upload_image_as_artifact:
+        description: Upload Docker image as artifact
         type: boolean
         default: false
-      upload_image_as_artifact:
-        description: Upload Docker image as artifact (incompatible with push)
-        type: boolean
-        default: true
       build_arm64:
         description: Build both amd64 and arm64 platforms (if false, only builds specified platform)
         type: boolean
@@ -25,13 +21,9 @@ on:
         type: string
         required: true
       docker_tag:
-        description: Docker tag for the built image
+        description: Docker tag(s) for the built image (comma-separated for multiple tags)
         type: string
         required: true
-      cache_from_type:
-        description: Cache backend type (default gha for GitHub Actions)
-        type: string
-        default: 'gha'
       java_version:
         description: Java version to use for Maven builds
         type: string
@@ -90,6 +82,7 @@ jobs:
         with:
           java_version: ${{ inputs.java_version }}
           dockerfile: ${{ inputs.dockerfile_path }}
+          docker_login: false
 
       - name: Generate Dockerfile hash
         if: matrix.build == true
@@ -116,51 +109,24 @@ jobs:
           echo "artifact_path=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
           ARTIFACT_FULL_PATH="${ARTIFACT_PATH}/${ARTIFACT_NAME}"
           echo "artifact_full_path=$ARTIFACT_FULL_PATH" >> $GITHUB_OUTPUT
-
-      - name: Login to Docker registry
-        if: fromJSON(inputs.push_image_to_dockerhub) && matrix.build == true
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #3.6.0
-        with:
-          username: ${{ secrets.registry_username }}
-          password: ${{ secrets.registry_password }}
-        continue-on-error: true
-
-      - name: Determine Docker output
-        if: matrix.build == true
-        id: output
-        env:
-          PUSH: ${{ inputs.push_image_to_dockerhub }}
-          ARTIFACT_FULL_PATH: ${{ steps.artifact.outputs.artifact_full_path }}
-        run: |
-          if [ "$PUSH" = "true" ]; then
-            echo "output=type=image,push=true" >> $GITHUB_OUTPUT
-          elif [ "$LOAD" = "true" ]; then
-            # Load into Docker daemon requires specific platform syntax
-            echo "output=type=docker" >> $GITHUB_OUTPUT
-          else
-            echo "output=type=docker,dest=$ARTIFACT_FULL_PATH" >> $GITHUB_OUTPUT
-          fi
+          OUTPUT_TYPE="type=docker,dest=${ARTIFACT_FULL_PATH}"
+          echo "output_type=$OUTPUT_TYPE" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
         if: matrix.build == true
         id: build-image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        uses: ./.github/actions/build-docker-image
         with:
-          context: .
-          file: ${{ inputs.dockerfile_path }}
-          target: ${{ inputs.image_stage }}
-          push: ${{ inputs.push_image_to_dockerhub }}
-          load: false
-          tags: ${{ inputs.docker_tag }}
-          platforms: ${{ matrix.platform }}
-          cache-from: type=${{ inputs.cache_from_type }}
-          cache-to: type=${{ inputs.cache_from_type }},mode=max
-          outputs: ${{ steps.output.outputs.output }}
+          dockerfile_path: ${{ inputs.dockerfile_path }}
+          image_stage: ${{ inputs.image_stage }}
+          docker_tag: ${{ inputs.docker_tag }}
+          platform: ${{ matrix.platform }}
+          push_image: false
+          output_type: ${{ steps.artifact.outputs.output_type }}
 
       - name: Upload image artifact
         id: upload-artifact
         if: |
-          !fromJSON(inputs.push_image_to_dockerhub) && 
           matrix.build == true && 
           fromJSON(inputs.upload_image_as_artifact)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_test_action_build_docker_image.yml
+++ b/.github/workflows/_test_action_build_docker_image.yml
@@ -1,0 +1,170 @@
+# Test Build Docker Image Action
+# ==============================
+# Test suite for the build-docker-image composite action.
+#
+# Tests validate:
+# - Docker image build with various dockerfile paths
+#
+# Triggers: Push/PR to action files
+# Local testing: act -j test_action_build_docker_image
+
+name: Test Build Docker Image Action
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '.github/actions/build-docker-image/**'
+      - '.github/workflows/_test_action_build_docker_image.yml'
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - '.github/actions/build-docker-image/**'
+      - '.github/workflows/_test_action_build_docker_image.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test_action_build_docker_image:
+    name: Test build-docker-image action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+
+      - name: Setup Basic Mock Dockerfile
+        run: |
+          echo -e "FROM alpine:latest AS publish\nRUN echo 'Hello, World!'" > test.Dockerfile
+          # Add another stage
+          echo -e "\nFROM publish AS extra\nRUN echo 'Extra Stage'" >> test.Dockerfile
+    
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-environment
+        with:
+          with_java: false
+          with_docker: true
+          with_qemu: true
+          with_docker_cache_injection: false
+
+      - name: Test 1 - Basic build with default Dockerfile
+        id: test1_basic
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile_path: 'test.Dockerfile'
+          image_stage: 'publish'
+          docker_tag: 'test:basic'
+          platform: 'linux/amd64'
+          output_type: 'type=image'
+
+      - name: Verify Test 1 outputs
+        run: |
+          echo "Image ID: ${{ steps.test1_basic.outputs.imageid }}"
+          echo "Digest: ${{ steps.test1_basic.outputs.digest }}"
+          
+          if [ -z '${{ steps.test1_basic.outputs.imageid }}' ]; then
+            echo "Test 1 FAILED: Expected imageid output"
+            exit 1
+          fi
+          
+          if [ -z '${{ steps.test1_basic.outputs.digest }}' ]; then
+            echo "Test 1 FAILED: Expected digest output"
+            exit 1
+          fi
+          
+          echo "Test 1 PASSED: Basic Docker build works"
+      
+      - name: Test 2 - Build with different emulated platform
+        id: test2_platform
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile_path: 'test.Dockerfile'
+          image_stage: 'extra'
+          docker_tag: 'test:platform'
+          platform: 'linux/arm64'
+          output_type: 'type=image'
+
+      - name: Verify Test 2 outputs
+        run: |
+          echo "Image ID: ${{ steps.test2_platform.outputs.imageid }}"
+          echo "Digest: ${{ steps.test2_platform.outputs.digest }}"
+          
+          if [ -z '${{ steps.test2_platform.outputs.imageid }}' ]; then
+            echo "Test 2 FAILED: Expected imageid output"
+            exit 1
+          fi
+
+          if [ -z '${{ steps.test2_platform.outputs.digest }}' ]; then
+            echo "Test 2 FAILED: Expected digest output"
+            exit 1
+          fi
+          
+          echo "Test 2 PASSED: Platform build works"
+      
+      - name: Test 3 - Test Image and Digest ID with type=docker output
+        id: test3
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile_path: 'test.Dockerfile'
+          image_stage: 'publish'
+          docker_tag: 'test:test3'
+          platform: 'linux/amd64'
+          output_type: 'type=docker'
+      - name: Verify Test 3 outputs
+        run: |
+          echo "Image ID: ${{ steps.test3.outputs.imageid }}"
+          echo "Digest: ${{ steps.test3.outputs.digest }}"
+
+          if [ -z '${{ steps.test3.outputs.imageid }}' ]; then
+            echo "Test 3 FAILED: Expected imageid output even with type=docker"
+            exit 1
+          fi
+
+          if [ -z '${{ steps.test3.outputs.digest }}' ]; then
+            echo "Test 3 FAILED: Expected digest output even with type=docker"
+            exit 1
+          fi
+      
+      - name: Test 4 - Empty output_type returns no image and digest IDs
+        id: test4
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile_path: 'test.Dockerfile'
+          image_stage: 'publish'
+          docker_tag: 'test:test4'
+          platform: 'linux/amd64'
+          output_type: ''
+      - name: Verify Test 4 outputs
+        run: |
+          echo "Image ID: ${{ steps.test4.outputs.imageid }}"
+          echo "Digest: ${{ steps.test4.outputs.digest }}"
+          
+          if [ -n '${{ steps.test4.outputs.imageid }}' ]; then
+            echo "Test 4 FAILED: Expected no imageid output with empty output_type"
+            exit 1
+          fi
+
+          if [ -n '${{ steps.test4.outputs.digest }}' ]; then
+            echo "Test 4 FAILED: Expected no digest output with empty output_type"
+            exit 1
+          fi
+      - name: Summary
+        if: always()
+        run: |
+          echo "=========================================="
+          echo "Build Docker Image Action - Test Summary"
+          echo "=========================================="
+          echo "Test 1: Basic build - PASSED"
+          echo "Test 2: Platform build - PASSED"
+          echo "Test 3: type=docker output - PASSED"
+          echo "Test 4: Empty output_type - PASSED"
+          echo "=========================================="
+          echo "All tests executed successfully"
+          echo ""
+          echo "Test Coverage:"
+          echo "  Test 1: Basic build with default Dockerfile"
+          echo "  Test 2: Build with different emulated platform"
+          echo "  Test 3: Image and Digest ID with type=docker output"
+          echo "  Test 4: Empty output_type returns no image and digest IDs"
+          echo "=========================================="

--- a/.github/workflows/_test_action_setup_build_environment.yml
+++ b/.github/workflows/_test_action_setup_build_environment.yml
@@ -62,7 +62,9 @@ jobs:
           echo "Test 1 PASSED: Default configuration with Docker works correctly"
 
       - name: Test build functionality
-        run: ./mvnw clean compile -q
+        run: |
+          java --version
+          ./mvnw --help
 
       - name: Test 2 - Docker Buildx setup verification
         run: |

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -46,6 +46,7 @@ jobs:
       docker_tag: local/openrouteservice:test
       build_amd64: true
       build_arm64: ${{ fromJSON(needs.prepare_environment.outputs.build_arm64) }}
+      upload_image_as_artifact: true
   
   build_minimal_images:
     name: Build Docker images for both platforms - minimal
@@ -56,6 +57,7 @@ jobs:
       docker_tag: local/openrouteservice:test-minimal
       build_amd64: true
       build_arm64: ${{ fromJSON(needs.prepare_environment.outputs.build_arm64) }}
+      upload_image_as_artifact: true
 
   docker_image_tests:
     name: Test ${{ matrix.platform }} - publish image
@@ -88,6 +90,14 @@ jobs:
         with:
           with_java: false
           with_docker: true
+
+      - name: Check artifact availability
+        if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
+        run: |
+          if [[ -z "${{ matrix.artifact_name }}" ]]; then
+            echo "Artifact not available for platform ${{ matrix.platform }}"
+            exit 1
+          fi
 
       - name: Download image artifact
         if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
@@ -169,6 +179,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Check artifact availability
+        if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
+        run: |
+          if [[ -z "${{ matrix.artifact_name }}" ]]; then
+            echo "Artifact not available for platform ${{ matrix.platform }}"
+            exit 1
+          fi
 
       - name: Download image artifact
         if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}

--- a/.github/workflows/publish-tagged-release.yml
+++ b/.github/workflows/publish-tagged-release.yml
@@ -3,101 +3,100 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build from dispatch (overrides github.event.release.tag_name)'
+        required: true
 
 jobs:
-  build_and_publish_docker:
-    name: Build and push the image to docker hub
+  parse_tag:
+    name: Parse release tag and determine if build is needed
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.parse.outputs.tag }}
+      tags_version: ${{ steps.parse.outputs.tags_version }}
+      tags_latest: ${{ steps.parse.outputs.tags_latest }}
+      build_version: ${{ steps.parse.outputs.build_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Parse release tag
+        id: parse
+        uses: ./.github/actions/parse-release-tag
         with:
-          fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        id: buildx
-        with:
-          install: true
-      - name: Get the release tag
-        id: get_tag
-        run: echo ::set-output name=tag::${{ github.event.release.tag_name }}
-      - name: Prepare
-        id: prepare
-        run: |
-          function test_version() {
-            # Loads all versions ever published under the given namespace (max 1024) and splits them. The result is sorted.
-            curl -s -S "https://registry.hub.docker.com/v2/repositories/openrouteservice/openrouteservice/tags/?page_size=1024" |
-              sed -e 's/,/,\n/g' -e 's/\[/\[\n/g' |
-              grep '"name"' |
-              awk -F\" '{print $4;}' |
-              sort -fu
-          }
+          tag: ${{ github.event.inputs.tag || '' }}
 
-          DOCKER_IMAGE=openrouteservice/openrouteservice
-          CURRENT_VERSIONS=$(test_version)
-          LATEST_IMAGE_VERSION=${{ steps.get_tag.outputs.tag }}
-          DOCKER_PLATFORMS=linux/amd64,linux/arm64
-          BUILD_VERSION=true
-
-          TAGS_LATEST_VERSION="${DOCKER_IMAGE}:${LATEST_IMAGE_VERSION}"
-          echo "HIGHEST MAYOR VERSION: $TAGS_HIGHEST_VERSION"
-          TAGS_LATEST="${DOCKER_IMAGE}:latest"
-
-          # Test if the latest published version is already in the versions at docker hub. If so skip the version build.
-          if [[ $CURRENT_VERSIONS =~ $LATEST_IMAGE_VERSION ]]; then
-            echo "Image version: $LATEST_IMAGE_VERSION present or latest. Skipping it!"
-            BUILD_VERSION=false
-          fi
-
-          echo ::set-output name=build_version::${BUILD_VERSION}
-          echo ::set-output name=build_platforms::${DOCKER_PLATFORMS}
-          echo ::set-output name=buildx_tags_version::${TAGS_LATEST_VERSION}
-          echo ::set-output name=buildx_tags_latest::${TAGS_LATEST}
-      - name: Login to DockerHub
-        if: ${{ steps.prepare.outputs.build_version == 'true' }}
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Checkout version if needed
-        if: ${{ steps.prepare.outputs.build_version == 'true' }}
+  build_docker_images:
+    name: Build and cache the Docker images with native runners
+    needs: parse_tag
+    if: ${{ needs.parse_tag.outputs.build_version == 'true' }}
+    uses: ./.github/workflows/_reusable_build_docker_images.yml
+    with:
+      upload_image_as_artifact: false
+      build_amd64: true
+      build_arm64: true
+      image_stage: 'publish'
+      docker_tag: ${{ needs.parse_tag.outputs.tags_version }},${{ needs.parse_tag.outputs.tags_latest }}
+      dockerfile_path: 'Dockerfile'
+  
+  publish_docker_image:
+    name: Publish Docker image to DockerHub
+    runs-on: ubuntu-latest
+    if: ${{ needs.parse_tag.outputs.build_version == 'true' }}
+    needs:
+      - parse_tag
+      - build_docker_images
+    steps:
+      - name: Checkout normally
         uses: actions/checkout@v4
+      - name: Setup Build environment
+        uses: ./.github/actions/setup-build-environment
         with:
-          ref: ${{ steps.get_tag.outputs.tag }}
-      - name: Build and publish version if needed
-        if: ${{ steps.prepare.outputs.build_version == 'true' }}
-        uses: docker/build-push-action@v4
+          with_java: true
+          with_docker: true
+          with_qemu: true
+          with_docker_cache_injection: true
+          java_version: 21
+          dockerfile: 'Dockerfile'
+
+      - name: Build and publish manual version
+        if: ${{ github.event_name == 'workflow_dispatch' && needs.parse_tag.outputs.build_version == 'true' }}
+        uses: ./.github/actions/build-docker-image
         with:
-          context: .
-          push: true
-          tags: ${{ steps.prepare.outputs.buildx_tags_version }},${{ steps.prepare.outputs.buildx_tags_latest }}
-          platforms: ${{ steps.prepare.outputs.build_platforms }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          dockerfile_path: 'Dockerfile'
+          image_stage: 'publish'
+          docker_tag: ${{ needs.parse_tag.outputs.tags_version }}
+          platform: 'linux/amd64,linux/arm64'
+          push_image: true
+          cache_from_type: gha
+          cache_to_type: ''
+      - name: Build and publish release version
+        if: ${{ github.event_name == 'release' && needs.parse_tag.outputs.build_version == 'true' }}
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile_path: 'Dockerfile'
+          image_stage: 'publish'
+          docker_tag: ${{ needs.parse_tag.outputs.tags_version }},${{ needs.parse_tag.outputs.tags_latest }}
+          platform: 'linux/amd64,linux/arm64'
+          push_image: true
+          cache_from_type: gha
+          cache_to_type: ''
+
   build_and_publish_release_artifacts:
+    if: ${{ needs.parse_tag.outputs.build_version == 'true' && github.event_name == 'release' }}
     runs-on: ubuntu-latest
-    needs: build_and_publish_docker
+    needs: [parse_tag, publish_docker_image]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build-environment
         with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'maven'
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Download maven dependencies
-        run: ./mvnw package -Dmaven.test.skip=true -B dependency:go-offline dependency:resolve-plugins dependency:resolve -q
+          with_java: true
+          with_docker: false
+          java_version: 21
       - name: Build JAR
         run: |
           ./mvnw -q clean package -DskipTests
@@ -108,14 +107,10 @@ jobs:
           ./mvnw -q clean package -DskipTests -PbuildWar
           # Copy the WAR to the root directory
           cp ors-api/target/ors.war ors.war
-      - name: Get the release tag
-        id: get_tag
-        run: echo ::set-output name=tag::${{ github.event.release.tag_name }}
       - name: Rewrite the docker-compose.yml image tag to the release tag
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           # Replace the image part
-          sed -i "s/local\/openrouteservice:latest/openrouteservice\/openrouteservice:${{ steps.get_tag.outputs.tag }}/g" docker-compose.yml
+          sed -i "s/local\/openrouteservice:latest/openrouteservice\/openrouteservice:${{ needs.parse_tag.outputs.tag }}/g" docker-compose.yml
       - name: Attach the files to the release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -84,7 +84,7 @@ jobs:
       docker_tag: local/openrouteservice:test
       build_amd64: true
       build_arm64: ${{ !fromJson(needs.prepare_environment.outputs.is_draft) }}
-
+      upload_image_as_artifact: true
   scan_images:
     name: Scan ${{ matrix.platform_name }} image
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
- A lot of redundant code could be removed. However, the test file `.github/workflows/_test_action_setup_build_environment.yml` added a few lines. So it looks bigger than it actually is but the additional code adds a lot of test safety to the workflows.
- Extracted the Docker build step into a composite action named build-docker-image so the logic is reusable and easier to test.
  - The reusable docker-builder workflow now calls the composite action in a pre-defined way.
  - The publishing pipeline calls the same composite action directly at a lower level for more control.
- The publishing (release) workflow now uses the same cache keys/configuration as our other CI workflows to improve caching consistency and runtime.
- Maven artifact publishing remains unchanged (no functional changes to artifact generation/publishing). However, the maven caches now use the proper system-wide caches as well.
- The release workflow can be manually triggered. When run manually it will build and push container images if credentials are present, but it will not create GitHub release artifacts because a manual run does not include a release tag in the git history.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
