### PR TITLE
chore: extent Docker image build workflow with push-by-digest option and related outputs

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -70,5 +70,5 @@ runs:
         tags: ${{ inputs.docker_tag }}
         platforms: ${{ inputs.platform }}
         cache-from: type=${{ inputs.cache_from_type }}
-        cache-to: type=${{ inputs.cache_from_type }}
-        outputs: ${{ inputs.output_type }}
+        cache-to: type=${{ inputs.cache_to_type }}
+        outputs: ${{ inputs.push_image && '' || inputs.output_type }}

--- a/.github/workflows/_reusable_build_docker_images.yml
+++ b/.github/workflows/_reusable_build_docker_images.yml
@@ -8,6 +8,14 @@ on:
         description: Upload Docker image as artifact
         type: boolean
         default: false
+      push_by_digest:
+        description: Push images directly to registry using push-by-digest (for multi-arch manifest combining)
+        type: boolean
+        default: false
+      docker_login:
+        description: Login to Docker registry (required when push_by_digest is true)
+        type: boolean
+        default: false
       build_arm64:
         description: Build both amd64 and arm64 platforms (if false, only builds specified platform)
         type: boolean
@@ -52,9 +60,28 @@ on:
       image_hash_arm64:
         description: Hash of the built image for linux/arm64
         value: ${{ jobs.build_docker_image.outputs.image_hash_arm64 || '' }}
+      image_digest_amd64:
+        description: Digest of the pushed image for linux/amd64 (when push_by_digest is true)
+        value: ${{ jobs.build_docker_image.outputs.image_digest_amd64 || '' }}
+      image_digest_arm64:
+        description: Digest of the pushed image for linux/arm64 (when push_by_digest is true)
+        value: ${{ jobs.build_docker_image.outputs.image_digest_arm64 || '' }}
 
 jobs:
+
+  validate_input_parameters:
+    name: Validate input parameters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate docker_login and push_by_digest
+        run: |
+          if [ "${{ inputs.push_by_digest }}" = "true" ] && [ "${{ inputs.docker_login }}" != "true" ]; then
+            echo "Error: docker_login must be true when push_by_digest is true."
+            exit 1
+          fi
+
   build_docker_image:
+    needs: validate_input_parameters
     strategy:
       matrix:
         include:
@@ -72,6 +99,8 @@ jobs:
       image_hash_arm64: ${{ matrix.platform == 'linux/arm64' && steps.final-artifact.outputs.image_hash || '' }}
       artifact_name_amd64: ${{ matrix.platform == 'linux/amd64' && steps.final-artifact.outputs.artifact_name || '' }}
       artifact_name_arm64: ${{ matrix.platform == 'linux/arm64' && steps.final-artifact.outputs.artifact_name || '' }}
+      image_digest_amd64: ${{ matrix.platform == 'linux/amd64' && steps.build-image.outputs.digest || '' }}
+      image_digest_arm64: ${{ matrix.platform == 'linux/arm64' && steps.build-image.outputs.digest || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -82,7 +111,9 @@ jobs:
         with:
           java_version: ${{ inputs.java_version }}
           dockerfile: ${{ inputs.dockerfile_path }}
-          docker_login: false
+          docker_login: ${{ inputs.docker_login }}
+          docker_username: ${{ secrets.registry_username }}
+          docker_password: ${{ secrets.registry_password }}
 
       - name: Generate Dockerfile hash
         if: matrix.build == true
@@ -93,7 +124,7 @@ jobs:
           HASH=$(sha256sum "$DOCKERFILE_PATH" | cut -d' ' -f1 | cut -c1-8)
           echo "hash=$HASH" >> $GITHUB_OUTPUT
 
-      - name: Set artifact names
+      - name: Set artifact names and output type
         if: matrix.build == true
         id: artifact
         env:
@@ -101,6 +132,8 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           HASH: ${{ steps.dockerfile-hash.outputs.hash }}
           RUNNER_TEMP: ${{ runner.temp }}
+          PUSH_BY_DIGEST: ${{ inputs.push_by_digest }}
+          DOCKER_TAG: ${{ inputs.docker_tag }}
         run: |
           PLATFORM_NAME=$(echo "$PLATFORM" | sed 's/\//_/g')
           ARTIFACT_NAME="image-${PLATFORM_NAME}-${IMAGE_STAGE}-${HASH}.tar"
@@ -109,8 +142,20 @@ jobs:
           echo "artifact_path=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
           ARTIFACT_FULL_PATH="${ARTIFACT_PATH}/${ARTIFACT_NAME}"
           echo "artifact_full_path=$ARTIFACT_FULL_PATH" >> $GITHUB_OUTPUT
-          OUTPUT_TYPE="type=docker,dest=${ARTIFACT_FULL_PATH}"
+          
+          if [ "$PUSH_BY_DIGEST" = "true" ]; then
+            # Use push-by-digest for multi-arch manifest combining
+            OUTPUT_TYPE="push-by-digest=true,type=image"
+            CACHE_TO_TYPE='' # no cache-to needed when pushing
+            PUSH_IMAGE="true"
+          else
+            # Use docker output for artifact
+            OUTPUT_TYPE="type=docker,dest=${ARTIFACT_FULL_PATH}"
+            PUSH_IMAGE="false"
+          fi
           echo "output_type=$OUTPUT_TYPE" >> $GITHUB_OUTPUT
+          echo "cache_to_type=$CACHE_TO_TYPE" >> $GITHUB_OUTPUT
+          echo "push_image=$PUSH_IMAGE" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
         if: matrix.build == true
@@ -121,14 +166,16 @@ jobs:
           image_stage: ${{ inputs.image_stage }}
           docker_tag: ${{ inputs.docker_tag }}
           platform: ${{ matrix.platform }}
-          push_image: false
+          push_image: ${{ steps.artifact.outputs.push_image == 'true' }}
           output_type: ${{ steps.artifact.outputs.output_type }}
+          cache_to_type: ${{ steps.artifact.outputs.cache_to_type || 'gha' }}
 
       - name: Upload image artifact
         id: upload-artifact
         if: |
           matrix.build == true && 
-          fromJSON(inputs.upload_image_as_artifact)
+          fromJSON(inputs.upload_image_as_artifact) &&
+          !fromJSON(inputs.push_by_digest)
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.artifact_name }}


### PR DESCRIPTION
This is a preparation step to have a streamlined and modern multi-arch build process. Build digests can be built on separate machines and later combined into one multi-arch image tag release.

The functionality is already tested inside [_test_action_build_docker_image.yml](https://github.com/GIScience/openrouteservice/blob/main/.github/workflows/_test_action_build_docker_image.yml) and with this PR just be made available also to [_reusable_build_docker_images.yml](https://github.com/GIScience/openrouteservice/blob/main/.github/workflows/_reusable_build_docker_images.yml)


### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
