### PR TITLE
fix: improve preparation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Releasing is documented in RELEASE.md
 ### Added
 
 ### Changed
+- improve `preparation_mode` ([#2221](https://github.com/GIScience/openrouteservice/pull/2221))
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ USER ors
 
 # Run Java jar directly as PID 1
 # Configuration via environment variables:
-# - JAVA_OPTS: additional JVM options
+# - JDK_JAVA_OPTIONS: additional JVM options
 # - Server settings via Spring properties (e.g., server.port, server.servlet.context-path)
 # - Logging via Spring properties (logging.level.*, logging.pattern.*)
 ENTRYPOINT ["java", "-jar", "/ors.jar"]

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -182,6 +182,8 @@ public class RoutingProfile {
      * </ul>
      *
      * @param profileProperties profile properties holding graph path and profile name; must not be null and must include a non-null graph path and profile name
+     * @param graphVersion      version identifier of the graph data, used as part of the generated archive and metadata filenames
+     * @return {@code true} if the graph was successfully prepared (archived), {@code false} if any step failed (copying graph info, creating the archive, or if no graph files were found)
      */
     public static boolean prepareGeneratedGraphForUpload(ProfileProperties profileProperties, String graphVersion) {
         LOGGER.info("Running in preparation_mode, preparing graph for upload");

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -201,7 +201,6 @@ public class RoutingProfile {
             return false;
         }
 
-
         // create a zip archive of all files in graphFilesPath with .ghz extension
         Path graphArchiveDst = profileProperties.getGraphPath().resolve(graphBaseFilename + ".ghz");
         try (FileOutputStream fos = new FileOutputStream(graphArchiveDst.toFile()); ZipOutputStream zos = new ZipOutputStream(fos)) {

--- a/ors-engine/src/main/java/org/heigit/ors/util/RuntimeUtility.java
+++ b/ors-engine/src/main/java/org/heigit/ors/util/RuntimeUtility.java
@@ -30,10 +30,10 @@ public class RuntimeUtility {
     }
 
     public static void printRAMInfo(String hint, Logger logger) {
-        logger.info(hint + "Total - " + getMemorySize(Runtime.getRuntime().totalMemory()) + ", Free - "
-                + getMemorySize(Runtime.getRuntime().freeMemory()) + ", Max: " + getMemorySize(Runtime.getRuntime().maxMemory())
-                + ", Used - "
-                + getMemorySize(Runtime.getRuntime().totalMemory() - (Runtime.getRuntime().freeMemory())));
+        logger.info(hint + "Total: " + getMemorySize(Runtime.getRuntime().totalMemory()) +
+                ", Free: " + getMemorySize(Runtime.getRuntime().freeMemory()) +
+                ", Max: " + getMemorySize(Runtime.getRuntime().maxMemory()) +
+                ", Used: " + getMemorySize(Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()));
     }
 
     public static String getMemorySize(long size) {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [x] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

### Information about the changes
Reason for change:
- properly fail ORS startup if running in preparation mode and graph packing fails
- refactoring (code formatting)
- docs (corrected docker slim image env var name)
