### PR TITLE
fix: non-empty route summary for zero-length routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Releasing is documented in RELEASE.md
 
 ### Fixed
 - correct distance calculation of skipped segments ([#2230](https://github.com/GIScience/openrouteservice/pull/2230))
+- non-empty route summary in (geo)JSON response for zero-length routes ([#2234](https://github.com/GIScience/openrouteservice/pull/2234))
 
 ### Security
 

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/json/JSONSummary.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/json/JSONSummary.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 
 @Schema(description = "Route statistics such as distance and duration.")
-@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class JSONSummary {
     @Schema(description = "Total route distance in specified units.", example = "12.6")
     @JsonProperty(value = "distance")

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -3090,6 +3090,43 @@ class ResultTest extends ServiceTest {
     }
 
     @Test
+    void testIdenticalStartAndEndCoordinates() {
+        JSONObject body = new JSONObject();
+        body.put("coordinates", HelperFunctions.constructCoords("8.690915,49.430117|8.690915,49.430117"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.jsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/json")
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].summary.isEmpty()", is(false))
+                .body("routes[0].summary.distance", is(0.0))
+                .body("routes[0].summary.duration", is(0.0))
+                .statusCode(200);
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.geoJsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .assertThat()
+                .body("any { it.key == 'features' }", is(true))
+                .body("features[0].properties.isEmpty()", is(false))
+                .body("features[0].properties.summary.isEmpty()", is(false))
+                .body("features[0].properties.summary.distance", is(0.0))
+                .body("features[0].properties.summary.duration", is(0.0))
+                .statusCode(200);
+    }
+
+    @Test
     void testIdenticalCoordinatesIndexing() { // Taki needs to look into this, see if the problem in question is addressed properly...
         JSONObject body = new JSONObject();
         body.put("coordinates", HelperFunctions.constructCoords("8.676131,49.418149|8.676142,49.457555|8.676142,49.457555|8.680733,49.417248"));


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2233.

### Information about the changes
- **Key functionality added:** Serializes the route summary object with explicit 0 distance/duration values, instead of an empty object in the case of 0‑length routes, e.g., when the start and end coordinates are the same.
- **Reason for change:** user-reported bug


[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
