### PR TITLE
fix: respect isochrone range limit for different distance units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Releasing is documented in RELEASE.md
 ### Removed
 
 ### Fixed
+- scale the isochrone ranges and intervals according to the specified distance units such that they align with the range limits defined in meters ([#2240](https://github.com/GIScience/openrouteservice/pull/2240))
 
 ### Security
 - update lodash-es to 4.17.23 due to [CVE-2025-13465](https://www.cve.org/CVERecord?id=CVE-2025-13465)

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/isochrones/IsochronesRequest.java
@@ -69,8 +69,8 @@ public class IsochronesRequest extends APIRequest {
     private boolean hasLocationType = false;
 
     @Schema(name = PARAM_RANGE, description = """
-            Maximum range value of the analysis in **seconds** for time and **metres** for distance.\
-            Alternatively a comma separated list of specific range values. Ranges will be the same for all locations.\
+            Maximum range value of the analysis in **seconds** when `range_type` is set to `time`, or in the given `units` when it is set to `distance`.\
+            Alternatively, a comma-separated list of specific range values. The same ranges will apply to all locations.\
             """,
             example = "[ 300, 200 ]",
             requiredMode = Schema.RequiredMode.REQUIRED)
@@ -152,7 +152,7 @@ public class IsochronesRequest extends APIRequest {
 
     @Schema(name = PARAM_INTERVAL, description = """
             Interval of isochrones or equidistants. This is only used if a single range value is given. \
-            Value in **seconds** for time and **meters** for distance.\
+            Value in **seconds** when `range_type = time`, or in the given `units` when `range_type = distance`.\
             """,
             example = "30"
     )

--- a/ors-api/src/main/java/org/heigit/ors/api/services/IsochronesService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/IsochronesService.java
@@ -1,6 +1,7 @@
 package org.heigit.ors.api.services;
 
 import org.heigit.ors.api.APIEnums;
+import org.heigit.ors.api.APIEnums.Units;
 import org.heigit.ors.api.config.ApiEngineProperties;
 import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.requests.common.APIRequest;
@@ -212,15 +213,32 @@ public class IsochronesService extends ApiService {
         if (isochronesRequest.hasLocationType())
             travellerInfo.setLocationType(isochronesRequest.getLocationType().toString());
         travellerInfo.setLocation(convertSingleCoordinate(coordinate));
-        travellerInfo.getRanges();
-        //range + interval
         if (isochronesRequest.getRange() == null) {
             throw new ParameterValueException(IsochronesErrorCodes.MISSING_PARAMETER, IsochronesRequest.PARAM_RANGE);
         }
         List<Double> rangeValues = isochronesRequest.getRange();
         Double intervalValue = isochronesRequest.getInterval();
         setRangeAndIntervals(travellerInfo, rangeValues, intervalValue);
+        if (isochronesRequest.hasRangeUnits() && travellerInfo.getRangeType() == TravelRangeType.DISTANCE)
+            performRangeUnitConversion(travellerInfo, isochronesRequest.getRangeUnit());
+
         return travellerInfo;
+    }
+
+    private static void performRangeUnitConversion(TravellerInfo traveller, APIEnums.Units unit) {
+        if (unit == null || APIEnums.Units.METRES.equals(unit))
+            return;
+
+        double scale = switch (unit) {
+            case KILOMETRES -> 1000;
+            case MILES -> 1609.34;
+            default -> 1.0;
+        };
+
+        double[] ranges = traveller.getRanges();
+        for (int i = 0; i < ranges.length; i++) {
+            ranges[i] *= scale;
+        }
     }
 
     RouteSearchParameters constructRouteSearchParameters(IsochronesRequest isochronesRequest) throws Exception {

--- a/ors-api/src/main/java/org/heigit/ors/api/services/IsochronesService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/IsochronesService.java
@@ -1,7 +1,6 @@
 package org.heigit.ors.api.services;
 
 import org.heigit.ors.api.APIEnums;
-import org.heigit.ors.api.APIEnums.Units;
 import org.heigit.ors.api.config.ApiEngineProperties;
 import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.requests.common.APIRequest;
@@ -17,7 +16,9 @@ import org.heigit.ors.exceptions.ParameterOutOfRangeException;
 import org.heigit.ors.exceptions.ParameterValueException;
 import org.heigit.ors.exceptions.StatusCodeException;
 import org.heigit.ors.fastisochrones.partitioning.FastIsochroneFactory;
-import org.heigit.ors.isochrones.*;
+import org.heigit.ors.isochrones.IsochroneMapCollection;
+import org.heigit.ors.isochrones.IsochroneRequest;
+import org.heigit.ors.isochrones.IsochronesErrorCodes;
 import org.heigit.ors.isochrones.statistics.StatisticsProviderConfiguration;
 import org.heigit.ors.routing.RouteSearchParameters;
 import org.heigit.ors.routing.RoutingProfileManager;

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
@@ -65,7 +65,6 @@ class ParamsTest extends ServiceTest {
         JSONArray ranges_2 = new JSONArray();
         ranges_2.put(1800);
         ranges_2.put(1800);
-        //ranges_3.put(1800);
 
         JSONArray ranges_1800 = new JSONArray();
         ranges_1800.put(1800);
@@ -211,7 +210,6 @@ class ParamsTest extends ServiceTest {
                 .statusCode(400);
     }
 
-    // too many locations
     @Test
     void testTooManyLocations() {
 
@@ -232,7 +230,6 @@ class ParamsTest extends ServiceTest {
                 .statusCode(400);
     }
 
-    // unknown units
     @Test
     void testUnknownUnits() {
 
@@ -450,7 +447,7 @@ class ParamsTest extends ServiceTest {
     }
 
     @Test
-    void testRangetypeUnitsKm() {
+    void testRangeTypeUnitsKm() {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
@@ -470,9 +467,8 @@ class ParamsTest extends ServiceTest {
                 .statusCode(200);
     }
 
-    // m
     @Test
-    void testRangetypeUnitsM() {
+    void testRangeTypeUnitsM() {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
@@ -493,9 +489,8 @@ class ParamsTest extends ServiceTest {
 
     }
 
-    // mi
     @Test
-    void testRangetypeUnitsMi() {
+    void testRangeTypeUnitsMi() {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
@@ -545,29 +545,6 @@ class ParamsTest extends ServiceTest {
     }
 
     @Test
-    void testRangesUserUnits() {
-
-        JSONArray ranges = new JSONArray();
-        ranges.put(200);
-
-        JSONObject body = new JSONObject();
-        body.put("locations", getParameter("locations_1"));
-        body.put("range", ranges);
-        body.put("range_type", "distance");
-        body.put("units", "km");
-        body.put("location_type", "destination");
-
-        given()
-                .headers(geoJsonContent)
-                .pathParam("profile", getParameter("carProfile"))
-                .body(body.toString())
-                .when()
-                .post(getEndPointPath() + "/{profile}/geojson")
-                .then()
-                .statusCode(200);
-    }
-
-    @Test
     void testRangeRestrictionTime() {
 
         JSONArray ranges = new JSONArray();

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
@@ -454,9 +454,9 @@ class ParamsTest extends ServiceTest {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
-        body.put("range", getParameter("ranges_1800"));
+        body.put("range", new JSONArray().put(18));
         body.put("range_type", "distance");
-        body.put("interval", getParameter("interval_200"));
+        body.put("interval", 2);
         body.put("units", "km");
         body.put("location_type", "start");
 
@@ -499,9 +499,9 @@ class ParamsTest extends ServiceTest {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
-        body.put("range", getParameter("ranges_1800"));
+        body.put("range", new JSONArray().put(9));
         body.put("range_type", "distance");
-        body.put("interval", getParameter("interval_200"));
+        body.put("interval", 1);
         body.put("units", "mi");
         body.put("location_type", "start");
 

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
@@ -592,15 +592,34 @@ class ParamsTest extends ServiceTest {
 
     @Test
     void testRangeRestrictionDistance() {
-
         JSONArray ranges = new JSONArray();
-        ranges.put(1100000);
+        ranges.put(100000);
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
         body.put("range", ranges);
         body.put("range_type", "distance");
 
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("cyclingProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(400)
+                .body("error.code", Matchers.is(IsochronesErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM));
+
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(200);
+
+        ranges.put(200000);
         given()
                 .headers(geoJsonContent)
                 .pathParam("profile", getParameter("carProfile"))

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ParamsTest.java
@@ -632,6 +632,48 @@ class ParamsTest extends ServiceTest {
     }
 
     @Test
+    void testRangeRestrictionDistanceUnitsKm() {
+        JSONArray ranges = new JSONArray();
+        ranges.put(100);
+
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", ranges);
+        body.put("range_type", "distance");
+        body.put("units", "km");
+
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("cyclingProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(400)
+                .body("error.code", Matchers.is(IsochronesErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM));
+
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(200);
+
+        ranges.put(200);
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(400)
+                .body("error.code", Matchers.is(IsochronesErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM));
+    }
+
+    @Test
     void testAttributes() {
 
         JSONArray ranges = new JSONArray();

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/ResultTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.*;
 @VersionAnnotation(version = "v2")
 class ResultTest extends ServiceTest {
     public static final RestAssuredConfig JSON_CONFIG_DOUBLE_NUMBERS = RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE));
+    public static final double MILE_IN_METERS = 1609.34;
 
     public ResultTest() {
 
@@ -82,6 +83,8 @@ class ResultTest extends ServiceTest {
         Integer interval_400 = 400;
         Integer interval_900 = 900;
 
+        JSONArray attributesArea = new JSONArray().put("area");
+
         JSONArray attributesReachfactorArea = new JSONArray();
         attributesReachfactorArea.put("area");
         attributesReachfactorArea.put("reachfactor");
@@ -102,6 +105,7 @@ class ResultTest extends ServiceTest {
         addParameter("interval_200", interval_200);
         addParameter("interval_200", interval_400);
         addParameter("interval_900", interval_900);
+        addParameter("attributesArea", attributesArea);
         addParameter("attributesReachfactorArea", attributesReachfactorArea);
         addParameter("attributesReachfactorAreaFaulty", attributesReachfactorAreaFaulty);
 
@@ -364,6 +368,78 @@ class ResultTest extends ServiceTest {
                 .body("features[0].properties.reachfactor", is(closeTo(0.7629, 0.0148)))
                 .statusCode(200);
 
+    }
+
+    @Test
+    void testAreaRangeUnitsMAreaUnitsM() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", new JSONArray().put(MILE_IN_METERS));
+        body.put("range_type", "distance");
+        body.put("units", "m");
+        body.put("area_units", "m");
+        body.put("attributes", getParameter("attributesArea"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.geoJsonContent)
+                .pathParam("profile", getParameter("cyclingProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .body("any { it.key == 'type' }", is(true))
+                .body("any { it.key == 'features' }", is(true))
+                .body("features[0].properties.area", is(closeTo(5443455, 1000)))
+                .statusCode(200);
+    }
+
+    @Test
+    void testAreaRangeUnitsKmAreaUnitsM() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", new JSONArray().put(MILE_IN_METERS / 1000));
+        body.put("range_type", "distance");
+        body.put("units", "km");
+        body.put("area_units", "m");
+        body.put("attributes", getParameter("attributesArea"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.geoJsonContent)
+                .pathParam("profile", getParameter("cyclingProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .body("any { it.key == 'type' }", is(true))
+                .body("any { it.key == 'features' }", is(true))
+                .body("features[0].properties.area", is(closeTo(5443455, 1000)))
+                .statusCode(200);
+    }
+
+    @Test
+    void testAreaRangeUnitsMiAreaUnitsM() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", new JSONArray().put(1));
+        body.put("range_type", "distance");
+        body.put("units", "mi");
+        body.put("area_units", "m");
+        body.put("attributes", getParameter("attributesArea"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.geoJsonContent)
+                .pathParam("profile", getParameter("cyclingProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .body("any { it.key == 'type' }", is(true))
+                .body("any { it.key == 'features' }", is(true))
+                .body("features[0].properties.area", is(closeTo(5443455, 1000)))
+                .statusCode(200);
     }
 
     @Test

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ParamsTest.java
@@ -457,9 +457,9 @@ class ParamsTest extends ServiceTest {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
-        body.put("range", getParameter("ranges_1800"));
+        body.put("range", new JSONArray().put(18));
         body.put("range_type", "distance");
-        body.put("interval", getParameter("interval_200"));
+        body.put("interval", 2);
         body.put("units", "km");
         body.put("location_type", "start");
 
@@ -502,9 +502,9 @@ class ParamsTest extends ServiceTest {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
-        body.put("range", getParameter("ranges_1800"));
+        body.put("range", new JSONArray().put(9));
         body.put("range_type", "distance");
-        body.put("interval", getParameter("interval_200"));
+        body.put("interval", 1);
         body.put("units", "mi");
         body.put("location_type", "start");
 
@@ -547,29 +547,6 @@ class ParamsTest extends ServiceTest {
     }
 
     @Test
-    void testRangesUserUnits() {
-
-        JSONArray ranges = new JSONArray();
-        ranges.put(200);
-
-        JSONObject body = new JSONObject();
-        body.put("locations", getParameter("locations_1"));
-        body.put("range", ranges);
-        body.put("range_type", "distance");
-        body.put("units", "km");
-        body.put("location_type", "destination");
-
-        given()
-                .headers(geoJsonContent)
-                .pathParam("profile", getParameter("hgvProfile"))
-                .body(body.toString())
-                .when()
-                .post(getEndPointPath() + "/{profile}/geojson")
-                .then()
-                .statusCode(200);
-    }
-
-    @Test
     void testRangeRestrictionTime() {
 
         JSONArray ranges = new JSONArray();
@@ -594,15 +571,56 @@ class ParamsTest extends ServiceTest {
 
     @Test
     void testRangeRestrictionDistance() {
-
         JSONArray ranges = new JSONArray();
-        ranges.put(1100000);
+        ranges.put(500000);
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
         body.put("range", ranges);
         body.put("range_type", "distance");
 
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("hgvProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(200);
+
+        ranges.put(1000000);
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("hgvProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(400)
+                .body("error.code", Matchers.is(IsochronesErrorCodes.PARAMETER_VALUE_EXCEEDS_MAXIMUM));
+    }
+
+    @Test
+    void testRangeRestrictionDistanceUnitsKm() {
+        JSONArray ranges = new JSONArray();
+        ranges.put(500);
+
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", ranges);
+        body.put("range_type", "distance");
+        body.put("units", "km");
+
+        given()
+                .headers(geoJsonContent)
+                .pathParam("profile", getParameter("hgvProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .statusCode(200);
+
+        ranges.put(1000);
         given()
                 .headers(geoJsonContent)
                 .pathParam("profile", getParameter("hgvProfile"))

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ParamsTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ParamsTest.java
@@ -66,7 +66,6 @@ class ParamsTest extends ServiceTest {
         JSONArray ranges_2 = new JSONArray();
         ranges_2.put(1800);
         ranges_2.put(1800);
-        //ranges_3.put(1800);
 
         JSONArray ranges_1800 = new JSONArray();
         ranges_1800.put(1800);
@@ -212,7 +211,6 @@ class ParamsTest extends ServiceTest {
                 .statusCode(400);
     }
 
-    // too many locations
     @Test
     void testTooManyLocations() {
 
@@ -233,7 +231,6 @@ class ParamsTest extends ServiceTest {
                 .statusCode(400);
     }
 
-    // unknown units
     @Test
     void testUnknownUnits() {
 
@@ -453,7 +450,7 @@ class ParamsTest extends ServiceTest {
     }
 
     @Test
-    void testRangetypeUnitsKm() {
+    void testRangeTypeUnitsKm() {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
@@ -473,9 +470,8 @@ class ParamsTest extends ServiceTest {
                 .statusCode(200);
     }
 
-    // m
     @Test
-    void testRangetypeUnitsM() {
+    void testRangeTypeUnitsM() {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));
@@ -496,9 +492,8 @@ class ParamsTest extends ServiceTest {
 
     }
 
-    // mi
     @Test
-    void testRangetypeUnitsMi() {
+    void testRangeTypeUnitsMi() {
 
         JSONObject body = new JSONObject();
         body.put("locations", getParameter("locations_1"));

--- a/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/isochrones/fast/ResultTest.java
@@ -14,12 +14,14 @@
 package org.heigit.ors.apitests.isochrones.fast;
 
 import io.restassured.RestAssured;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.path.json.config.JsonPathConfig;
 import org.hamcrest.Matchers;
 import org.heigit.ors.apitests.common.EndPointAnnotation;
 import org.heigit.ors.apitests.common.ServiceTest;
 import org.heigit.ors.apitests.common.VersionAnnotation;
 import org.heigit.ors.apitests.isochrones.IsochronesErrorCodes;
+import org.heigit.ors.apitests.utils.CommonHeaders;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,9 @@ import static org.heigit.ors.apitests.utils.CommonHeaders.geoJsonContent;
 @EndPointAnnotation(name = "isochrones")
 @VersionAnnotation(version = "v2")
 class ResultTest extends ServiceTest {
+    public static final RestAssuredConfig JSON_CONFIG_DOUBLE_NUMBERS = RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE));
     private static final float REACHFACTOR_REFERENCE_VALUE = 0.0544f;
+    private static final double MILE_IN_METERS = 1609.34;
 
     public ResultTest() {
 
@@ -80,6 +84,8 @@ class ResultTest extends ServiceTest {
         Integer interval_400 = 400;
         Integer interval_900 = 900;
 
+        JSONArray attributesArea = new JSONArray().put("area");
+
         JSONArray attributesReachfactorArea = new JSONArray();
         attributesReachfactorArea.put("area");
         attributesReachfactorArea.put("reachfactor");
@@ -100,6 +106,7 @@ class ResultTest extends ServiceTest {
         addParameter("interval_200", interval_200);
         addParameter("interval_200", interval_400);
         addParameter("interval_900", interval_900);
+        addParameter("attributesArea", attributesArea);
         addParameter("attributesReachfactorArea", attributesReachfactorArea);
         addParameter("attributesReachfactorAreaFaulty", attributesReachfactorAreaFaulty);
 
@@ -319,6 +326,78 @@ class ResultTest extends ServiceTest {
                 .body("features[0].properties.reachfactor", is(closeTo(REACHFACTOR_REFERENCE_VALUE, 0.01)))
                 .statusCode(200);
 
+    }
+
+    @Test
+    void testAreaRangeUnitsMAreaUnitsM() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", new JSONArray().put(MILE_IN_METERS));
+        body.put("range_type", "distance");
+        body.put("units", "m");
+        body.put("area_units", "m");
+        body.put("attributes", getParameter("attributesArea"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.geoJsonContent)
+                .pathParam("profile", getParameter("hgvProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .body("any { it.key == 'type' }", is(true))
+                .body("any { it.key == 'features' }", is(true))
+                .body("features[0].properties.area", is(closeTo(4433000, 1000)))
+                .statusCode(200);
+    }
+
+    @Test
+    void testAreaRangeUnitsKmAreaUnitsM() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", new JSONArray().put(MILE_IN_METERS / 1000));
+        body.put("range_type", "distance");
+        body.put("units", "km");
+        body.put("area_units", "m");
+        body.put("attributes", getParameter("attributesArea"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.geoJsonContent)
+                .pathParam("profile", getParameter("hgvProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .body("any { it.key == 'type' }", is(true))
+                .body("any { it.key == 'features' }", is(true))
+                .body("features[0].properties.area", is(closeTo(4433000, 1000)))
+                .statusCode(200);
+    }
+
+    @Test
+    void testAreaRangeUnitsMiAreaUnitsM() {
+        JSONObject body = new JSONObject();
+        body.put("locations", getParameter("locations_1"));
+        body.put("range", new JSONArray().put(1));
+        body.put("range_type", "distance");
+        body.put("units", "mi");
+        body.put("area_units", "m");
+        body.put("attributes", getParameter("attributesArea"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.geoJsonContent)
+                .pathParam("profile", getParameter("hgvProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}/geojson")
+                .then()
+                .body("any { it.key == 'type' }", is(true))
+                .body("any { it.key == 'features' }", is(true))
+                .body("features[0].properties.area", is(closeTo(4433000, 1000)))
+                .statusCode(200);
     }
 
     @Test

--- a/ors-engine/src/main/java/org/heigit/ors/common/TravellerInfo.java
+++ b/ors-engine/src/main/java/org/heigit/ors/common/TravellerInfo.java
@@ -57,44 +57,6 @@ public class TravellerInfo {
         return ranges;
     }
 
-    /**
-     * Returns the range specified in the unit given by the user. The algorithm converts
-     * the input range to m so we need to convert it back.
-     *
-     * @param unit the unit to return in
-     * @return the ranges array in the specified unit
-     */
-
-    public double[] getRangesInUnit(String unit) {
-        // convert ranges from meters to user specified unit
-        double[] rangesInUnit = new double[ranges.length];
-
-        if (!(unit == null || "m".equalsIgnoreCase(unit))) {
-            double scale = 1.0;
-            if (rangeType == TravelRangeType.DISTANCE) {
-                switch (unit) {
-                    case "km":
-                        scale = 1 / 1000.0;
-                        break;
-                    case "mi":
-                        scale = 1 / 1609.34;
-                        break;
-                    default:
-                    case "m":
-                        break;
-                }
-            }
-
-            if (scale != 1.0) {
-                for (int i = 0; i < ranges.length; i++)
-                    rangesInUnit[i] = ranges[i] * scale;
-                return rangesInUnit;
-            }
-            return ranges;
-        }
-        return ranges;
-    }
-
     public void setRanges(double range, double interval) {
         int nRanges = (int) Math.ceil(range / interval);
         ranges = new double[nRanges];

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/IsochroneRequest.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/IsochroneRequest.java
@@ -15,7 +15,6 @@ package org.heigit.ors.isochrones;
 
 import org.apache.log4j.Logger;
 import org.heigit.ors.common.ServiceRequest;
-import org.heigit.ors.common.TravelRangeType;
 import org.heigit.ors.common.TravellerInfo;
 import org.heigit.ors.exceptions.InternalServerException;
 import org.heigit.ors.isochrones.statistics.StatisticsProvider;

--- a/ors-engine/src/main/java/org/heigit/ors/isochrones/IsochroneRequest.java
+++ b/ors-engine/src/main/java/org/heigit/ors/isochrones/IsochroneRequest.java
@@ -129,32 +129,7 @@ public class IsochroneRequest extends ServiceRequest {
 
     public IsochroneSearchParameters getSearchParameters(int travellerIndex) {
         TravellerInfo traveller = travellers.get(travellerIndex);
-        double[] ranges = traveller.getRanges();
-
-        // convert ranges in units to meters or seconds
-        if (!(units == null || "m".equalsIgnoreCase(units))) {
-            double scale = 1.0;
-            if (traveller.getRangeType() == TravelRangeType.DISTANCE) {
-                switch (units) {
-                    default:
-                    case "m":
-                        break;
-                    case "km":
-                        scale = 1000;
-                        break;
-                    case "mi":
-                        scale = 1609.34;
-                        break;
-                }
-            }
-
-            if (scale != 1.0) {
-                for (int i = 0; i < ranges.length; i++)
-                    ranges[i] = ranges[i] * scale;
-            }
-        }
-
-        IsochroneSearchParameters parameters = new IsochroneSearchParameters(travellerIndex, traveller.getLocation(), ranges);
+        IsochroneSearchParameters parameters = new IsochroneSearchParameters(travellerIndex, traveller.getLocation(), traveller.getRanges());
         parameters.setLocation(traveller.getLocation());
         parameters.setRangeType(traveller.getRangeType());
         parameters.setCalcMethod(calcMethod);


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [x] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2239.

### Information about the changes
- Key functionality added: scale the isochrone ranges appropriately based on the specified units so that they align with the range limits defined in meters.
- Reason for change: bug report


[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines