### PR TITLE
fix: avoid duplicate fields in the geometry of the GeoJSON response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Releasing is documented in RELEASE.md
 - scale the isochrone ranges and intervals according to the specified distance units such that they align with the range limits defined in meters ([#2240](https://github.com/GIScience/openrouteservice/pull/2240))
 - adapt docs to always download latest version ([#2243](https://github.com/GIScience/openrouteservice/pull/2243))
 - output ors_id in export endpoint topojson result with `additional_info` flag ([#2244](https://github.com/GIScience/openrouteservice/pull/2244))
+- avoid duplicate fields in the route geometry of the GeoJSON response ([#2249](https://github.com/GIScience/openrouteservice/pull/2249))
 
 ### Security
 - update lodash-es to 4.17.23 due to [CVE-2025-13465](https://www.cve.org/CVERecord?id=CVE-2025-13465)

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONGeometry.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONGeometry.java
@@ -24,7 +24,7 @@ public class GeoJSONGeometry {
 
     @Schema(description = "The coordinates array for the geometry")
     @JsonProperty("coordinates")
-    final Object coordinates;
+    public final Object coordinates;
 
     public GeoJSONGeometry(String type, Object coordinates) {
         this.type = type;

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONGeometry.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONGeometry.java
@@ -16,18 +16,12 @@ package org.heigit.ors.api.responses.routing.geojson;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.json.simple.JSONArray;
 
-public class GeoJSONGeometry {
-    @Schema(description = "The geometry type", example = "LineString")
-    @JsonProperty("type")
-    public final String type;
+public record GeoJSONGeometry(
+        @Schema(description = "The geometry type", example = "LineString")
+        @JsonProperty("type") String type,
 
-    @Schema(description = "The coordinates array for the geometry")
-    @JsonProperty("coordinates")
-    public final Object coordinates;
-
-    public GeoJSONGeometry(String type, Object coordinates) {
-        this.type = type;
-        this.coordinates = coordinates;
-    }
-}
+        @Schema(description = "The coordinates array for the geometry")
+        @JsonProperty("coordinates") JSONArray coordinates
+) {}

--- a/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONGeometry.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/responses/routing/geojson/GeoJSONGeometry.java
@@ -14,35 +14,20 @@
 
 package org.heigit.ors.api.responses.routing.geojson;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.json.simple.JSONObject;
 
 public class GeoJSONGeometry {
-
-    private final JSONObject json;
-
-    public GeoJSONGeometry(String type, Object coordinates) {
-        this.json = new JSONObject();
-        this.json.put("type", type);
-        this.json.put("coordinates", coordinates);
-    }
-
     @Schema(description = "The geometry type", example = "LineString")
     @JsonProperty("type")
-    public String getType() {
-        return (String) json.get("type");
-    }
+    public final String type;
 
     @Schema(description = "The coordinates array for the geometry")
     @JsonProperty("coordinates")
-    public Object getCoordinates() {
-        return json.get("coordinates");
-    }
+    final Object coordinates;
 
-    @JsonAnyGetter
-    public JSONObject getJson() {
-        return json;
+    public GeoJSONGeometry(String type, Object coordinates) {
+        this.type = type;
+        this.coordinates = coordinates;
     }
 }

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -26,7 +26,6 @@ import org.heigit.ors.apitests.utils.CommonHeaders;
 import org.heigit.ors.apitests.utils.HelperFunctions;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -56,8 +55,7 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.JsonConfig.jsonConfig;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EndPointAnnotation(name = "directions")
 @VersionAnnotation(version = "v2")
@@ -776,11 +774,13 @@ class ResultTest extends ServiceTest {
                 .response();
 
         // Configure Jackson for strict duplicate detection
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+        ObjectMapper mapper = new ObjectMapper().enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+
+        // Small check to ensure the mapper fails on duplicate keys
+        assertThrows(IOException.class, () -> mapper.readTree("{\"foo\": \"bar\", \"foo\": \"bar\"}"));
 
         // Attempt to parse the JSON and fail if any exception is thrown
-        Assertions.assertDoesNotThrow(() -> mapper.readTree(response.asString()));
+        assertDoesNotThrow(() -> mapper.readTree(response.asString()));
     }
 
     @Test

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -13,6 +13,8 @@
  */
 package org.heigit.ors.apitests.routing;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.path.json.config.JsonPathConfig;
@@ -24,10 +26,12 @@ import org.heigit.ors.apitests.utils.CommonHeaders;
 import org.heigit.ors.apitests.utils.HelperFunctions;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -750,6 +754,39 @@ class ResultTest extends ServiceTest {
                 .body("metadata.containsKey('system_message')", is(true))
 
                 .statusCode(200);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"JSON", "GeoJSON"})
+    void testDuplicateFieldsInResponse(String format) {
+        format = format.toLowerCase();
+        JSONObject body = new JSONObject();
+        body.put("coordinates", getParameter("coordinatesShort"));
+
+        Response response = given()
+                .headers(format.equals("geojson") ? CommonHeaders.geoJsonContent : CommonHeaders.jsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when().log().ifValidationFails()
+                .post(getEndPointPath() + "/{profile}/" + format)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        // Configure Jackson for strict duplicate detection
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+
+        // Attempt to parse the JSON
+        try {
+            // readTree validates the entire structure for duplicates
+            mapper.readTree(response.asString());
+        } catch (Exception e) {
+            // If Jackson detects a duplicate, it throws an exception
+            Assertions.fail(e.getMessage());
+        }
     }
 
     @Test

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -779,14 +779,8 @@ class ResultTest extends ServiceTest {
         ObjectMapper mapper = new ObjectMapper();
         mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
 
-        // Attempt to parse the JSON
-        try {
-            // readTree validates the entire structure for duplicates
-            mapper.readTree(response.asString());
-        } catch (Exception e) {
-            // If Jackson detects a duplicate, it throws an exception
-            Assertions.fail(e.getMessage());
-        }
+        // Attempt to parse the JSON and fail if any exception is thrown
+        Assertions.assertDoesNotThrow(() -> mapper.readTree(response.asString()));
     }
 
     @Test


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [x] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [x] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [x] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2248.

### Information about the changes
- Key functionality added: address duplicate fields.
- Reason for change: invalid GeoJSON response.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
