### PR TITLE
feat: allow bikes on `sac_scale=strolling`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Releasing is documented in RELEASE.md
 
 ### Added
 - add opencontainers metadata annotations to image ([#2264](https://github.com/GIScience/openrouteservice/pull/2264))
+- accept bikes on [`sac_scale=strolling`](https://wiki.openstreetmap.org/wiki/Key:sac_scale) ([#2253](https://github.com/GIScience/openrouteservice/pull/2253))
 
 ### Changed
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
@@ -72,6 +72,7 @@ public abstract class CommonBikeFlagEncoder extends BikeCommonFlagEncoder {
     public static final String KEY_ONEWAY_BICYCLE = "oneway:bicycle";
     public static final String KEY_BRIDLEWAY = "bridleway";
     public static final String KEY_CONSTRUCTION = "construction";
+    public static final String KEY_SAC_SCALE = "sac_scale";
 
     // Pushing section highways are parts where you need to get off your bike and push it (German: Schiebestrecke)
     protected final HashSet<String> pushingSectionsHighways = new HashSet<>();
@@ -332,9 +333,9 @@ public abstract class CommonBikeFlagEncoder extends BikeCommonFlagEncoder {
             return EncodingManager.Access.CAN_SKIP;
         }
 
-        String sacScale = way.getTag("sac_scale");
+        String sacScale = way.getTag(KEY_SAC_SCALE);
         if (sacScale != null) {
-            if (way.hasTag(KEY_HIGHWAY, KEY_CYCLEWAY) && (way.hasTag("sac_scale", "strolling") || way.hasTag("sac_scale", "hiking"))) {
+            if (way.hasTag(KEY_HIGHWAY, KEY_CYCLEWAY) && (way.hasTag(KEY_SAC_SCALE, "strolling") || way.hasTag(KEY_SAC_SCALE, "hiking"))) {
                 return EncodingManager.Access.WAY;
             }
             if (!isSacScaleAllowed(sacScale)) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/CommonBikeFlagEncoder.java
@@ -334,7 +334,7 @@ public abstract class CommonBikeFlagEncoder extends BikeCommonFlagEncoder {
 
         String sacScale = way.getTag("sac_scale");
         if (sacScale != null) {
-            if ((way.hasTag(KEY_HIGHWAY, KEY_CYCLEWAY)) && (way.hasTag("sac_scale", "hiking"))) {
+            if (way.hasTag(KEY_HIGHWAY, KEY_CYCLEWAY) && (way.hasTag("sac_scale", "strolling") || way.hasTag("sac_scale", "hiking"))) {
                 return EncodingManager.Access.WAY;
             }
             if (!isSacScaleAllowed(sacScale)) {
@@ -380,7 +380,7 @@ public abstract class CommonBikeFlagEncoder extends BikeCommonFlagEncoder {
 
     boolean isSacScaleAllowed(String sacScale) {
         // other scales are nearly impossible by an ordinary bike, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
-        return "hiking".equals(sacScale);
+        return "strolling".equals(sacScale) || "hiking".equals(sacScale);
     }
 
     /**

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/MountainBikeFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/bike/MountainBikeFlagEncoder.java
@@ -156,7 +156,7 @@ public class MountainBikeFlagEncoder extends CommonBikeFlagEncoder {
     @Override
     boolean isSacScaleAllowed(String sacScale) {
         // other scales are too dangerous even for MTB, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
-        return "hiking".equals(sacScale) || "mountain_hiking".equals(sacScale)
+        return "strolling".equals(sacScale) || "hiking".equals(sacScale) || "mountain_hiking".equals(sacScale)
                 || "demanding_mountain_hiking".equals(sacScale) || "alpine_hiking".equals(sacScale);
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HikingFlagEncoderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HikingFlagEncoderTest.java
@@ -22,6 +22,8 @@ import org.heigit.ors.routing.graphhopper.extensions.ORSDefaultFlagEncoderFactor
 import org.heigit.ors.routing.graphhopper.extensions.util.PriorityCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.TreeMap;
 
@@ -60,10 +62,11 @@ class HikingFlagEncoderTest {
         assertTrue(flagEncoder.getAccess(way).isWay());
     }
 
-    @Test
-    void acceptSimpleSacScale() {
+    @ParameterizedTest
+    @ValueSource(strings = {"strolling", "hiking"})
+    void acceptSimpleSacScale(String value) {
         way = generateHikeWay();
-        way.setTag("sac_scale", "strolling");
+        way.setTag("sac_scale", value);
         assertTrue(flagEncoder.getAccess(way).isWay());
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/PedestrianFlagEncoderTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.TreeMap;
 
@@ -76,10 +77,11 @@ class PedestrianFlagEncoderTest {
         assertTrue(flagEncoder.getAccess(way).canSkip());
     }
 
-    @Test
-    void acceptSimpleSacScale() {
+    @ParameterizedTest
+    @ValueSource(strings = {"strolling", "hiking"})
+    void acceptSimpleSacScale(String value) {
         way = generatePedestrianWay();
-        way.setTag("sac_scale", "strolling");
+        way.setTag("sac_scale", value);
         assertTrue(flagEncoder.getAccess(way).isWay());
     }
 

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/RegularBikeFlagEncoderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/RegularBikeFlagEncoderTest.java
@@ -21,6 +21,8 @@ import org.heigit.ors.routing.graphhopper.extensions.ORSDefaultFlagEncoderFactor
 import org.heigit.ors.routing.graphhopper.extensions.flagencoders.bike.RegularBikeFlagEncoder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,5 +50,13 @@ class RegularBikeFlagEncoderTest {
 
         way.setTag("bicycle", "no");
         assertTrue(flagEncoder.getAccess(way).canSkip());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"strolling", "hiking"})
+    void acceptSimpleSacScale(String value) {
+        way.setTag("highway", "path");
+        way.setTag("sac_scale", value);
+        assertTrue(flagEncoder.getAccess(way).isWay());
     }
 }


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
