### PR TITLE
docs: add opencontainer metadata annotations to image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Releasing is documented in RELEASE.md
 ## [unreleased]
 
 ### Added
+- add opencontainers metadata annotations to image ([#2264](https://github.com/GIScience/openrouteservice/pull/2264))
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ EXPOSE 8082
 
 HEALTHCHECK --interval=3s --timeout=2s CMD ["sh", "-c", "wget --quiet --tries=1 --spider http://localhost:8082/ors/v2/health || exit 1"]
 
+LABEL org.opencontainers.image.source="https://github.com/GIScience/openrouteservice"
+LABEL org.opencontainers.image.licenses="LGPL-3.0-only"
+
 FROM base AS slim
 # ============================================================================
 # K8s-ready image stage


### PR DESCRIPTION
The Open Container Initiatives Image specification defines a set of optional annotations that add metadata to container images here https://github.com/opencontainers/image-spec/blob/main/annotations.md
Some of these annotations are used by downstream tools that scan images for various reasons. This PR adds 2 common annotations:
- **org.opencontainers.image.source** URL to get source code for building the image (string). Commonly used by dependency updater tools like [renovate](https://github.com/renovatebot/renovate) to find relevant releases and change logs.
- **org.opencontainers.image.licenses** License(s) under which contained software is distributed as an [SPDX License Expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/).