### PR TITLE
fix: guard against invalid `mtb_scale` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Releasing is documented in RELEASE.md
 ### Removed
 
 ### Fixed
+- fix: check whether `mtb_scale` values are within the valid range before attempting to store them ([#2280](https://github.com/GIScience/openrouteservice/pull/2280))
 
 ### Security
 - update postcss to 8.5.12

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/MtbScaleParser.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/MtbScaleParser.java
@@ -37,7 +37,8 @@ public class MtbScaleParser implements TagParser {
                 mtbScale = getMtbScale(way.getTag("mtb:scale:imba"));
         }
 
-        mtbScaleEnc.setInt(false, edgeFlags, mtbScale);
+        if (mtbScale > 0 && mtbScale < 8)
+            mtbScaleEnc.setInt(false, edgeFlags, mtbScale);
 
         return edgeFlags;
     }


### PR DESCRIPTION
### Information about the changes
During an attempt to store values that are outside of the encoder’s range, an uncaught exception is thrown, which causes the build process to fail. This fix prevents that from happening by ensuring the validity of the stored values.

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
