### PR TITLE
feat: speedup ghz handling and add proper logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Releasing is documented in RELEASE.md
 ## [unreleased]
 
 ### Added
+- speedup zip packing and unpacking with Apache Commons parallel processes ([#2294](https://github.com/GIScience/openrouteservice/pull/2294))
 
 ### Changed
 - replace tollways storage with a corresponding encoded value from GraphHopper ([#2257](https://github.com/GIScience/openrouteservice/pull/2257))

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
@@ -237,7 +238,7 @@ public class RoutingProfile {
                 ParallelScatterZipCreator creator = new ParallelScatterZipCreator(pool);
                 for (Path file : graphFiles) {
                     ZipArchiveEntry entry = new ZipArchiveEntry(graphFilesPath.relativize(file).toString().replace('\\', '/'));
-                    entry.setMethod(ZipArchiveEntry.DEFLATED);
+                    entry.setMethod(ZipEntry.DEFLATED);
                     creator.addArchiveEntry(entry, () -> {
                         try {
                             return Files.newInputStream(file);

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -34,19 +34,21 @@ import org.json.simple.JSONObject;
 import org.springframework.util.FileSystemUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import java.util.stream.Stream;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
@@ -201,32 +203,63 @@ public class RoutingProfile {
             return false;
         }
 
-        // create a zip archive of all files in graphFilesPath with .ghz extension
+        // create a zip archive (DEFLATED, parallel NIO) of all files in graphFilesPath with .ghz extension
         Path graphArchiveDst = profileProperties.getGraphPath().resolve(graphBaseFilename + ".ghz");
-        try (FileOutputStream fos = new FileOutputStream(graphArchiveDst.toFile()); ZipOutputStream zos = new ZipOutputStream(fos)) {
-            File[] graphFiles = graphFilesPath.toFile().listFiles();
-            if (graphFiles == null) {
+        if (Files.isDirectory(graphArchiveDst)) {
+            LOGGER.error("Failed to create archive: destination path is a directory: %s".formatted(graphArchiveDst));
+            return false;
+        }
+        Map<String, String> zipEnv = Map.of("create", "true", "compressionMethod", "DEFLATED", "zip64", "true");
+        // "jar:" scheme is required — FileSystems.newFileSystem dispatches by URI scheme; "file:" would route to the
+        // local filesystem provider instead of the built-in ZIP provider and throw FileSystemNotFoundException.
+        // Note: Path.toUri() on a directory appends a trailing slash, which the jar: provider also does not accept.
+        URI zipUri = URI.create("jar:" + graphArchiveDst.toUri());
+        // Declare outside the try so we can log after ZipFileSystem.close() flushes the central directory.
+        double totalRawMB;
+        int fileCount;
+        long packStart;
+        long packEnd;
+        try (FileSystem zipFs = FileSystems.newFileSystem(zipUri, zipEnv)) {
+            List<Path> graphFiles;
+            try (Stream<Path> walk = Files.walk(graphFilesPath)) {
+                graphFiles = walk.filter(p -> !Files.isDirectory(p)).toList();
+            }
+            if (graphFiles.isEmpty()) {
                 LOGGER.error("No graph files found to archive at %s, though we found a graph_build_info file before.".formatted(graphFilesPath.toString()));
                 return false;
             }
-            for (File file : graphFiles) {
-                if (!Files.isDirectory(file.toPath())) {
-                    try (FileInputStream fis = new FileInputStream(file)) {
-                        ZipEntry zipEntry = new ZipEntry(graphFilesPath.relativize(file.toPath()).toString());
-                        zos.putNextEntry(zipEntry);
-                        byte[] buffer = new byte[1024];
-                        int len;
-                        while ((len = fis.read(buffer)) > 0) {
-                            zos.write(buffer, 0, len);
-                        }
+            long totalRawBytes = graphFiles.stream().mapToLong(p -> p.toFile().length()).sum();
+            totalRawMB = totalRawBytes / (1024.0 * 1024.0);
+            fileCount = graphFiles.size();
+            LOGGER.info("Starting archive of %d files (%.1f MB raw) to %s".formatted(fileCount, totalRawMB, graphArchiveDst));
+            packStart = System.currentTimeMillis();
+            List<IOException> packErrors = Collections.synchronizedList(new ArrayList<>());
+            graphFiles.parallelStream().forEach(file -> {
+                try {
+                    Path zipPath = zipFs.getPath(graphFilesPath.relativize(file).toString());
+                    if (zipPath.getParent() != null) {
+                        Files.createDirectories(zipPath.getParent());
                     }
+                    Files.copy(file, zipPath, REPLACE_EXISTING);
+                } catch (IOException e) {
+                    packErrors.add(e);
                 }
+            });
+            if (!packErrors.isEmpty()) {
+                throw packErrors.get(0);
             }
-            LOGGER.info("Created archive %s".formatted(graphArchiveDst.toString()));
+            packEnd = System.currentTimeMillis();
         } catch (IOException e) {
             LOGGER.error("Failed to create archive: %s".formatted(e.toString()));
             return false;
         }
+        // ZipFileSystem.close() has now written the central directory — file size is final.
+        double packElapsedS = (packEnd - packStart) / 1000.0;
+        double archiveMB = graphArchiveDst.toFile().length() / (1024.0 * 1024.0);
+        double throughputMBs = packElapsedS > 0 ? totalRawMB / packElapsedS : 0;
+        LOGGER.info("Archived %d files (%.1f MB) into %.1f MB in %.1fs (%.1f MB/s) using parallel NIO ZipFileSystem (DEFLATED)."
+                .formatted(fileCount, totalRawMB, archiveMB, packElapsedS, throughputMBs));
+        LOGGER.info("Created archive %s".formatted(graphArchiveDst.toString()));
 
         // delete original graph files
         try {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -33,20 +33,24 @@ import org.heigit.ors.util.TimeUtility;
 import org.json.simple.JSONObject;
 import org.springframework.util.FileSystemUtils;
 
+import org.apache.commons.compress.archivers.zip.ParallelScatterZipCreator;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.Zip64Mode;
+
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -203,23 +207,18 @@ public class RoutingProfile {
             return false;
         }
 
-        // create a zip archive (DEFLATED, parallel NIO) of all files in graphFilesPath with .ghz extension
+        // create a zip archive (DEFLATED, parallel scatter-gather) of all files in
+        // graphFilesPath with .ghz extension
         Path graphArchiveDst = profileProperties.getGraphPath().resolve(graphBaseFilename + ".ghz");
         if (Files.isDirectory(graphArchiveDst)) {
             LOGGER.error("Failed to create archive: destination path is a directory: %s".formatted(graphArchiveDst));
             return false;
         }
-        Map<String, String> zipEnv = Map.of("create", "true", "compressionMethod", "DEFLATED", "zip64", "true");
-        // "jar:" scheme is required — FileSystems.newFileSystem dispatches by URI scheme; "file:" would route to the
-        // local filesystem provider instead of the built-in ZIP provider and throw FileSystemNotFoundException.
-        // Note: Path.toUri() on a directory appends a trailing slash, which the jar: provider also does not accept.
-        URI zipUri = URI.create("jar:" + graphArchiveDst.toUri());
-        // Declare outside the try so we can log after ZipFileSystem.close() flushes the central directory.
         double totalRawMB;
         int fileCount;
         long packStart;
         long packEnd;
-        try (FileSystem zipFs = FileSystems.newFileSystem(zipUri, zipEnv)) {
+        try {
             List<Path> graphFiles;
             try (Stream<Path> walk = Files.walk(graphFilesPath)) {
                 graphFiles = walk.filter(p -> !Files.isDirectory(p)).toList();
@@ -233,31 +232,37 @@ public class RoutingProfile {
             fileCount = graphFiles.size();
             LOGGER.info("Starting archive of %d files (%.1f MB raw) to %s".formatted(fileCount, totalRawMB, graphArchiveDst));
             packStart = System.currentTimeMillis();
-            List<IOException> packErrors = Collections.synchronizedList(new ArrayList<>());
-            graphFiles.parallelStream().forEach(file -> {
-                try {
-                    Path zipPath = zipFs.getPath(graphFilesPath.relativize(file).toString());
-                    if (zipPath.getParent() != null) {
-                        Files.createDirectories(zipPath.getParent());
+            ExecutorService pool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+            ParallelScatterZipCreator creator = new ParallelScatterZipCreator(pool);
+            for (Path file : graphFiles) {
+                ZipArchiveEntry entry = new ZipArchiveEntry(graphFilesPath.relativize(file).toString());
+                entry.setMethod(ZipArchiveEntry.DEFLATED);
+                creator.addArchiveEntry(entry, () -> {
+                    try {
+                        return Files.newInputStream(file);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
                     }
-                    Files.copy(file, zipPath, REPLACE_EXISTING);
-                } catch (IOException e) {
-                    packErrors.add(e);
-                }
-            });
-            if (!packErrors.isEmpty()) {
-                throw packErrors.get(0);
+                });
+            }
+            try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(graphArchiveDst.toFile())) {
+                zos.setUseZip64(Zip64Mode.AlwaysWithCompatibility);
+                creator.writeTo(zos);
             }
             packEnd = System.currentTimeMillis();
-        } catch (IOException e) {
+        } catch (IOException | ExecutionException e) {
             LOGGER.error("Failed to create archive: %s".formatted(e.toString()));
             return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Failed to create archive (interrupted): %s".formatted(e.toString()));
+            return false;
         }
-        // ZipFileSystem.close() has now written the central directory — file size is final.
         double packElapsedS = (packEnd - packStart) / 1000.0;
         double archiveMB = graphArchiveDst.toFile().length() / (1024.0 * 1024.0);
         double throughputMBs = packElapsedS > 0 ? totalRawMB / packElapsedS : 0;
-        LOGGER.info("Archived %d files (%.1f MB) into %.1f MB in %.1fs (%.1f MB/s) using parallel NIO ZipFileSystem (DEFLATED)."
+        LOGGER.info(
+                "Archived %d files (%.1f MB) into %.1f MB in %.1fs (%.1f MB/s) using parallel scatter-gather (DEFLATED)."
                 .formatted(fileCount, totalRawMB, archiveMB, packElapsedS, throughputMBs));
         LOGGER.info("Created archive %s".formatted(graphArchiveDst.toString()));
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -236,7 +236,7 @@ public class RoutingProfile {
             try {
                 ParallelScatterZipCreator creator = new ParallelScatterZipCreator(pool);
                 for (Path file : graphFiles) {
-                    ZipArchiveEntry entry = new ZipArchiveEntry(graphFilesPath.relativize(file).toString());
+                    ZipArchiveEntry entry = new ZipArchiveEntry(graphFilesPath.relativize(file).toString().replace('\\', '/'));
                     entry.setMethod(ZipArchiveEntry.DEFLATED);
                     creator.addArchiveEntry(entry, () -> {
                         try {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -255,11 +255,11 @@ public class RoutingProfile {
             }
             packEnd = System.currentTimeMillis();
         } catch (IOException | ExecutionException e) {
-            LOGGER.error("Failed to create archive: %s".formatted(e.toString()));
+            LOGGER.error("Failed to create archive: %s".formatted(e.getMessage()), e);
             return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.error("Failed to create archive (interrupted): %s".formatted(e.toString()));
+            LOGGER.error("Failed to create archive (interrupted): %s".formatted(e.getMessage()), e);
             return false;
         }
         double packElapsedS = (packEnd - packStart) / 1000.0;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfile.java
@@ -233,21 +233,25 @@ public class RoutingProfile {
             LOGGER.info("Starting archive of %d files (%.1f MB raw) to %s".formatted(fileCount, totalRawMB, graphArchiveDst));
             packStart = System.currentTimeMillis();
             ExecutorService pool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
-            ParallelScatterZipCreator creator = new ParallelScatterZipCreator(pool);
-            for (Path file : graphFiles) {
-                ZipArchiveEntry entry = new ZipArchiveEntry(graphFilesPath.relativize(file).toString());
-                entry.setMethod(ZipArchiveEntry.DEFLATED);
-                creator.addArchiveEntry(entry, () -> {
-                    try {
-                        return Files.newInputStream(file);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
-            }
-            try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(graphArchiveDst.toFile())) {
-                zos.setUseZip64(Zip64Mode.AlwaysWithCompatibility);
-                creator.writeTo(zos);
+            try {
+                ParallelScatterZipCreator creator = new ParallelScatterZipCreator(pool);
+                for (Path file : graphFiles) {
+                    ZipArchiveEntry entry = new ZipArchiveEntry(graphFilesPath.relativize(file).toString());
+                    entry.setMethod(ZipArchiveEntry.DEFLATED);
+                    creator.addArchiveEntry(entry, () -> {
+                        try {
+                            return Files.newInputStream(file);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+                }
+                try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(graphArchiveDst.toFile())) {
+                    zos.setUseZip64(Zip64Mode.AlwaysWithCompatibility);
+                    creator.writeTo(zos);
+                }
+            } finally {
+                pool.shutdown();
             }
             packEnd = System.currentTimeMillis();
         } catch (IOException | ExecutionException e) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
@@ -369,8 +369,8 @@ public class ORSGraphFileManager implements ORSGraphFolderStrategy {
             long end = System.currentTimeMillis();
             double elapsedS = (end - start) / 1000.0;
             double throughputMBs = elapsedS > 0 ? compressedMB / elapsedS : 0;
-            LOGGER.info("Extracted %s (%.1f MB) in %.1fs (%.1f MB/s) using parallel ZipFile (commons-compress).".formatted(
-                    graphDownloadFile.getName(), compressedMB, elapsedS, throughputMBs));
+            LOGGER.info("[%s] Extracted %s (%.1f MB) in %.1fs (%.1f MB/s) using parallel ZipFile (commons-compress).".formatted(
+                    getProfileDescriptiveName(), graphDownloadFile.getName(), compressedMB, elapsedS, throughputMBs));
             deleteFileWithLogging(graphDownloadFile,
                     "[%s] Deleted downloaded graph file %s".formatted(getProfileDescriptiveName(), graphDownloadFileAbsPath),
                     "Error deleting downloaded graph file: %s");

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
@@ -363,6 +363,8 @@ public class ORSGraphFileManager implements ORSGraphFolderStrategy {
                     }
                 });
                 if (!extractErrors.isEmpty()) {
+                    extractErrors.stream().skip(1).forEach(e ->
+                            LOGGER.error("[%s] Additional extraction error: %s".formatted(getProfileDescriptiveName(), e.getMessage())));
                     throw extractErrors.get(0);
                 }
             }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.Unzipper;
 import lombok.NoArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
@@ -23,9 +22,14 @@ import org.heigit.ors.util.AppInfo;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -35,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.fasterxml.jackson.core.JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN;
 import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.*;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @NoArgsConstructor
 public class ORSGraphFileManager implements ORSGraphFolderStrategy {
@@ -335,13 +340,35 @@ public class ORSGraphFileManager implements ORSGraphFolderStrategy {
         try {
             LOGGER.info("[%s] Extracting downloaded graph file to %s".formatted(getProfileDescriptiveName(), extractionDirectoryAbsPath));
             long start = System.currentTimeMillis();
-            (new Unzipper()).unzip(graphDownloadFileAbsPath, extractionDirectoryAbsPath, true);
+            double compressedMB = graphDownloadFile.length() / (1024.0 * 1024.0);
+            // "jar:" scheme is required. FileSystems.newFileSystem dispatches by URI scheme.
+            // Using "file:" would route to the local filesystem provider instead of the built-in ZIP provider and throw FileSystemNotFoundException.
+            URI zipUri = URI.create("jar:" + graphDownloadFile.toURI());
+            try (FileSystem zipFs = FileSystems.newFileSystem(zipUri, Map.of())) {
+                Path zipRoot = zipFs.getPath("/");
+                List<Path> entries;
+                try (Stream<Path> walk = Files.walk(zipRoot)) {
+                    entries = walk.filter(p -> !Files.isDirectory(p)).toList();
+                }
+                List<IOException> extractErrors = Collections.synchronizedList(new ArrayList<>());
+                entries.parallelStream().forEach(zipPath -> {
+                    try {
+                        Path targetPath = extractionDirectory.toPath().resolve(zipRoot.relativize(zipPath).toString());
+                        Files.createDirectories(targetPath.getParent());
+                        Files.copy(zipPath, targetPath, REPLACE_EXISTING);
+                    } catch (IOException e) {
+                        extractErrors.add(e);
+                    }
+                });
+                if (!extractErrors.isEmpty()) {
+                    throw extractErrors.get(0);
+                }
+            }
             long end = System.currentTimeMillis();
-
-            LOGGER.debug("[%s] Extraction of downloaded graph file finished after %d ms, deleting downloaded graph file %s".formatted(
-                    getProfileDescriptiveName(),
-                    end - start,
-                    graphDownloadFileAbsPath));
+            double elapsedS = (end - start) / 1000.0;
+            double throughputMBs = elapsedS > 0 ? compressedMB / elapsedS : 0;
+            LOGGER.info("Extracted %s (%.1f MB) in %.1fs (%.1f MB/s) using parallel NIO ZipFileSystem.".formatted(
+                    graphDownloadFile.getName(), compressedMB, elapsedS, throughputMBs));
             deleteFileWithLogging(graphDownloadFile,
                     "[%s] Deleted downloaded graph file %s".formatted(getProfileDescriptiveName(), graphDownloadFileAbsPath),
                     "Error deleting downloaded graph file: %s");

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
@@ -19,16 +19,16 @@ import org.heigit.ors.routing.graphhopper.extensions.manage.GraphManagementRunti
 import org.heigit.ors.routing.graphhopper.extensions.manage.PersistedGraphBuildInfo;
 import org.heigit.ors.util.AppInfo;
 
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.net.URI;
+import java.io.InputStream;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Stream;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -340,28 +340,24 @@ public class ORSGraphFileManager implements ORSGraphFolderStrategy {
             LOGGER.info("[%s] Extracting downloaded graph file to %s".formatted(getProfileDescriptiveName(), extractionDirectoryAbsPath));
             long start = System.currentTimeMillis();
             double compressedMB = graphDownloadFile.length() / (1024.0 * 1024.0);
-            // "jar:" scheme is required. FileSystems.newFileSystem dispatches by URI scheme.
-            // Using "file:" would route to the local filesystem provider instead of the built-in ZIP provider and throw FileSystemNotFoundException.
-            URI zipUri = URI.create("jar:" + graphDownloadFile.toURI());
-            try (FileSystem zipFs = FileSystems.newFileSystem(zipUri, Map.of())) {
-                Path zipRoot = zipFs.getPath("/");
-                List<Path> entries;
-                try (Stream<Path> walk = Files.walk(zipRoot)) {
-                    entries = walk.filter(p -> !Files.isDirectory(p)).toList();
-                }
+            try (ZipFile zipFile = ZipFile.builder().setFile(graphDownloadFile).get()) {
+                List<ZipArchiveEntry> entries = Collections.list(zipFile.getEntries())
+                        .stream().filter(e -> !e.isDirectory()).toList();
                 List<IOException> extractErrors = Collections.synchronizedList(new ArrayList<>());
-                entries.parallelStream().forEach(zipPath -> {
+                entries.parallelStream().forEach(entry -> {
                     try {
-                        Path relative = zipRoot.relativize(zipPath).normalize();
-                        Path targetPath = extractionDirectory.toPath().resolve(relative.toString()).normalize();
+                        Path relative = Path.of(entry.getName()).normalize();
+                        Path targetPath = extractionDirectory.toPath().resolve(relative).normalize();
                         if (!targetPath.startsWith(extractionDirectory.toPath())) {
-                            throw new IOException("Refusing to write zip entry outside target dir: " + relative);
+                            throw new IOException("Refusing to extract entry outside target dir: " + relative);
                         }
                         Path parent = targetPath.getParent();
                         if (parent != null) {
                             Files.createDirectories(parent);
                         }
-                        Files.copy(zipPath, targetPath, REPLACE_EXISTING);
+                        try (InputStream is = zipFile.getInputStream(entry)) {
+                            Files.copy(is, targetPath, REPLACE_EXISTING);
+                        }
                     } catch (IOException e) {
                         extractErrors.add(e);
                     }
@@ -373,7 +369,7 @@ public class ORSGraphFileManager implements ORSGraphFolderStrategy {
             long end = System.currentTimeMillis();
             double elapsedS = (end - start) / 1000.0;
             double throughputMBs = elapsedS > 0 ? compressedMB / elapsedS : 0;
-            LOGGER.info("Extracted %s (%.1f MB) in %.1fs (%.1f MB/s) using parallel NIO ZipFileSystem.".formatted(
+            LOGGER.info("Extracted %s (%.1f MB) in %.1fs (%.1f MB/s) using parallel ZipFile (commons-compress).".formatted(
                     graphDownloadFile.getName(), compressedMB, elapsedS, throughputMBs));
             deleteFileWithLogging(graphDownloadFile,
                     "[%s] Deleted downloaded graph file %s".formatted(getProfileDescriptiveName(), graphDownloadFileAbsPath),

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
@@ -28,7 +28,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.text.DateFormat;
 import java.text.ParseException;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManager.java
@@ -352,8 +352,15 @@ public class ORSGraphFileManager implements ORSGraphFolderStrategy {
                 List<IOException> extractErrors = Collections.synchronizedList(new ArrayList<>());
                 entries.parallelStream().forEach(zipPath -> {
                     try {
-                        Path targetPath = extractionDirectory.toPath().resolve(zipRoot.relativize(zipPath).toString());
-                        Files.createDirectories(targetPath.getParent());
+                        Path relative = zipRoot.relativize(zipPath).normalize();
+                        Path targetPath = extractionDirectory.toPath().resolve(relative.toString()).normalize();
+                        if (!targetPath.startsWith(extractionDirectory.toPath())) {
+                            throw new IOException("Refusing to write zip entry outside target dir: " + relative);
+                        }
+                        Path parent = targetPath.getParent();
+                        if (parent != null) {
+                            Files.createDirectories(parent);
+                        }
                         Files.copy(zipPath, targetPath, REPLACE_EXISTING);
                     } catch (IOException e) {
                         extractErrors.add(e);

--- a/ors-engine/src/test/java/org/heigit/ors/routing/PrepareGeneratedGraphForUploadTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/PrepareGeneratedGraphForUploadTest.java
@@ -11,11 +11,17 @@ import org.springframework.util.FileSystemUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -74,6 +80,18 @@ class PrepareGeneratedGraphForUploadTest {
         assertTrue(result, "Preparation should return true on success");
         assertTrue(Files.exists(archive), "Archive file should be created on success");
         assertFalse(Files.exists(profileDir), "Source profile directory should be deleted after successful archive");
+
+        URI zipUri = URI.create("jar:" + archive.toUri());
+        try (var zipFs = FileSystems.newFileSystem(zipUri, Map.of())) {
+            List<String> entries;
+            try (Stream<Path> walk = Files.walk(zipFs.getPath("/"))) {
+                entries = walk.filter(p -> !Files.isDirectory(p)).map(Path::toString).toList();
+            }
+            assertEquals(2, entries.size(), "archive should contain exactly the 2 source files");
+            assertTrue(entries.stream().anyMatch(e -> e.endsWith("graph_build_info.yml")));
+            assertTrue(entries.stream().anyMatch(e -> e.endsWith("data.bin")));
+            assertEquals("payload", Files.readString(zipFs.getPath("data.bin"), StandardCharsets.UTF_8));
+        }
     }
 
     @Test

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManagerTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManagerTest.java
@@ -235,6 +235,22 @@ class ORSGraphFileManagerTest {
     }
 
     @Test
+    @DisplayName("Given a .ghz archive containing a path-traversal entry, when extractDownloadedGraph is called, then an exception is thrown and no file is written outside the extraction directory")
+    void extractDownloadedGraph_zipSlipEntry_throwsException() throws IOException {
+        setupORSGraphManager(managementPropsBuilder().build());
+        File ghzFile = new File(orsGraphFileManager.getDownloadedCompressedGraphFileAbsPath());
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(ghzFile))) {
+            zos.putNextEntry(new ZipEntry("../../traversal.txt"));
+            zos.write("evil".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        assertThrows(Exception.class, () -> orsGraphFileManager.extractDownloadedGraph());
+
+        assertFalse(tempDir.getParent().resolve("traversal.txt").toFile().exists());
+    }
+
+    @Test
     @DisplayName("Given no .ghz archive exists, when extractDownloadedGraph is called, then nothing happens and no directory is created")
     void extractDownloadedGraph_noGhzFile_doesNothing() throws IOException {
         setupORSGraphManager(managementPropsBuilder().build());

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManagerTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/local/ORSGraphFileManagerTest.java
@@ -12,13 +12,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.DisplayName;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.heigit.ors.routing.graphhopper.extensions.manage.RepoManagerTestHelper.*;
@@ -204,6 +210,40 @@ class ORSGraphFileManagerTest {
 
         List<File> backups = orsGraphFileManager.findGraphBackupsSortedByName();
         assertEquals(0, backups.size());
+    }
+
+    @Test
+    @DisplayName("Given a .ghz archive containing a text file, when extractDownloadedGraph is called, then the file is extracted and the archive is deleted")
+    void extractDownloadedGraph_extractsTextFileFromGhzArchive() throws IOException {
+        setupORSGraphManager(managementPropsBuilder().build());
+        File ghzFile = new File(orsGraphFileManager.getDownloadedCompressedGraphFileAbsPath());
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(ghzFile))) {
+            zos.putNextEntry(new ZipEntry("hello.txt"));
+            zos.write("Hello, ORS!".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        assertTrue(orsGraphFileManager.hasGraphDownloadFile());
+
+        orsGraphFileManager.extractDownloadedGraph();
+
+        assertFalse(ghzFile.exists(), ".ghz archive should be deleted after extraction");
+        File extractedDir = orsGraphFileManager.getDownloadedExtractedGraphDirectory();
+        assertTrue(extractedDir.isDirectory(), "Extracted directory should exist");
+        File extractedText = new File(extractedDir, "hello.txt");
+        assertTrue(extractedText.exists(), "hello.txt should exist in the extracted directory");
+        assertEquals("Hello, ORS!", Files.readString(extractedText.toPath(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("Given no .ghz archive exists, when extractDownloadedGraph is called, then nothing happens and no directory is created")
+    void extractDownloadedGraph_noGhzFile_doesNothing() throws IOException {
+        setupORSGraphManager(managementPropsBuilder().build());
+        assertFalse(orsGraphFileManager.hasGraphDownloadFile());
+
+        orsGraphFileManager.extractDownloadedGraph();
+
+        assertFalse(orsGraphFileManager.getDownloadedExtractedGraphDirectory().exists(),
+                "Extracted directory should not be created when no archive exists");
     }
 
 }


### PR DESCRIPTION
Replace the single threaded packaging and unpackaging with nio. Nio is natively threaded. On planet the performance gains are -70% on time spend in packaging.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
