### PR TITLE
fix: use the elevation from `ele` node tags for preprocessed PBFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ Releasing is documented in RELEASE.md
 - check whether `mtb_scale` values are within the valid range before attempting to store them ([#2280](https://github.com/GIScience/openrouteservice/pull/2280))
 - update springdoc-openapi and swagger dependencies to address test suite errors ([#2290](https://github.com/GIScience/openrouteservice/pull/2290))
 - return status code 200, and issue a warning if extra info surface or waytype is requested but not available for the given profile ([#2296](https://github.com/GIScience/openrouteservice/pull/2296))
-- fix the graphhopper upgrade barrier node handling ([#2292](https://github.com/GIScience/openrouteservice/pull/2292))
+- barrier node handling after graphhopper upgrade ([#2292](https://github.com/GIScience/openrouteservice/pull/2292))
+- prevent the downloading of elevation data for OSM files preprocessed with `ele` node tags ([#2305](https://github.com/GIScience/openrouteservice/pull/2305))
 
 ### Security
 - update postcss to 8.5.12

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSGraphHopper.java
@@ -125,6 +125,10 @@ public class ORSGraphHopper extends GraphHopperGtfs {
     public GraphHopper init(GraphHopperConfig ghConfig) {
         GraphHopper ret = super.init(ghConfig);
 
+        if (processContext.getElevationFromPreprocessedData()) {
+            ret.setElevationProvider(new PbfElevationProvider());
+        }
+
         if (ghConfig instanceof ORSGraphHopperConfig orsConfig) {
             corePreparationHandler.init(orsConfig);
             coreLMPreparationHandler.init(orsConfig);

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/PbfElevationProvider.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/PbfElevationProvider.java
@@ -1,0 +1,51 @@
+/*  This file is part of Openrouteservice.
+ *
+ *  Openrouteservice is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+
+ *  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+
+ *  You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, see <https://www.gnu.org/licenses/>.
+ */
+package org.heigit.ors.routing.graphhopper.extensions;
+
+import com.graphhopper.reader.ReaderNode;
+import com.graphhopper.reader.dem.ElevationProvider;
+import org.apache.log4j.Logger;
+
+public class PbfElevationProvider implements ElevationProvider {
+    private static final Logger LOGGER = Logger.getLogger(PbfElevationProvider.class);
+    private boolean errorLogged = false;
+
+    @Override
+    public double getEle(ReaderNode node) {
+        double ele = node.getEle();
+        if (Double.isNaN(ele)) {
+            if (!errorLogged) {
+                LOGGER.warn("'ors.engine.elevation.preprocessed: true' set in ors config, but found a node with invalid 'ele' tag! Set this flag only if you use a preprocessed pbf file! Node ID: " + node.getId());
+                errorLogged = true;
+            }
+            ele = 0;
+        }
+        return ele;
+    }
+
+    @Override
+    public double getEle(double lat, double lon) {
+        throw new UnsupportedOperationException("PbfElevationProvider does not support resolving elevation from coordinates.");
+    }
+
+    @Override
+    public boolean canInterpolate() {
+        return false;
+    }
+
+    @Override
+    public void release() {
+        // there are no resources to release in this implementation
+    }
+}

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/PbfElevationProvider.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/PbfElevationProvider.java
@@ -15,8 +15,10 @@ package org.heigit.ors.routing.graphhopper.extensions;
 
 import com.graphhopper.reader.ReaderNode;
 import com.graphhopper.reader.dem.ElevationProvider;
+import lombok.Getter;
 import org.apache.log4j.Logger;
 
+@Getter
 public class PbfElevationProvider implements ElevationProvider {
     private static final Logger LOGGER = Logger.getLogger(PbfElevationProvider.class);
     private boolean errorLogged = false;

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/PbfElevationProviderTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/PbfElevationProviderTest.java
@@ -1,0 +1,79 @@
+/*  This file is part of Openrouteservice.
+ *
+ *  Openrouteservice is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1
+ *  of the License, or (at your option) any later version.
+
+ *  This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Lesser General Public License for more details.
+
+ *  You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, see <https://www.gnu.org/licenses/>.
+ */
+package org.heigit.ors.routing.graphhopper.extensions;
+
+import com.graphhopper.reader.ReaderNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PbfElevationProviderTest {
+    private PbfElevationProvider elevationProvider;
+
+    @BeforeEach
+    void setUp() {
+        elevationProvider = new PbfElevationProvider();
+    }
+
+    @AfterEach
+    void tearDown() {
+        elevationProvider.release();
+    }
+
+    @Test
+    void testGetEleForNodeWithValidElevation() {
+        ReaderNode node = new ReaderNode(1, 0.0, 0.0, Map.of("ele", "100"));
+        assertEquals(100.0,  elevationProvider.getEle(node), "Elevation should match the node's elevation value.");
+    }
+
+    @Test
+    void testGetEleForNodeWithInvalidElevation() {
+        ReaderNode node = new ReaderNode(1, 0.0, 0.0, Map.of("ele", "abc"));
+        assertEquals(0.0,  elevationProvider.getEle(node), "Invalid elevation should default to 0.");
+    }
+
+    @Test
+    void testGetEleForNodeWithMissingElevation() {
+        ReaderNode node = new ReaderNode(1, 0.0, 0.0);
+        assertEquals(0.0,  elevationProvider.getEle(node), "Missing elevation should default to 0.");
+    }
+
+    @Test
+    void testGetEleForNodeLogsWarningOnce() {
+        ReaderNode node = new ReaderNode(1, 0.0, 0.0);
+
+        assertFalse(elevationProvider.isErrorLogged());
+        elevationProvider.getEle(node);
+        assertTrue(elevationProvider.isErrorLogged());
+    }
+
+    @Test
+    void testGetEleForCoordinatesThrowsException() {
+        UnsupportedOperationException exception = assertThrows(
+                UnsupportedOperationException.class,
+                () -> elevationProvider.getEle(0.0, 0.0),
+                "Expected UnsupportedOperationException for getEle with coordinates."
+        );
+        assertEquals("PbfElevationProvider does not support resolving elevation from coordinates.", exception.getMessage());
+    }
+
+    @Test
+    void testCanInterpolate() {
+        assertFalse(elevationProvider.canInterpolate());
+    }
+}


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2304.

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
