### PR TITLE
fix: correct access restrictions hierarchy in `AccesRestrictionsParser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Releasing is documented in RELEASE.md
 - barrier node handling after graphhopper upgrade ([#2292](https://github.com/GIScience/openrouteservice/pull/2292))
 - prevent the downloading of elevation data for OSM files preprocessed with `ele` node tags ([#2305](https://github.com/GIScience/openrouteservice/pull/2305))
 - handle CSV parsing exceptions in CsvGraphStorageBuilder gracefully ([#2312](https://github.com/GIScience/openrouteservice/pull/2312))
+- handle the hierarchy of access restrictions properly in `AccessRestrictionsParser` ([#2311](https://github.com/GIScience/openrouteservice/pull/2311))
 
 ### Security
 - update postcss to 8.5.12

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/AccessRestrictionType.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/AccessRestrictionType.java
@@ -30,8 +30,6 @@ public abstract class AccessRestrictionType {
     }
 
     public static int getFromString(String tagValue) {
-        //TODO: account for multiple values separated by ';' (e.g. "private;customers")
-        //      see https://github.com/GIScience/openrouteservice/issues/2275
         if (tagValue == null) {
             return NONE;
         }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
@@ -14,8 +14,6 @@ import java.util.*;
 
 
 public class AccessRestrictionsParser implements TagParser {
-    private final IntEncodedValue accessRestrictionEnc;
-
     private static final String VAL_ACCESS = "access";
     private static final String VAL_MOTOR_VEHICLE = "motor_vehicle";
     private static final String VAL_MOTORCAR = "motorcar";
@@ -24,22 +22,13 @@ public class AccessRestrictionsParser implements TagParser {
     private static final String VAL_HGV = "hgv";
     private static final String VAL_BICYCLE = "bicycle";
     private static final String VAL_FOOT = "foot";
-    private final List<String> motorcarTags = new ArrayList<>(5);
-    private final List<String> motorcycleTags = new ArrayList<>(5);
-    private final List<String> hgvTags = new ArrayList<>(5);
-    private final List<String> bicycleTags = new ArrayList<>(5);
-    private final List<String> footTags = new ArrayList<>(5);
-
+    private static final List<String> motorcarTags = Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS);
+    private static final List<String> motorcycleTags = Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS);
+    private static final List<String> hgvTags = Arrays.asList(VAL_HGV, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS);
+    private static final List<String> bicycleTags = Arrays.asList(VAL_BICYCLE, VAL_VEHICLE, VAL_ACCESS);
+    private static final List<String> footTags = Arrays.asList(VAL_FOOT, VAL_ACCESS);
+    private final IntEncodedValue accessRestrictionEnc;
     private final int profileType;
-
-    public void initTags() {
-        motorcarTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
-        motorcycleTags.addAll(Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
-        hgvTags.addAll(Arrays.asList(VAL_HGV, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
-        bicycleTags.addAll(Arrays.asList(VAL_BICYCLE, VAL_VEHICLE, VAL_ACCESS));
-        footTags.addAll(Arrays.asList(VAL_FOOT, VAL_ACCESS));
-    }
-
 
     public AccessRestrictionsParser(int profileType) {
         this(AccessRestriction.create(), profileType);
@@ -48,7 +37,6 @@ public class AccessRestrictionsParser implements TagParser {
     public AccessRestrictionsParser(IntEncodedValue accessRestrictionEnc, int profileType) {
         this.accessRestrictionEnc = accessRestrictionEnc;
         this.profileType = profileType;
-        initTags();
     }
 
     @Override
@@ -96,7 +84,7 @@ public class AccessRestrictionsParser implements TagParser {
     private int getRestrictionType(ReaderWay way, List<String> tags) {
         int res = 0;
 
-      for (String value : way.getFirstPriorityTagValues(tags)) {
+        for (String value : way.getFirstPriorityTagValues(tags)) {
             res = updateRestriction(res, value);
         }
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
@@ -36,6 +36,9 @@ public class AccessRestrictionsParser implements TagParser {
         motorCarTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE));
         motorCycleTags.addAll(Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE));
 
+//        motorCarTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
+//        motorCycleTags.addAll(Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
+
         restrictedValues.add("private");
         restrictedValues.add("no");
         restrictedValues.add("restricted");
@@ -143,6 +146,8 @@ public class AccessRestrictionsParser implements TagParser {
      * @return An integer encoded representation of all restrictions that have been set
      */
     private int updateRestriction(int encodedRestrictions, String restrictionValue) {
+        //TODO: account for multiple values separated by ';' (e.g. "private;customers")
+        //      see https://github.com/GIScience/openrouteservice/issues/2275
         return encodedRestrictions | AccessRestrictionType.getFromString(restrictionValue);
     }
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
@@ -24,34 +24,20 @@ public class AccessRestrictionsParser implements TagParser {
     private static final String VAL_HGV = "hgv";
     private static final String VAL_BICYCLE = "bicycle";
     private static final String VAL_FOOT = "foot";
-    private final List<String> accessRestrictedTags = new ArrayList<>(5);
     private final List<String> motorcarTags = new ArrayList<>(5);
     private final List<String> motorcycleTags = new ArrayList<>(5);
     private final List<String> hgvTags = new ArrayList<>(5);
     private final List<String> bicycleTags = new ArrayList<>(5);
     private final List<String> footTags = new ArrayList<>(5);
-    private final Set<String> restrictedValues = new HashSet<>(5);
 
     private final int profileType;
 
     public void initTags() {
-        accessRestrictedTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS, VAL_BICYCLE, VAL_FOOT));
         motorcarTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
         motorcycleTags.addAll(Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
         hgvTags.addAll(Arrays.asList(VAL_HGV, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
         bicycleTags.addAll(Arrays.asList(VAL_BICYCLE, VAL_VEHICLE, VAL_ACCESS));
         footTags.addAll(Arrays.asList(VAL_FOOT, VAL_ACCESS));
-
-        restrictedValues.add("private");
-        restrictedValues.add("no");
-        restrictedValues.add("restricted");
-        restrictedValues.add("military");
-        restrictedValues.add("destination");
-        restrictedValues.add("customers");
-        restrictedValues.add("emergency");
-        restrictedValues.add("permissive");
-        restrictedValues.add("delivery");
-        restrictedValues.add("permit");
     }
 
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionsParser.java
@@ -21,23 +21,26 @@ public class AccessRestrictionsParser implements TagParser {
     private static final String VAL_MOTORCAR = "motorcar";
     private static final String VAL_VEHICLE = "vehicle";
     private static final String VAL_MOTORCYCLE = "motorcycle";
+    private static final String VAL_HGV = "hgv";
     private static final String VAL_BICYCLE = "bicycle";
     private static final String VAL_FOOT = "foot";
     private final List<String> accessRestrictedTags = new ArrayList<>(5);
-    private final List<String> motorCarTags = new ArrayList<>(5);
-    private final List<String> motorCycleTags = new ArrayList<>(5);
+    private final List<String> motorcarTags = new ArrayList<>(5);
+    private final List<String> motorcycleTags = new ArrayList<>(5);
+    private final List<String> hgvTags = new ArrayList<>(5);
+    private final List<String> bicycleTags = new ArrayList<>(5);
+    private final List<String> footTags = new ArrayList<>(5);
     private final Set<String> restrictedValues = new HashSet<>(5);
-    private final Set<String> permissiveValues = new HashSet<>(5);
 
     private final int profileType;
 
     public void initTags() {
         accessRestrictedTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS, VAL_BICYCLE, VAL_FOOT));
-        motorCarTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE));
-        motorCycleTags.addAll(Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE));
-
-//        motorCarTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
-//        motorCycleTags.addAll(Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
+        motorcarTags.addAll(Arrays.asList(VAL_MOTORCAR, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
+        motorcycleTags.addAll(Arrays.asList(VAL_MOTORCYCLE, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
+        hgvTags.addAll(Arrays.asList(VAL_HGV, VAL_MOTOR_VEHICLE, VAL_VEHICLE, VAL_ACCESS));
+        bicycleTags.addAll(Arrays.asList(VAL_BICYCLE, VAL_VEHICLE, VAL_ACCESS));
+        footTags.addAll(Arrays.asList(VAL_FOOT, VAL_ACCESS));
 
         restrictedValues.add("private");
         restrictedValues.add("no");
@@ -49,10 +52,6 @@ public class AccessRestrictionsParser implements TagParser {
         restrictedValues.add("permissive");
         restrictedValues.add("delivery");
         restrictedValues.add("permit");
-
-        permissiveValues.add("yes");
-        permissiveValues.add("designated");
-        permissiveValues.add("official");
     }
 
 
@@ -79,39 +78,26 @@ public class AccessRestrictionsParser implements TagParser {
     }
 
     public int processWay(ReaderWay way) {
-        //TODO: modify the following logic to process access restriction tags from the most specific to the least
-        //      specific, e.g. motorcar > motor_vehicle > vehicle > access via a call to way.getFirstPriorityTag
-        //      see https://github.com/GIScience/openrouteservice/issues/2275
-
-        if (!way.hasTag(accessRestrictedTags, restrictedValues)) {
-            return 0;
-        }
-
-        if (RoutingProfileType.isDriving(profileType)) {
-            return processAccess(way, motorCarTags);
+        if (profileType == RoutingProfileType.DRIVING_CAR) {
+            return getRestrictionType(way, motorcarTags);
         }
         if (profileType == RoutingProfileType.DRIVING_MOTORCYCLE) {
-            return processAccess(way, motorCycleTags);
+            return getRestrictionType(way, motorcycleTags);
+        }
+        if (RoutingProfileType.isHeavyVehicle(profileType)) {
+            return getRestrictionType(way, hgvTags);
         }
         if (RoutingProfileType.isCycling(profileType)) {
-            return processAccess(way, VAL_BICYCLE);
+            return getRestrictionType(way, bicycleTags);
         }
         if (RoutingProfileType.isPedestrian(profileType)) {
-            return processAccess(way, VAL_FOOT);
+            return getRestrictionType(way, footTags);
         }
         if (profileType == RoutingProfileType.UNKNOWN) {
-            return processAccess(way, VAL_ACCESS);
+            return getRestrictionType(way, Collections.singletonList(VAL_ACCESS));
         }
 
         return 0;
-    }
-
-    private int processAccess(ReaderWay way, String tag) {
-        return processAccess(way, Collections.singletonList(tag));
-    }
-
-    private int processAccess(ReaderWay way, List<String> tags) {
-        return isAccessAllowed(way, tags) ? 0 : getRestrictionType(way, tags);
     }
 
     /**
@@ -124,15 +110,8 @@ public class AccessRestrictionsParser implements TagParser {
     private int getRestrictionType(ReaderWay way, List<String> tags) {
         int res = 0;
 
-        String tagValue = way.getTag(VAL_ACCESS);
-        if (tagValue != null)
-            res = updateRestriction(res, tagValue);
-
-        if (tags != null) {
-            for (String key : tags) {
-                tagValue = way.getTag(key);
-                res = updateRestriction(res, tagValue);
-            }
+      for (String value : way.getFirstPriorityTagValues(tags)) {
+            res = updateRestriction(res, value);
         }
 
         return res;
@@ -146,20 +125,6 @@ public class AccessRestrictionsParser implements TagParser {
      * @return An integer encoded representation of all restrictions that have been set
      */
     private int updateRestriction(int encodedRestrictions, String restrictionValue) {
-        //TODO: account for multiple values separated by ';' (e.g. "private;customers")
-        //      see https://github.com/GIScience/openrouteservice/issues/2275
         return encodedRestrictions | AccessRestrictionType.getFromString(restrictionValue);
     }
-
-    /**
-     * Check if access is allowed on the way. e.g. it would check if motor_car=yes/permissive/destination etc. is set
-     *
-     * @param way      The OSM way to be checked
-     * @param tagNames The tags (keys) to be checked
-     * @return Whether access is allowed on the way
-     */
-    private boolean isAccessAllowed(ReaderWay way, List<String> tagNames) {
-        return way.hasTag(tagNames, permissiveValues);
-    }
-
 }

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionParserTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionParserTest.java
@@ -25,9 +25,8 @@ class AccessRestrictionParserTest {
         intsRef = em.createEdgeFlags();
     }
 
-    @Test
-    void testAccessTypes() {
-        initParser(RoutingProfileType.DRIVING_CAR);
+    private void assertRestrictionsForProfile(int profileType) {
+        initParser(profileType);
         ReaderWay way = new ReaderWay(1);
 
         parser.handleWayTags(intsRef, way, false, relFlags);
@@ -63,40 +62,13 @@ class AccessRestrictionParserTest {
     }
 
     @Test
+    void testAccessTypesCar() {
+        assertRestrictionsForProfile(RoutingProfileType.DRIVING_CAR);
+    }
+
+    @Test
     void testAccessCycling() {
-        initParser(RoutingProfileType.CYCLING_REGULAR);
-        ReaderWay way = new ReaderWay(1);
-
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.NONE, accessRestrictionEnc.getInt(false, intsRef));
-
-        way.setTag("access", "no");
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.NO, accessRestrictionEnc.getInt(false, intsRef));
-
-        way.setTag("access", "customers");
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.CUSTOMERS, accessRestrictionEnc.getInt(false, intsRef));
-
-        way.setTag("access", "destination");
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
-
-        way.setTag("access", "delivery");
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.DELIVERY, accessRestrictionEnc.getInt(false, intsRef));
-
-        way.setTag("access", "private");
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.PRIVATE, accessRestrictionEnc.getInt(false, intsRef));
-
-        way.setTag("access", "permissive");
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.PERMISSIVE, accessRestrictionEnc.getInt(false, intsRef));
-
-        way.setTag("access", "permit");
-        parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.PERMIT, accessRestrictionEnc.getInt(false, intsRef));
+        assertRestrictionsForProfile(RoutingProfileType.CYCLING_REGULAR);
     }
 
     @Test

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionParserTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/util/parsers/AccessRestrictionParserTest.java
@@ -27,7 +27,44 @@ class AccessRestrictionParserTest {
 
     @Test
     void testAccessTypes() {
-        initParser(RoutingProfileType.UNKNOWN);
+        initParser(RoutingProfileType.DRIVING_CAR);
+        ReaderWay way = new ReaderWay(1);
+
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.NONE, accessRestrictionEnc.getInt(false, intsRef));
+
+        way.setTag("access", "no");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.NO, accessRestrictionEnc.getInt(false, intsRef));
+
+        way.setTag("access", "customers");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.CUSTOMERS, accessRestrictionEnc.getInt(false, intsRef));
+
+        way.setTag("access", "destination");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+
+        way.setTag("access", "delivery");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.DELIVERY, accessRestrictionEnc.getInt(false, intsRef));
+
+        way.setTag("access", "private");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.PRIVATE, accessRestrictionEnc.getInt(false, intsRef));
+
+        way.setTag("access", "permissive");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.PERMISSIVE, accessRestrictionEnc.getInt(false, intsRef));
+
+        way.setTag("access", "permit");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.PERMIT, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testAccessCycling() {
+        initParser(RoutingProfileType.CYCLING_REGULAR);
         ReaderWay way = new ReaderWay(1);
 
         parser.handleWayTags(intsRef, way, false, relFlags);
@@ -73,11 +110,103 @@ class AccessRestrictionParserTest {
 
         way.setTag("motorcar", "destination");
         parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.NO | AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
 
         way.setTag("motorcar", "yes");
         parser.handleWayTags(intsRef, way, false, relFlags);
         assertEquals(AccessRestrictionType.NONE, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testVehicleDestination() {
+        initParser(RoutingProfileType.DRIVING_CAR);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("vehicle", "destination");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testHgvDestination() {
+        initParser(RoutingProfileType.DRIVING_HGV);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("hgv", "destination");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testAccessNoVehicleDestination() {
+        initParser(RoutingProfileType.DRIVING_CAR);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("access", "no");
+        way.setTag("vehicle", "destination");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testMotorcarDestinationMotorvehicleYes() {
+        initParser(RoutingProfileType.DRIVING_CAR);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("motorcar", "destination");
+        way.setTag("motor_vehicle", "yes");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testMotorcarYesVehicleDestination() {
+        initParser(RoutingProfileType.DRIVING_CAR);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("motorcar", "yes");
+        way.setTag("vehicle", "destination");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.NONE, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testMotorcarDestinationAccessNo() {
+        initParser(RoutingProfileType.DRIVING_CAR);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("motorcar", "destination");
+        way.setTag("access", "no");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testAccessPrivateCustomers() {
+        initParser(RoutingProfileType.DRIVING_CAR);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("access", "private;customers");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.PRIVATE | AccessRestrictionType.CUSTOMERS, accessRestrictionEnc.getInt(false, intsRef));
+    }
+
+    @Test
+    void testMotorcarPrivateCustomers() {
+        initParser(RoutingProfileType.DRIVING_CAR);
+
+        ReaderWay way = new ReaderWay(1);
+
+        way.setTag("motorcar", "private;customers");
+        parser.handleWayTags(intsRef, way, false, relFlags);
+        assertEquals(AccessRestrictionType.PRIVATE | AccessRestrictionType.CUSTOMERS, accessRestrictionEnc.getInt(false, intsRef));
     }
 
     @Test
@@ -91,7 +220,7 @@ class AccessRestrictionParserTest {
 
         way.setTag("bicycle", "destination");
         parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.NO | AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
 
         way.setTag("bicycle", "yes");
         parser.handleWayTags(intsRef, way, false, relFlags);
@@ -109,7 +238,7 @@ class AccessRestrictionParserTest {
 
         way.setTag("foot", "destination");
         parser.handleWayTags(intsRef, way, false, relFlags);
-        assertEquals(AccessRestrictionType.NO | AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
+        assertEquals(AccessRestrictionType.DESTINATION, accessRestrictionEnc.getInt(false, intsRef));
 
         way.setTag("foot", "yes");
         parser.handleWayTags(intsRef, way, false, relFlags);


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #2275 .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
