### PR TITLE
fix: use direct mapping of node IDs to OSM IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Releasing is documented in RELEASE.md
 - handle CSV parsing exceptions in CsvGraphStorageBuilder gracefully ([#2312](https://github.com/GIScience/openrouteservice/pull/2312))
 - handle the hierarchy of access restrictions properly in `AccessRestrictionsParser` ([#2311](https://github.com/GIScience/openrouteservice/pull/2311))
 - correctly resolve country borders from an PBF enriched with country tags ([#2314](https://github.com/GIScience/openrouteservice/pull/2314))
+- use direct mapping of node IDs to OSM IDs to correctly resolve node tags for edges containing cloned nodes ([#2319](https://github.com/GIScience/openrouteservice/pull/2319))
 
 ### Security
 - update postcss to 8.5.12

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -2161,6 +2161,30 @@ class ResultTest extends ServiceTest {
     }
 
     @Test
+    void testBordersAtBarriers() {
+        JSONObject body = new JSONObject();
+        body.put("coordinates", HelperFunctions.constructCoords("8.682567,49.406522|8.68275,49.406215"));
+        body.put("preference", "shortest");
+        body.put("instructions", false);
+        body.put("units", "m");
+
+        body.put("options", new JSONObject().put("avoid_borders", "all"));
+
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.jsonContent)
+                .pathParam("profile", getParameter("carProfile"))
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}")
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].summary.distance", is(closeTo(44, 1)))
+                .statusCode(200);
+    }
+
+    @Test
     void testDetourFactor() {
         JSONObject body = new JSONObject();
         body.put("coordinates", getParameter("coordinatesShort"));

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
@@ -374,12 +374,8 @@ public class ORSOSMReader extends OSMReader {
         try {
             Map<Integer, Map<String, String>> tags = new HashMap<>();
             if (processNodeTags) {
-                // If we are processing the node tags then we need to obtain the tags for nodes that are on the way. We
-                // should store the internal node id though rather than the osm node as during the edge processing, we
-                // do not know the osm node id
-                Arrays.asList(edge.getBaseNode(), edge.getAdjNode()).forEach(nodeId -> {
+                for (int nodeId : new int[]{edge.getBaseNode(), edge.getAdjNode()}) {
                     long osmId = nodeData.getOsmId(nodeData.towerNodeToId(nodeId));
-
                     Map<String, String> tagsForNode = nodeTags.get(osmId);
 
                     if (countries != null && countries.containsKey(osmId)) {
@@ -391,7 +387,7 @@ public class ORSOSMReader extends OSMReader {
                     if (tagsForNode != null) {
                         tags.put(nodeId, tagsForNode);
                     }
-                });
+                }
             }
 
             procCntx.processEdge(way, edge, tags);

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/ORSOSMReader.java
@@ -377,15 +377,9 @@ public class ORSOSMReader extends OSMReader {
                 // If we are processing the node tags then we need to obtain the tags for nodes that are on the way. We
                 // should store the internal node id though rather than the osm node as during the edge processing, we
                 // do not know the osm node id
+                Arrays.asList(edge.getBaseNode(), edge.getAdjNode()).forEach(nodeId -> {
+                    long osmId = nodeData.getOsmId(nodeData.towerNodeToId(nodeId));
 
-                LongArrayList osmNodeIds = way.getNodes();
-                int size = osmNodeIds.size();
-
-                for (int i = 0; i < size; i++) {
-                    // find the node
-                    long osmId = osmNodeIds.get(i);
-                    // replace the osm id with the internal id
-                    int internalId = nodeData.getId(osmId);
                     Map<String, String> tagsForNode = nodeTags.get(osmId);
 
                     if (countries != null && countries.containsKey(osmId)) {
@@ -395,9 +389,9 @@ public class ORSOSMReader extends OSMReader {
                     }
 
                     if (tagsForNode != null) {
-                        tags.put(internalId, tagsForNode);
+                        tags.put(nodeId, tagsForNode);
                     }
-                }
+                });
             }
 
             procCntx.processEdge(way, edge, tags);

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
@@ -165,8 +165,7 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
             return;
         }
 
-        nodeTags.forEach((internalNodeId, tagPairs) -> {
-            int nodeId = convertTowerNodeId(internalNodeId);
+        nodeTags.forEach((nodeId, tagPairs) -> {
             if (nodeId != EMPTY_NODE) {
                 wayNodeTags.put(nodeId, tagPairs.get(TAG_KEY_COUNTRY));
             }
@@ -182,13 +181,6 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
             way.setTag(TAG_KEY_COUNTRY1, countries[0]);
             way.setTag(TAG_KEY_COUNTRY2, countries[0]);
         }
-    }
-
-    private int convertTowerNodeId(int id) {
-        if (id < TOWER_NODE)
-            return -id - 3;
-
-        return EMPTY_NODE;
     }
 
     /**
@@ -208,8 +200,7 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
             return;
         }
 
-        short countryId1 = 0;
-        short countryId2 = 0;
+        short countryId1, countryId2;
 
         if (preprocessed) {
             extractNodeToCountryMapping(nodeTags);

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/storages/builders/BordersGraphStorageBuilder.java
@@ -51,7 +51,6 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
     private static final String TAG_KEY_COUNTRY1 = "country1";
     private static final String TAG_KEY_COUNTRY2 = "country2";
     private static final int EMPTY_NODE = -1;
-    private static final int TOWER_NODE = -2;
     private HashMap<Integer, String> wayNodeTags;
 
     private BordersGraphStorage storage;
@@ -200,7 +199,8 @@ public class BordersGraphStorageBuilder extends AbstractGraphStorageBuilder {
             return;
         }
 
-        short countryId1, countryId2;
+        short countryId1;
+        short countryId2;
 
         if (preprocessed) {
             extractNodeToCountryMapping(nodeTags);

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
 
         <!-- switch graphhopper versions to enable debugging -->
-        <!--<graphhopper.version>4.13-SNAPSHOT</graphhopper.version>-->
-        <graphhopper.version>v4.13.1</graphhopper.version>
+        <!--<graphhopper.version>4.15-SNAPSHOT</graphhopper.version>-->
+        <graphhopper.version>v4.14.0</graphhopper.version>
         <lombok.version>1.18.34</lombok.version>
         <slf4j.version>2.0.13</slf4j.version>
         <log4j.version>2.25.4</log4j.version>


### PR DESCRIPTION
OSM nodes can sometimes become duplicated, such as barrier nodes when creating zero-length edges. In these cases, the original reverse mapping (OSM IDs to node IDs) is no longer sufficient to correctly resolve node tags (such as "country") on a per-edge basis.

Fixes #2315.

**To be run with https://github.com/GIScience/graphhopper/pull/117**