### PR TITLE
feat: add `preference` parameter to matrix

### DIFF
--- a/ors-api/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
@@ -40,6 +40,7 @@ public class MatrixRequest extends APIRequest {
     public static final String PARAM_SOURCES = "sources";
     public static final String PARAM_DESTINATIONS = "destinations";
     public static final String PARAM_METRICS = "metrics";
+    public static final String PARAM_PREFERENCE = "preference";
     public static final String PARAM_RESOLVE_LOCATIONS = "resolve_locations";
     public static final String PARAM_UNITS = "units";
     public static final String PARAM_OPTIMIZED = "optimized";
@@ -75,6 +76,14 @@ public class MatrixRequest extends APIRequest {
     private MatrixRequestEnums.Metrics[] metrics;
     @JsonIgnore
     private boolean hasMetrics = false;
+
+        @Schema(name = PARAM_PREFERENCE,
+            description = "Specifies the route preference used to compute matrix costs.",
+            defaultValue = "recommended")
+        @JsonProperty(value = PARAM_PREFERENCE)
+        private APIEnums.RoutePreference routePreference;
+        @JsonIgnore
+        private boolean hasRoutePreference = false;
 
     @Schema(name = PARAM_RESOLVE_LOCATIONS, description = """
             Specifies whether given locations are resolved or not. If the parameter value set to `true`, every element in \
@@ -194,6 +203,19 @@ public class MatrixRequest extends APIRequest {
 
     public boolean hasMetrics() {
         return hasMetrics;
+    }
+
+    public APIEnums.RoutePreference getRoutePreference() {
+        return routePreference;
+    }
+
+    public void setRoutePreference(APIEnums.RoutePreference routePreference) {
+        this.routePreference = routePreference;
+        hasRoutePreference = true;
+    }
+
+    public boolean hasRoutePreference() {
+        return hasRoutePreference;
     }
 
     public boolean getResolveLocations() {

--- a/ors-api/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/matrix/MatrixRequest.java
@@ -77,13 +77,13 @@ public class MatrixRequest extends APIRequest {
     @JsonIgnore
     private boolean hasMetrics = false;
 
-        @Schema(name = PARAM_PREFERENCE,
+    @Schema(name = PARAM_PREFERENCE,
             description = "Specifies the route preference used to compute matrix costs.",
             defaultValue = "recommended")
-        @JsonProperty(value = PARAM_PREFERENCE)
-        private APIEnums.RoutePreference routePreference;
-        @JsonIgnore
-        private boolean hasRoutePreference = false;
+    @JsonProperty(value = PARAM_PREFERENCE)
+    private APIEnums.RoutePreference routePreference;
+    @JsonIgnore
+    private boolean hasRoutePreference = false;
 
     @Schema(name = PARAM_RESOLVE_LOCATIONS, description = """
             Specifies whether given locations are resolved or not. If the parameter value set to `true`, every element in \

--- a/ors-api/src/main/java/org/heigit/ors/api/services/MatrixService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/MatrixService.java
@@ -6,6 +6,7 @@ import org.heigit.ors.api.config.EndpointsProperties;
 import org.heigit.ors.api.requests.matrix.MatrixRequest;
 import org.heigit.ors.api.requests.matrix.MatrixRequestEnums;
 import org.heigit.ors.exceptions.InternalServerException;
+import org.heigit.ors.exceptions.UnknownParameterValueException;
 import org.heigit.ors.exceptions.ParameterValueException;
 import org.heigit.ors.exceptions.ServerLimitExceededException;
 import org.heigit.ors.exceptions.StatusCodeException;
@@ -16,6 +17,7 @@ import org.heigit.ors.matrix.MatrixSearchParameters;
 import org.heigit.ors.routing.RoutingErrorCodes;
 import org.heigit.ors.routing.RoutingProfile;
 import org.heigit.ors.routing.RoutingProfileType;
+import org.heigit.ors.routing.WeightingMethod;
 import org.locationtech.jts.geom.Coordinate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -67,6 +69,9 @@ public class MatrixService extends ApiService {
 
         coreRequest.setProfileType(convertToMatrixProfileType(matrixRequest.getProfile()));
 
+        APIEnums.RoutePreference preference = matrixRequest.hasRoutePreference() ? matrixRequest.getRoutePreference() : APIEnums.RoutePreference.RECOMMENDED;
+        coreRequest.setWeightingMethod(convertWeightingMethod(matrixRequest, preference));
+
         if (matrixRequest.hasMetrics())
             coreRequest.setMetrics(convertMetrics(matrixRequest.getMetrics()));
 
@@ -110,6 +115,17 @@ public class MatrixService extends ApiService {
         }
 
         return isFlexibleMode(matrixRequest.getMatrixOptions());
+    }
+
+    private int convertWeightingMethod(MatrixRequest request, APIEnums.RoutePreference preferenceIn) throws UnknownParameterValueException {
+        if (request.getProfile().equals(APIEnums.Profile.DRIVING_CAR) && preferenceIn.equals(APIEnums.RoutePreference.RECOMMENDED)) {
+            return WeightingMethod.FASTEST;
+        }
+        int weightingMethod = WeightingMethod.getFromString(preferenceIn.toString());
+        if (weightingMethod == WeightingMethod.UNKNOWN)
+            throw new UnknownParameterValueException(MatrixErrorCodes.INVALID_PARAMETER_VALUE, MatrixRequest.PARAM_PREFERENCE, preferenceIn.toString());
+
+        return weightingMethod;
     }
 
     public int convertMetrics(MatrixRequestEnums.Metrics[] metrics) throws ParameterValueException {


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [x] 3. I have documented my code using JDocs tags.
- [x] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have tested on a larger dataset
          (at least Germany), and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [x] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes/additions to the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1178 [3903/13](https://ask.openrouteservice.org/t/matrix-for-shortest-fastest-route-preference/3903/13)

### Information about the changes
- **Key functionality added:**
  - Enabled the `preference` parameter in the Matrix API endpoint to allow users to specify route preference when computing matrix costs
  - Added support for all standard route preferences: `fastest`, `shortest`, `recommended`, and `custom`
  - Implemented special handling for `DRIVING_CAR` profile with `recommended` preference (defaults to `fastest` weighting method)
  - Added proper error handling for invalid preference values with `UnknownParameterValueException`

- **Reason for change:**
  - The Matrix API previously did not support route preference parameters, limiting users to default routing behavior
  - This change brings the Matrix API in line with other ORS endpoints (Directions, Isochrones) that already support preference parameters
  - Provides users with flexibility to optimize matrix computations based on their specific use case (time vs distance vs custom preferences)

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
- Not applicable - this change only affects the Matrix API endpoint parameter handling, not the core routing algorithm
- The weighting method conversion logic ensures backward compatibility by defaulting to `RECOMMENDED` preference when not specified
- For `DRIVING_CAR` + `RECOMMENDED`, the behavior matches existing live ORS behavior (uses `FASTEST` weighting)

### Required changes to ors config (if applicable)
- None - no configuration file changes required

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines