### PR TITLE
fix: more realistic travel speeds for HGVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Releasing is documented in RELEASE.md
 ### Added
 
 ### Changed
+- penalize routing through service ways ([#2313](https://github.com/GIScience/openrouteservice/pull/2313))
+- disable acceleration heuristic on motorways ([#2329](https://github.com/GIScience/openrouteservice/pull/2329))
 
 ### Deprecated
 
@@ -50,7 +52,6 @@ Releasing is documented in RELEASE.md
 - log the number of restricted nodes during core preparation ([#2317](https://github.com/GIScience/openrouteservice/pull/2317))
 
 ### Changed
-- penalize routing through service ways ([#2313](https://github.com/GIScience/openrouteservice/pull/2313))
 - replace tollways storage with a corresponding encoded value from GraphHopper ([#2257](https://github.com/GIScience/openrouteservice/pull/2257))
 - migrate hill index storage to a dedicated encoded value ([#2267](https://github.com/GIScience/openrouteservice/pull/2267))
 - migrate trail difficulty storage to `sac_scale`, `mtb_scale`, and `mtb_scale_uphill` encoded values ([#2277](https://github.com/GIScience/openrouteservice/pull/2277))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,14 @@ Releasing is documented in RELEASE.md
 ### Added
 
 ### Changed
-- penalize routing through service ways ([#2313](https://github.com/GIScience/openrouteservice/pull/2313))
-- disable acceleration heuristic on motorways ([#2329](https://github.com/GIScience/openrouteservice/pull/2329))
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- penalize routing through service ways ([#2313](https://github.com/GIScience/openrouteservice/pull/2313))
+- correct speed assignment for HGVs and disable acceleration heuristic on motorways/-roads ([#2329](https://github.com/GIScience/openrouteservice/pull/2329))
 
 ### Security
 - update postcss to 8.5.25

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -1499,7 +1499,7 @@ class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].summary.duration", is(closeTo(1996.2, 1)))
+                .body("routes[0].summary.duration", is(closeTo(1964.4, 1)))
                 .statusCode(200);
     }
 
@@ -4432,7 +4432,7 @@ class ResultTest extends ServiceTest {
 
         JSONObject customModel = new JSONObject();
         customModel.put("priority", new JSONArray());
-        customModel.put("distance_influence", 150);
+        customModel.put("distance_influence", 160);
         body.put("custom_model", customModel);
 
         given()

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -1461,11 +1461,10 @@ class ResultTest extends ServiceTest {
     @Test
     void testMaximumSpeed() {
         JSONObject body = new JSONObject();
-        body.put("coordinates", HelperFunctions.constructCoords("8.63348,49.41766|8.6441,49.4672"));
+        body.put("coordinates", getParameter("coordinatesCustom2"));
         body.put("preference", getParameter("preference"));
-        body.put("maximum_speed", 85);
 
-        //Test against default maximum speed lower bound setting
+        // Reference for driving-car
         given()
                 .config(JSON_CONFIG_DOUBLE_NUMBERS)
                 .headers(CommonHeaders.jsonContent)
@@ -1476,12 +1475,10 @@ class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].summary.duration", is(closeTo(1682.6, 1)))
+                .body("routes[0].summary.duration", is(closeTo(524.4, 1)))
                 .statusCode(200);
 
-        //Test profile-specific maximum speed lower bound
-        body.put("maximum_speed", 75);
-
+        // Reference for driving-hgv
         given()
                 .config(JSON_CONFIG_DOUBLE_NUMBERS)
                 .headers(CommonHeaders.jsonContent)
@@ -1492,7 +1489,37 @@ class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].summary.duration", is(closeTo(1966.0, 1)))
+                .body("routes[0].summary.duration", is(closeTo(667.5, 1)))
+                .statusCode(200);
+
+        // Test against default maximum speed lower bound setting
+        body.put("maximum_speed", 85);
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.jsonContent)
+                .pathParam("profile", "driving-car")
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}")
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].summary.duration", is(closeTo(540.4, 1)))
+                .statusCode(200);
+
+        // Test profile-specific maximum speed lower bound of 75 km/h for driving-hgv profile
+        body.put("maximum_speed", 75);
+        given()
+                .config(JSON_CONFIG_DOUBLE_NUMBERS)
+                .headers(CommonHeaders.jsonContent)
+                .pathParam("profile", "driving-hgv")
+                .body(body.toString())
+                .when()
+                .post(getEndPointPath() + "/{profile}")
+                .then()
+                .assertThat()
+                .body("any { it.key == 'routes' }", is(true))
+                .body("routes[0].summary.duration", is(closeTo(691.9, 1)))
                 .statusCode(200);
     }
 

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -1492,7 +1492,7 @@ class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].summary.duration", is(closeTo(2004.7, 1)))
+                .body("routes[0].summary.duration", is(closeTo(1966.0, 1)))
                 .statusCode(200);
     }
 

--- a/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
+++ b/ors-api/src/test/java/org/heigit/ors/apitests/routing/ResultTest.java
@@ -175,13 +175,6 @@ class ResultTest extends ServiceTest {
         coordinatesCustom3.put(coordinateCustom6);
         addParameter("coordinatesCustom3", coordinatesCustom3);
 
-//        8.6947238445282, 49.41176896906394
-//        8.7036609649658, 49.41281775942496
-
-        // 8.687862753868105, 49.41309522267728
-        // 8.691891431808473, 49.41331858818114
-
-
         JSONArray unreachableCoords = new JSONArray();
         JSONArray unreachableCoord1 = new JSONArray();
         unreachableCoord1.put(6.929281);
@@ -1483,7 +1476,7 @@ class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].summary.duration", is(closeTo(1710.7, 1)))
+                .body("routes[0].summary.duration", is(closeTo(1682.6, 1)))
                 .statusCode(200);
 
         //Test profile-specific maximum speed lower bound
@@ -1499,7 +1492,7 @@ class ResultTest extends ServiceTest {
                 .then()
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
-                .body("routes[0].summary.duration", is(closeTo(1964.4, 1)))
+                .body("routes[0].summary.duration", is(closeTo(2004.7, 1)))
                 .statusCode(200);
     }
 
@@ -4432,7 +4425,7 @@ class ResultTest extends ServiceTest {
 
         JSONObject customModel = new JSONObject();
         customModel.put("priority", new JSONArray());
-        customModel.put("distance_influence", 160);
+        customModel.put("distance_influence", 175);
         body.put("custom_model", customModel);
 
         given()
@@ -4478,7 +4471,7 @@ class ResultTest extends ServiceTest {
                 .assertThat()
                 .body("any { it.key == 'routes' }", is(true))
                 .body("routes[0].summary.distance", is(closeTo(9746, 50f)))
-                .body("routes[0].summary.duration", is(closeTo(702f, 5f)))
+                .body("routes[0].summary.duration", is(closeTo(670.5, 5f)))
                 .statusCode(200);
     }
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/EmergencyFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/EmergencyFlagEncoder.java
@@ -206,12 +206,7 @@ public class EmergencyFlagEncoder extends VehicleFlagEncoder {
     }
 
     @Override
-    protected double getSpeed(ReaderWay way) {
-        String highwayValue = way.getTag(KEY_HIGHWAY);
-        if (!Helper.isEmpty(highwayValue) && way.hasTag(KEY_MOTORROAD, "yes")
-                && !highwayValue.equals(KEY_MOTORWAY) && !highwayValue.equals(KEY_MOTORWAY_LINK)) {
-            highwayValue = KEY_MOTORROAD;
-        }
+    protected double getSpeed(ReaderWay way, String highwayValue) {
         Integer speed = speedLimitHandler.getSpeed(highwayValue);
         if (speed == null)
             throw new IllegalStateException(this + ", no speed found for: " + highwayValue + ", tags: " + way);
@@ -269,7 +264,7 @@ public class EmergencyFlagEncoder extends VehicleFlagEncoder {
 
         if (!access.isFerry()) {
             // get assumed speed from highway type
-            double speed = getSpeed(way);
+            double speed = getSpeed(way, getHighway(way));
             speed = applyMaxSpeed(way, speed);
             speed = getSurfaceSpeed(way, speed);
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -149,11 +149,6 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
     }
 
     @Override
-    protected String getHighway(ReaderWay way) {
-        return way.getTag(KEY_HIGHWAY);
-    }
-
-    @Override
     public EncodingManager.Access getAccess(ReaderWay way) {
         String highwayValue = way.getTag(KEY_HIGHWAY);
         String[] restrictionValues = way.getFirstPriorityTagValues(restrictions);
@@ -257,6 +252,7 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
                 switch (highway) {
                     case "motorway":
                     case "motorway_link":
+                    case "motorroad":
                     case "trunk":
                     case "trunk_link":
                         weightToPrioMap.put(100d, PriorityCode.BEST.getValue());

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -255,7 +255,7 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
                     case "motorroad":
                     case "trunk":
                     case "trunk_link":
-                        weightToPrioMap.put(100d, PriorityCode.BEST.getValue());
+                        weightToPrioMap.put(100d, PriorityCode.VERY_NICE.getValue());
                         break;
                     case "primary":
                     case "primary_link":
@@ -278,10 +278,10 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
                         }
                         break;
                     case "living_street":
-                        weightToPrioMap.put(100d, PriorityCode.AVOID_IF_POSSIBLE.getValue());
+                        weightToPrioMap.put(100d, PriorityCode.AVOID_AT_ALL_COSTS.getValue());
                         break;
                     case VAL_TRACK:
-                        weightToPrioMap.put(100d, PriorityCode.REACH_DEST.getValue());
+                        weightToPrioMap.put(100d, PriorityCode.WORST.getValue());
                         break;
                     default:
                         weightToPrioMap.put(40d, PriorityCode.AVOID_IF_POSSIBLE.getValue());

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/HeavyVehicleFlagEncoder.java
@@ -136,11 +136,11 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
         if (!isValidSpeed(maxSpeed)) {
             maxSpeed = super.getMaxSpeed(way);
             if (isValidSpeed(maxSpeed)) {
-                String highway = way.getTag(KEY_HIGHWAY);
+                String highway = getHighway(way);
                 if (!Helper.isEmpty(highway)) {
                     double defaultSpeed = speedLimitHandler.getSpeed(highway);
                     if (defaultSpeed < maxSpeed)
-                        maxSpeed = defaultSpeed;
+                        maxSpeed = Double.NaN;
                 }
             }
         }
@@ -245,7 +245,7 @@ public class HeavyVehicleFlagEncoder extends VehicleFlagEncoder {
         if (way.hasTag("hgv", VAL_DESIGNATED) || (way.hasTag("access", VAL_DESIGNATED) && (way.hasTag(VAL_GOODS, "yes") || way.hasTag("hgv", "yes") || way.hasTag("bus", "yes") || way.hasTag(VAL_AGRICULTURAL, "yes") || way.hasTag(VAL_FORESTRY, "yes"))))
             weightToPrioMap.put(100d, PriorityCode.BEST.getValue());
         else {
-            String highway = way.getTag(KEY_HIGHWAY);
+            String highway = getHighway(way);
             double maxSpeed = getMaxSpeed(way);
 
             if (!Helper.isEmpty(highway)) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
@@ -225,7 +225,7 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
             if (way.hasTag(KEY_ESTIMATED_DISTANCE)) {
                 if (way.hasTag(KEY_HIGHWAY, KEY_RESIDENTIAL)) {
                     speed = addResedentialPenalty(speed, way);
-                } else if (this.useAcceleration) {
+                } else if (this.useAcceleration && !way.hasTag(KEY_HIGHWAY, "motorway")) {
                     double estDist = way.getTag(KEY_ESTIMATED_DISTANCE, Double.MAX_VALUE);
                     speed = adjustSpeedForAcceleration(estDist, speed);
                 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
@@ -42,11 +42,12 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
     public static final String KEY_VEHICLE_FORWARD = "vehicle:forward";
     public static final String KEY_MOTOR_VEHICLE_FORWARD = "motor_vehicle:forward";
     public static final String KEY_MOTORROAD = "motorroad";
+    public static final String KEY_MOTORWAY = "motorway";
+    public static final String KEY_MOTORWAY_LINK = "motorway_link";
+    public static final String KEY_RESIDENTIAL = "residential";
     private static final double ACCELERATION_SPEED_CUTOFF_MAX = 80.0;
     private static final double ACCELERATION_SPEED_CUTOFF_MIN = 20.0;
     public static final int AVERAGE_SECS_TO_100_KMPH = 10;
-    public static final String KEY_MOTORWAY_LINK = "motorway_link";
-    public static final String KEY_RESIDENTIAL = "residential";
     protected SpeedLimitHandler speedLimitHandler;
 
     private double accelerationModifier = 0.0;
@@ -158,7 +159,7 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
 
         defaultSpeedMap = new HashMap<>();
         // autobahn
-        defaultSpeedMap.put("motorway", 100);
+        defaultSpeedMap.put(KEY_MOTORWAY, 100);
         defaultSpeedMap.put(KEY_MOTORWAY_LINK, 60);
         defaultSpeedMap.put(KEY_MOTORROAD, 90);
         // bundesstraße
@@ -207,8 +208,8 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
             return edgeFlags;
 
         if (!access.isFerry()) {
-            // get assumed speed from highway type
-            double speed = getSpeed(way);
+            String highwayValue = getHighway(way);
+            double speed = getSpeed(way, highwayValue);
             speed = applyMaxSpeed(way, speed);
 
             // TODO: save conditional speeds only if their value is different from the default speed
@@ -223,9 +224,9 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
             speed = getSurfaceSpeed(way, speed);
 
             if (way.hasTag(KEY_ESTIMATED_DISTANCE)) {
-                if (way.hasTag(KEY_HIGHWAY, KEY_RESIDENTIAL)) {
+                if (KEY_RESIDENTIAL.equals(highwayValue)) {
                     speed = addResedentialPenalty(speed, way);
-                } else if (this.useAcceleration && !way.hasTag(KEY_HIGHWAY, "motorway")) {
+                } else if (this.useAcceleration && !KEY_MOTORWAY.equals(highwayValue) && !KEY_MOTORROAD.equals(highwayValue)) {
                     double estDist = way.getTag(KEY_ESTIMATED_DISTANCE, Double.MAX_VALUE);
                     speed = adjustSpeedForAcceleration(estDist, speed);
                 }
@@ -333,8 +334,7 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
                 || way.hasTag(KEY_MOTOR_VEHICLE_FORWARD);
     }
 
-    protected double getSpeed(ReaderWay way) {
-        String highwayValue = getHighway(way);
+    protected double getSpeed(ReaderWay way, String highwayValue) {
         Integer speed = speedLimitHandler.getSpeed(highwayValue);
 
         // Note that Math.round(NaN) == 0
@@ -362,7 +362,7 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
     protected String getHighway(ReaderWay way) {
         String highwayValue = way.getTag(KEY_HIGHWAY);
         if (!Helper.isEmpty(highwayValue) && way.hasTag(KEY_MOTORROAD, "yes")
-                && !highwayValue.equals("motorway") && !highwayValue.equals(KEY_MOTORWAY_LINK)) {
+                && !highwayValue.equals(KEY_MOTORWAY) && !highwayValue.equals(KEY_MOTORWAY_LINK)) {
             highwayValue = KEY_MOTORROAD;
         }
         return highwayValue;

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/flagencoders/VehicleFlagEncoder.java
@@ -48,6 +48,7 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
     private static final double ACCELERATION_SPEED_CUTOFF_MAX = 80.0;
     private static final double ACCELERATION_SPEED_CUTOFF_MIN = 20.0;
     public static final int AVERAGE_SECS_TO_100_KMPH = 10;
+    public static final double MAX_SPEED_FACTOR = 0.9;
     protected SpeedLimitHandler speedLimitHandler;
 
     private double accelerationModifier = 0.0;
@@ -371,7 +372,7 @@ public abstract class VehicleFlagEncoder extends ORSAbstractFlagEncoder {
     @Override
     protected double applyMaxSpeed(ReaderWay way, double speed) {
         double maxSpeed = this.getMaxSpeed(way);
-        return isValidSpeed(maxSpeed) ? maxSpeed * 0.9D : speed;
+        return isValidSpeed(maxSpeed) ? maxSpeed * MAX_SPEED_FACTOR : speed;
     }
 
     /**


### PR DESCRIPTION
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [x] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [x] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes #1800

### Information about the changes
- Key functionality added: disable acceleration heuristic on motorways
- Reason for change: unrealistic long duration for bus routes on motorways

### Examples and reasons for differences between live ORS routes, and those generated from this pull request

### Public API 

#### car: avg. speed 109.1 km/h

<img width="1755" height="909" alt="image" src="https://github.com/user-attachments/assets/33f78ef8-888e-4638-a527-87c546b8c70a" />

#### hgv: avg. speed 55.6 km/h

<img width="1755" height="909" alt="image" src="https://github.com/user-attachments/assets/deff5692-9131-4312-8d80-fb8f72858c49" />

### This PR

#### hgv with just acceleration on motorways disabled: avg. speed 70.6 km/h
<img width="1785" height="909" alt="image" src="https://github.com/user-attachments/assets/a1ee380e-7dd3-484c-9a89-ecb3d09739ef" />

#### hgv with acceleration disabled and maxspeed fix: avg. speed 78.3 km/h
<img width="1776" height="925" alt="image" src="https://github.com/user-attachments/assets/831fa17b-8b0b-483f-9a41-ffbb01d6a1b0" />

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
