### PR TITLE
fix: update minio to 9.0.3 to fix CVE

### DIFF
--- a/ors-engine/pom.xml
+++ b/ors-engine/pom.xml
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
-            <version>8.6.0</version>
+            <version>9.0.3</version>
         </dependency>
 
         <dependency>

--- a/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/remote/MinioGraphRepoClient.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/graphhopper/extensions/manage/remote/MinioGraphRepoClient.java
@@ -15,8 +15,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -158,7 +156,7 @@ public class MinioGraphRepoClient extends AbstractGraphRepoClient implements ORS
                             .filename(localPath.toString())
                             .build()
             );
-        } catch (MinioException | IOException | NoSuchAlgorithmException | InvalidKeyException e) {
+        } catch (MinioException e) {
             LOGGER.warn("[%s] Caught %s when trying to download %s".formatted(getProfileDescriptiveName(), e, repoPath.toFile().getAbsolutePath()));
             throw new IllegalArgumentException(e);
         }

--- a/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/remote/MinioRepoManagerTest.java
+++ b/ors-engine/src/test/java/org/heigit/ors/routing/graphhopper/extensions/manage/remote/MinioRepoManagerTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ors.routing.graphhopper.extensions.manage.remote;
 
 import io.minio.*;
-import io.minio.errors.*;
-import io.minio.messages.Bucket;
+import io.minio.errors.MinioException;
+import io.minio.messages.ListAllMyBucketsResult;
 import io.minio.messages.Item;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,8 +24,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -63,11 +61,9 @@ class MinioRepoManagerTest {
                         minioClient.putObject(PutObjectArgs.builder()
                                 .bucket(BUCKET_NAME)
                                 .object(TESTFILE_ROOT.relativize(path).toString())
-                                .stream(new FileInputStream(path.toFile()), path.toFile().length(), -1)
+                                .stream(new FileInputStream(path.toFile()), path.toFile().length(), -1L)
                                 .build());
-                    } catch (ErrorResponseException | InsufficientDataException | InternalException |
-                             InvalidKeyException | InvalidResponseException | IOException | NoSuchAlgorithmException |
-                             ServerException | XmlParserException e) {
+                    } catch (MinioException | IOException e) {
                         throw new RuntimeException(e);
                     }
                 });
@@ -132,7 +128,7 @@ class MinioRepoManagerTest {
                 .endpoint(minioContainer.getS3URL())
                 .credentials(minioContainer.getUserName(), minioContainer.getPassword())
                 .build()) {
-            List<Bucket> buckets = minioClient.listBuckets();
+            List<ListAllMyBucketsResult.Bucket> buckets = minioClient.listBuckets();
             assertEquals(1, buckets.size());
             assertEquals(BUCKET_NAME, buckets.get(0).name());
             List<String> expected = List.of(


### PR DESCRIPTION
This fixes the CVE https://github.com/advisories/GHSA-574f-3g2m-x479. 
Minio pulls in  org.bouncycastle:bcprov with a vulnerable version. io.minio.minio > v9 fixes this.

However, this changes some imports. 

Also, `MinioException` now includes all the explicit exceptions `ErrorResponseException | InsufficientDataException | InternalException | InvalidKeyException | InvalidResponseException | NoSuchAlgorithmException | ServerException | XmlParserException`.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes 

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
