### PR TITLE
fix: Migrate the go yq build to a yq binary download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,6 @@ COPY ors-engine /tmp/ors/ors-engine
 RUN ./mvnw -pl 'ors-api,ors-engine' \
     -q clean package -DskipTests -Dmaven.test.skip=true
 
-FROM docker.io/golang:1.26.5-alpine3.24 AS build-go
-# ============================================================================
-# Build stage for Go-based tools
-# This stage is dedicated to building Go-based tools required in later stages.
-# ============================================================================
-
-RUN GO111MODULE=on go install github.com/mikefarah/yq/v4@v4.53.3
-
 FROM docker.io/amazoncorretto:21.0.12-alpine3.24 AS base
 # ============================================================================
 # Base image stage: common setup for all runtime stages
@@ -109,29 +101,27 @@ FROM base AS publish
 
 # Build ARGS
 ARG OSM_FILE=./ors-api/src/test/files/heidelberg.test.pbf
+ARG TARGETARCH
+ARG YQ_VERSION=v4.53.3
 
 # Copy over the needed bits and pieces from the other stages.
 COPY --chown=ors:ors --chmod=755 ./$OSM_FILE /heidelberg.test.pbf
 COPY --chown=ors:ors --chmod=755 ./docker-entrypoint.sh /entrypoint.sh
-COPY --chown=ors:ors --from=build-go /go/bin/yq /bin/yq
 # Copy JAR from build stage with broader permissions
 COPY --chown=ors:ors --chmod=755 --from=build /tmp/ors/ors-api/target/ors.jar /ors.jar
-
-
-# Setup additional packages for publish stage and allow read access to others
-RUN apk add --no-cache bash=~5 jq=~1 openssl=~3 && \
-    chmod -R o-rwx ${ORS_HOME}
-
 # Copy the example config files to the build folder
 COPY --chown=ors:ors --chmod=755 ./ors-config.yml /example-ors-config.yml
 COPY --chown=ors:ors --chmod=755 ./ors-config.env /example-ors-config.env
 
-# Rewrite the example config to use the right files in the container
-RUN yq -i -p=props -o=props \
+RUN wget -qO /bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH}" && \
+    chmod +x /bin/yq && \
+    apk add --no-cache bash=~5 jq=~1 openssl=~3 && \
+    yq -i -p=props -o=props \
     '.ors.engine.profile_default.build.source_file="/home/ors/files/example-heidelberg.test.pbf"' \
     /example-ors-config.env && \
     yq -i e '.ors.engine.profile_default.build.source_file = "/home/ors/files/example-heidelberg.test.pbf"' \
-    /example-ors-config.yml
+    /example-ors-config.yml && \
+    chmod -R o-rwx ${ORS_HOME}
 
 ENV BUILD_GRAPHS="False"
 ENV REBUILD_GRAPHS="False"


### PR DESCRIPTION
The go dependency introduced a lot of CVEs in the workflow regularly. By downloading the appropriate ARCH binary directly we avoid pulling in the CVEs.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
