### PR TITLE
feat: attach SBOM and max-mode provenance attestations on push

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -43,6 +43,22 @@ inputs:
     required: false
     type: string
     default: 'type=docker'
+  sbom:
+    description: >-
+      Attach an SBOM attestation to the image. Attestations are only supported by
+      the image/oci exporters, so this is forced off whenever the image is not
+      pushed (the scan path exports type=docker to a tarball).
+    required: false
+    type: string
+    default: 'true'
+  provenance:
+    description: >-
+      Provenance attestation mode ('mode=min', 'mode=max' or 'false'). Same
+      exporter restriction as `sbom`. Defaults to mode=max so the attestation
+      records the full build definition, including the digest-pinned base images.
+    required: false
+    type: string
+    default: 'mode=max'
 
 outputs:
   imageid:
@@ -72,3 +88,5 @@ runs:
         cache-from: type=${{ inputs.cache_from_type }}
         cache-to: type=${{ inputs.cache_to_type }}
         outputs: ${{ inputs.push_image && '' || inputs.output_type }}
+        sbom: ${{ inputs.push_image == 'true' && inputs.sbom == 'true' }}
+        provenance: ${{ inputs.push_image == 'true' && inputs.provenance || 'false' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Releasing is documented in RELEASE.md
 ## [unreleased]
 
 ### Added
+- add SBOM and provenance via docker buildx commands ([#2347](https://github.com/GIScience/openrouteservice/pull/2347))
 
 ### Changed
 - replace Grype with Trivy for CI vulnerability scanning ([#2335](https://github.com/GIScience/openrouteservice/pull/2335))


### PR DESCRIPTION
The composite action forwarded neither `sbom` nor `provenance` to docker/build-push-action, so published images carried no SBOM at all and only BuildKit's default `mode=min` provenance.

Results can be verified with: 

### Check the OCI index structure
docker buildx imagetools inspect openrouteservice/openrouteservice:nightly-slim --raw

### SBOM (empty {} if none)
docker buildx imagetools inspect openrouteservice/openrouteservice:nightly-slim --format '{{ json .SBOM }}'

### Provenance (null if none)
docker buildx imagetools inspect openrouteservice/openrouteservice:nightly-slim --format '{{ json .Provenance }}'



### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
