### PR TITLE
fix: let the slim image run under an arbitrary UID

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -207,16 +207,33 @@ jobs:
         run: |
           echo "UID=$(id -u)" >> $GITHUB_ENV
 
+      - name: Verify the slim image is not bound to a specific user ID
+        if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
+        run: |
+          # A UID without an /etc/passwd entry gets GID 0, which is how Kubernetes injects
+          # injects its own user. Group 0 must therefore carry the owner's
+          # rights on both the JAR and ORS_HOME. This guards two regressions that are
+          # invisible in a Dockerfile diff: copying the JAR with --chmod=750 again, and
+          # chowning ORS_HOME back to ors:ors.
+          docker run --rm --user 1234567:0 --entrypoint sh ${{ env.TEST_SLIM_IMAGE_NAME }} -c '
+            set -eu
+            id
+            [ -r /ors.jar ] || { echo "FAIL: /ors.jar is not readable under an arbitrary UID"; exit 1; }
+            touch /home/ors/graphs/.uid-probe || { echo "FAIL: ORS_HOME is not writable under an arbitrary UID"; exit 1; }
+            echo "OK: arbitrary UID can read /ors.jar and write ORS_HOME"'
+
       - name: Test slim image with graph build
         if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
         run: |
           mkdir -p $(pwd)/ors-docker/elevation_cache
           chown -R $UID $(pwd)/ors-docker/elevation_cache
-          # Place cached elevation file 
+          # Place cached elevation file
           cp ors-api/src/test/files/elevation/srtm_38_03.gh $(pwd)/ors-docker/elevation_cache
           # Start kubernetes image with graph build configured via environment variables
+          # GID 0, not 1000: the runner's UID plus GID 1000 would pass through the `ors`
+          # group and hide the fact that an injected UID only ever lands in group 0.
           docker run -it -d -p 8080:8082 \
-            -u $UID:1000 \
+            -u $UID:0 \
             -v graphs:/home/ors/graphs \
             -v $(pwd)/ors-docker/elevation_cache:/home/ors/elevation_cache \
             -v $(pwd)/ors-api/src/test/files/heidelberg.test.pbf:/home/ors/files/heidelberg.test.pbf:ro \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Releasing is documented in RELEASE.md
 
 ### Fixed
 - give the healthcheck a start-period so it survives longer graph loading ([#2365](https://github.com/GIScience/openrouteservice/pull/2365))
+- let the slim image run under an arbitrary UID: own `ORS_HOME` as group 0 with the group bits mirroring the owner, copy the JAR read-only instead of `750`, and declare a numeric `USER 1001:0` that `runAsNonRoot` can resolve ([#2366](https://github.com/GIScience/openrouteservice/pull/2366))
 - penalize routing through service ways ([#2313](https://github.com/GIScience/openrouteservice/pull/2313))
 - correct speed assignment for HGVs and disable acceleration heuristic on motorways/-roads ([#2329](https://github.com/GIScience/openrouteservice/pull/2329))
 - pass branch through to the reusable Docker build workflow so CI actually builds the triggering commit instead of always `main` ([#2340](https://github.com/GIScience/openrouteservice/pull/2340))

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ ARG ORS_HOME=/home/ors
 RUN addgroup ors -g ${GID} && \
     adduser -D -u ${UID} --system -G ors ors && \
     mkdir -p ${ORS_HOME}/logs ${ORS_HOME}/files ${ORS_HOME}/graphs ${ORS_HOME}/elevation_cache ${ORS_HOME}/app && \
-    chown -R ors:ors ${ORS_HOME} && \
-    chmod -R u+rwX,g+rwX ${ORS_HOME}
+    chown -R ors:0 ${ORS_HOME} && \
+    chmod -R u+rwX,g=u ${ORS_HOME}
 
 # Set the default language
 ENV LANG='en_US' LANGUAGE='en_US' LC_ALL='en_US' \
@@ -85,14 +85,15 @@ FROM base AS slim
 # - No config presets or example data
 # ============================================================================
 
-# Copy JAR from build stage
-COPY --chown=ors:ors --chmod=750 --from=build /tmp/ors/ors-api/target/ors.jar /ors.jar
+# Copy JAR from build stage.
+# 644, not 750: `java -jar` only reads the archive.
+COPY --chown=ors:0 --chmod=644 --from=build /tmp/ors/ors-api/target/ors.jar /ors.jar
 
 # Stdout/stderr only for the slim image. Can be overridden by setting LOGGING_FILE_NAME to a file path in the container.
 ENV LOGGING_FILE_NAME=""
 
-# Switch to non-root user
-USER ors
+# Switch to a non-root user, declared numerically and above 1000.
+USER 1001:0
 
 # Run Java jar directly as PID 1
 # Configuration via environment variables:
@@ -120,8 +121,9 @@ ARG OSM_FILE=./ors-api/src/test/files/heidelberg.test.pbf
 COPY --chown=ors:ors --chmod=755 ./$OSM_FILE /heidelberg.test.pbf
 COPY --chown=ors:ors --chmod=755 ./docker-entrypoint.sh /entrypoint.sh
 COPY --chown=ors:ors --from=build-go /go/bin/yq /bin/yq
-# Copy JAR from build stage with broader permissions
-COPY --chown=ors:ors --chmod=755 --from=build /tmp/ors/ors-api/target/ors.jar /ors.jar
+# Copy JAR from build stage. Read-only data: docker-entrypoint.sh starts it with
+# `java -jar`, never by executing it, so no execute bit is needed here either.
+COPY --chown=ors:0 --chmod=644 --from=build /tmp/ors/ors-api/target/ors.jar /ors.jar
 
 
 # Setup additional packages for publish stage and allow read access to others


### PR DESCRIPTION
ORS_HOME and the JAR were owned by ors:ors with the JAR at 750, so only UID <1000 could start the container or access the files properly. 

This PR fixes this as followed:
A UID with no /etc/passwd entry lands in GID 0, so own ORS_HOME as ors:0 with group bits mirroring the owner, copy the JAR read-only (644, never executed), and declare USER 1001:0 instead of USER ors so runAsNonRoot can resolve it. 

CI ran with -u $UID:1000, which hid the bug via the ors group. It now runs with GID 0 plus a dedicated arbitrary- UID check. The publish stage stays root by default, unchanged, to avoid breaking the docker compose quickstart.

Requirement:
```text
> https://container.gov.de/docs/referenzen/container-hardening-checklist

Der Container ist nicht an bestimmte Benutzer-IDs gebunden (MUSS) - 
Die Ausführung der Anwendung funktioniert mit beliebigen Benutzer-IDs. 
Dies ermöglicht die Ausführung in Umgebungen, die Containern zufällige Benutzer-IDs zuweisen (z. B. OpenShift), und erhöht die Portabilität.
```
### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
