### PR TITLE
feat: Disable file logging to finally support read-only for the slim image

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -232,3 +232,40 @@ jobs:
             ${{ env.TEST_SLIM_IMAGE_NAME }}
           # Wait for graph build and health check (kubernetes image is non-interactive)
           ./.github/utils/url_check.sh 127.0.0.1 8080 /ors/v2/health 200 60 || (docker logs ors-slim-test && exit 1)
+
+      - name: Stop graph-build test container
+        if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
+        run: |
+          docker stop ors-slim-test
+          docker container prune -f
+
+      - name: Verify the slim image serves requests under a read-only root filesystem
+        if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
+        run: |
+          # Reuses the graph from the previous step; elevation_cache is deliberately
+          # left off since it's only written to during a build. graphs (GraphHopper
+          # lock file) and tmpfs /tmp (GeoTools EPSG cache) must stay writable.
+          docker run -d --read-only --tmpfs /tmp -p 8080:8082 \
+            -u $UID:1000 \
+            -v graphs:/home/ors/graphs \
+            -e server.port=8082 \
+            -e ors.engine.profile_default.graph_path=/home/ors/graphs \
+            -e ors.engine.graphs_data_access=MMAP \
+            -e ors.engine.profiles.driving-car.enabled=true \
+            --name ors-slim-readonly-test \
+            ${{ env.TEST_SLIM_IMAGE_NAME }}
+          ./.github/utils/url_check.sh 127.0.0.1 8080 /ors/v2/health 200 60 || (docker logs ors-slim-readonly-test && exit 1)
+
+          response_code=$(curl -s -o /tmp/avoid-polygons-response.json -w "%{http_code}" -X POST \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -H "Accept: application/geo+json; charset=utf-8" \
+            --data '{"coordinates":[[8.681495,49.41461],[8.686507,49.41943],[8.687872,49.420318]],"options":{"avoid_polygons":{"coordinates":[[[8.684881031827587,49.41768066444595],[8.684881031827587,49.41699648134178],[8.685816955915811,49.41699648134178],[8.685816955915811,49.41768066444595],[8.684881031827587,49.41768066444595]]],"type":"Polygon"}}}' \
+            http://127.0.0.1:8080/ors/v2/directions/driving-car/geojson)
+          if [ "${response_code}" != "200" ]; then
+            echo "FAIL: avoid_polygons request returned HTTP ${response_code}"
+            cat /tmp/avoid-polygons-response.json
+            docker logs ors-slim-readonly-test
+            exit 1
+          fi
+          docker exec ors-slim-readonly-test test -d /tmp/GeoTools || { echo "FAIL: GeoTools did not initialize its EPSG cache under tmpfs /tmp"; docker logs ors-slim-readonly-test; exit 1; }
+          echo "OK: read-only rootfs served avoid_polygons and initialized GeoTools' EPSG cache"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Releasing is documented in RELEASE.md
 ### Added
 - add SBOM and provenance via docker buildx commands ([#2347](https://github.com/GIScience/openrouteservice/pull/2347))
 - add OCI title/description/documentation labels to base image ([#2364](https://github.com/GIScience/openrouteservice/pull/2364))
+- disable file logging in the slim image so it can run with a read-only root filesystem given a tmpfs at `/tmp` for GeoTools' EPSG cache ([#2367](https://github.com/GIScience/openrouteservice/pull/2367))
 
 ### Changed
 - replace Grype with Trivy for CI vulnerability scanning ([#2335](https://github.com/GIScience/openrouteservice/pull/2335))

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ FROM base AS slim
 # Copy JAR from build stage
 COPY --chown=ors:ors --chmod=750 --from=build /tmp/ors/ors-api/target/ors.jar /ors.jar
 
+# Stdout/stderr only for the slim image. Can be overridden by setting LOGGING_FILE_NAME to a file path in the container.
+ENV LOGGING_FILE_NAME=""
+
 # Switch to non-root user
 USER ors
 


### PR DESCRIPTION
The log file was the last thing that broke the read-only part. It can be overwritten easily and logs written to a mount.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
