### PR TITLE
feat: harden slim tomcat

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -250,6 +250,27 @@ jobs:
           # Wait for graph build and health check (kubernetes image is non-interactive)
           ./.github/utils/url_check.sh 127.0.0.1 8080 /ors/v2/health 200 60 || (docker logs ors-slim-test && exit 1)
 
+      - name: Check slim image pins the hardened response settings
+        if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
+        run: |
+          # These settings are provable by inspection rather than over the wire,
+          # which is the point of pinning them: `docker inspect` is the evidence.
+          env_json=$(docker inspect -f '{{json .Config.Env}}' ${{ env.TEST_SLIM_IMAGE_NAME }})
+          for expected in 'SERVER_SERVER_HEADER=' 'SERVER_ERROR_INCLUDE_STACKTRACE=never' \
+                          'SERVER_ERROR_INCLUDE_MESSAGE=never' 'SERVER_ERROR_INCLUDE_EXCEPTION=false' \
+                          'SERVER_ERROR_INCLUDE_BINDING_ERRORS=never' \
+                          'SERVER_MAX_HTTP_REQUEST_HEADER_SIZE=8KB'; do
+            if ! echo "${env_json}" | grep -q "\"${expected}"; then
+              echo "::error::${expected} missing from the slim image environment"
+              exit 1
+            fi
+          done
+          # And the one thing the pins are there to guarantee, checked on the wire.
+          if curl -sI http://127.0.0.1:8080/ors/v2/health | grep -i '^server:\|^x-powered-by:'; then
+            echo "::error::slim image leaks a Server or X-Powered-By response header"
+            exit 1
+          fi
+
       - name: Stop graph-build test container
         if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
         run: |

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -250,6 +250,24 @@ jobs:
           # Wait for graph build and health check (kubernetes image is non-interactive)
           ./.github/utils/url_check.sh 127.0.0.1 8080 /ors/v2/health 200 60 || (docker logs ors-slim-test && exit 1)
 
+      - name: Test slim image does not expose Swagger UI or the OpenAPI document
+        if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
+        run: |
+          # The webjars path is included on purpose: it is the one that regresses
+          # silently, because it serves the UI without going through /swagger-ui.
+          for path in /ors/swagger-ui /ors/swagger-ui/index.html \
+                      /ors/webjars/swagger-ui/index.html /ors/v2/api-docs; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:8080${path}")
+            echo "${path} -> ${code}"
+            if [[ "${code}" != "404" ]]; then
+              echo "::error::${path} answered ${code}, expected 404 - the slim image must not ship Swagger UI or api-docs"
+              exit 1
+            fi
+          done
+          # Routing must still work with springdoc switched off.
+          ./.github/utils/url_check.sh 127.0.0.1 8080 "/ors/v2/directions/driving-car?start=8.681495,49.41461&end=8.687872,49.420318" 200 1 \
+            || (docker logs ors-slim-test && exit 1)
+
       - name: Check slim image pins the hardened response settings
         if: ${{ !(matrix.skip_on_draft && (needs.prepare_environment.outputs.is_draft == 'true')) }}
         run: |
@@ -258,8 +276,9 @@ jobs:
           env_json=$(docker inspect -f '{{json .Config.Env}}' ${{ env.TEST_SLIM_IMAGE_NAME }})
           for expected in 'SERVER_SERVER_HEADER=' 'SERVER_ERROR_INCLUDE_STACKTRACE=never' \
                           'SERVER_ERROR_INCLUDE_MESSAGE=never' 'SERVER_ERROR_INCLUDE_EXCEPTION=false' \
-                          'SERVER_ERROR_INCLUDE_BINDING_ERRORS=never' \
-                          'SERVER_MAX_HTTP_REQUEST_HEADER_SIZE=8KB'; do
+                          'SERVER_ERROR_INCLUDE_BINDING_ERRORS=never' 'SERVER_MAX_HTTP_REQUEST_HEADER_SIZE=8KB' \
+                          'SERVER_TOMCAT_CONNECTION_TIMEOUT=20s' 'SPRINGDOC_SWAGGER_UI_ENABLED=false' \
+                          'SPRINGDOC_API_DOCS_ENABLED=false'; do
             if ! echo "${env_json}" | grep -q "\"${expected}"; then
               echo "::error::${expected} missing from the slim image environment"
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Releasing is documented in RELEASE.md
 - scan all images arm/amd64 for publish/slim stages but only fail for critical and high on slim ([#2345](https://github.com/GIScience/openrouteservice/pull/2345))
 - pin dockerfile base images by digest ([#2346](https://github.com/GIScience/openrouteservice/pull/2346))
 - reduce the Docker `HEALTHCHECK` interval from 30s to 10s to match Kubernetes' default probe interval; Kubernetes does not consume Docker's `HEALTHCHECK` itself, so this timing only affects plain Docker/Podman/Swarm deployments ([#2369](https://github.com/GIScience/openrouteservice/pull/2369))
+- harden the embedded Tomcat of the slim image: pin the already-effective response settings, shorten the connector timeout to 20s and disable Swagger UI and the OpenAPI document ([#2368](https://github.com/GIScience/openrouteservice/pull/2368))
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,14 @@ COPY --chown=ors:0 --chmod=644 --from=build /tmp/ors/ors-api/target/ors.jar /ors
 # Stdout/stderr only for the slim image. Can be overridden by setting LOGGING_FILE_NAME to a file path in the container.
 ENV LOGGING_FILE_NAME=""
 
+# Apache Tomcat hardening: response settings pinned to their effective defaults
+ENV SERVER_SERVER_HEADER="" \
+    SERVER_ERROR_INCLUDE_STACKTRACE=never \
+    SERVER_ERROR_INCLUDE_MESSAGE=never \
+    SERVER_ERROR_INCLUDE_EXCEPTION=false \
+    SERVER_ERROR_INCLUDE_BINDING_ERRORS=never \
+    SERVER_MAX_HTTP_REQUEST_HEADER_SIZE=8KB
+
 # Switch to a non-root user, declared numerically and above 1000.
 USER 1001:0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,13 +92,16 @@ COPY --chown=ors:0 --chmod=644 --from=build /tmp/ors/ors-api/target/ors.jar /ors
 # Stdout/stderr only for the slim image. Can be overridden by setting LOGGING_FILE_NAME to a file path in the container.
 ENV LOGGING_FILE_NAME=""
 
-# Apache Tomcat hardening: response settings pinned to their effective defaults
+# Apache Tomcat hardening: pinned response settings, shorter connector timeout, no Swagger UI or OpenAPI document
 ENV SERVER_SERVER_HEADER="" \
     SERVER_ERROR_INCLUDE_STACKTRACE=never \
     SERVER_ERROR_INCLUDE_MESSAGE=never \
     SERVER_ERROR_INCLUDE_EXCEPTION=false \
     SERVER_ERROR_INCLUDE_BINDING_ERRORS=never \
-    SERVER_MAX_HTTP_REQUEST_HEADER_SIZE=8KB
+    SERVER_MAX_HTTP_REQUEST_HEADER_SIZE=8KB \
+    SERVER_TOMCAT_CONNECTION_TIMEOUT=20s \
+    SPRINGDOC_SWAGGER_UI_ENABLED=false \
+    SPRINGDOC_API_DOCS_ENABLED=false
 
 # Switch to a non-root user, declared numerically and above 1000.
 USER 1001:0


### PR DESCRIPTION
Add the following ENV variables to harden the embedded tomcat:

```
ENV SERVER_SERVER_HEADER="" \
    SERVER_ERROR_INCLUDE_STACKTRACE=never \
    SERVER_ERROR_INCLUDE_MESSAGE=never \
    SERVER_ERROR_INCLUDE_EXCEPTION=false \
    SERVER_ERROR_INCLUDE_BINDING_ERRORS=never \
    SERVER_MAX_HTTP_REQUEST_HEADER_SIZE=8KB \
    SERVER_TOMCAT_CONNECTION_TIMEOUT=20s \
    SPRINGDOC_SWAGGER_UI_ENABLED=false \
    SPRINGDOC_API_DOCS_ENABLED=false
```


### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
