### PR TITLE
ci: set top-level permissions on the workflows

### DIFF
--- a/.github/workflows/config-conversion-automation.yml
+++ b/.github/workflows/config-conversion-automation.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'ors-api/src/main/resources/application.yml'
 
+permissions: {}
+
 jobs:
   sync_config:
     name: Synchronize changes in application.yml to ors-config.yml and ors-config.env

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -7,8 +7,12 @@ on:
   pull_request_target:
     types: [ edited, opened, ready_for_review, review_requested, reopened, closed, synchronize ]
 
+permissions: {}
+
 jobs:
   convention_commit_check:
+    permissions:
+      contents: read
     name: Run conventional commit style check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -7,10 +7,18 @@ on:
   pull_request_target:
     types: [ opened, edited ]
 
+permissions: {}
+
 jobs:
   add_conventional_release_labels:
     name: Add PR title conventional type to PR labels
     runs-on: ubuntu-latest
+    # Job-level permissions replace the top-level set rather than adding to it,
+    # so contents: read has to be repeated here. Writing labels onto the pull
+    # request is the entire purpose of this job.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Add conventional release labels
         uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # v1

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -10,9 +10,12 @@ env:
   TEST_IMAGE_NAME: 'local/openrouteservice:test'
   TEST_SLIM_IMAGE_NAME: 'local/openrouteservice:test-slim'
 
+permissions: {}
 
 jobs:
   prepare_environment:
+    permissions:
+      contents: read
     name: Prepare the environment variables
     runs-on: ubuntu-latest
     outputs:
@@ -38,6 +41,8 @@ jobs:
           echo " Is Draft: ${{ steps.check-draft.outputs.is_draft }}"
           echo " Build ARM64: ${{ steps.check-draft.outputs.build_arm64 }}"
   build_docker_images:
+    permissions:
+      contents: read
     name: Build Docker images for both platforms - publish
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     needs: prepare_environment
@@ -50,6 +55,8 @@ jobs:
       upload_image_as_artifact: true
 
   build_slim_images:
+    permissions:
+      contents: read
     name: Build Docker images for both platforms - slim
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     needs: prepare_environment
@@ -62,6 +69,8 @@ jobs:
       upload_image_as_artifact: true
 
   docker_image_tests:
+    permissions:
+      contents: read
     name: Test ${{ matrix.platform }} - publish image
     runs-on: ${{ matrix.runner }}
     needs:
@@ -160,6 +169,8 @@ jobs:
           ./.github/utils/cors_check.sh 127.0.0.1 8080 /ors/v2/isochrones/geojson "https://example.com" 403 10
 
   slim_image_tests:
+    permissions:
+      contents: read
     name: Test ${{ matrix.platform }} - slim image
     runs-on: ${{ matrix.runner }}
     needs:

--- a/.github/workflows/docker-nightly-image.yml
+++ b/.github/workflows/docker-nightly-image.yml
@@ -24,8 +24,12 @@ on:
         required: false
         default: 'schedule'
 
+permissions: {}
+
 jobs:
   setup-build-environment:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       new_commits: ${{ steps.check.outputs.NEW_COMMITS }}
@@ -65,6 +69,8 @@ jobs:
           echo "HeiGIT slim stage image tag: ${HEIGIT_BASE_TAG}-slim"
   
   build_and_push_publish_images:
+    permissions:
+      contents: read
     needs:
       - setup-build-environment
     uses: ./.github/workflows/_reusable_build_docker_images.yml
@@ -84,6 +90,8 @@ jobs:
       registry_password: ${{ secrets.DOCKER_PASSWORD }}
   
   build_and_push_slim_images:
+    permissions:
+      contents: read
     needs:
       - setup-build-environment
     uses: ./.github/workflows/_reusable_build_docker_images.yml
@@ -103,6 +111,8 @@ jobs:
       registry_password: ${{ secrets.DOCKER_PASSWORD }}
 
   combine_and_push_multi_arch_manifests:
+    permissions:
+      contents: read
     needs:
       - setup-build-environment
       - build_and_push_publish_images

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,8 +32,12 @@ on:
       - '.github/workflows/_reusable_build_docker_images.yml'
       - 'ors-config.yml'
 
+permissions: {}
+
 jobs:
   build_test_scenario_base_image:
+    permissions:
+      contents: read
     name: Build test scenario builder images
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     with:
@@ -46,6 +50,8 @@ jobs:
       upload_image_as_artifact: false
 
   build_test_scenario_jar_builder_image:
+    permissions:
+      contents: read
     name: Build test scenario jar builder image
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     needs:
@@ -60,6 +66,8 @@ jobs:
       upload_image_as_artifact: true
 
   build_test_scenario_war_builder_image:
+    permissions:
+      contents: read
     name: Build test scenario war builder image
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     needs:
@@ -74,6 +82,8 @@ jobs:
       upload_image_as_artifact: true
 
   cache-graph:
+    permissions:
+      contents: read
     name: Build and cache shared graph for integration tests
     runs-on: ubuntu-latest
     needs:
@@ -120,6 +130,8 @@ jobs:
           ONE_SHOT_GRAPH_BUILDER: true
 
   integration-tests:
+    permissions:
+      contents: read
     name: Integration tests
     runs-on: ubuntu-22.04
     needs:

--- a/.github/workflows/publish-tagged-release.yml
+++ b/.github/workflows/publish-tagged-release.yml
@@ -3,8 +3,12 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   check_version:
+    permissions:
+      contents: read
     name: Check if this is the latest semantic version
     runs-on: ubuntu-latest
     outputs:
@@ -24,6 +28,8 @@ jobs:
           current-tag: ${{ github.event.release.tag_name }}
 
   build_and_push_publish_images:
+    permissions:
+      contents: read
     name: Build and cache the Docker images with native runners
     needs: check_version
     uses: ./.github/workflows/_reusable_build_docker_images.yml
@@ -42,6 +48,8 @@ jobs:
       registry_password: ${{ secrets.DOCKER_PASSWORD }}
   
   build_and_push_slim_images:
+    permissions:
+      contents: read
     name: Build and cache the slim Docker images with native runners
     needs: check_version
     uses: ./.github/workflows/_reusable_build_docker_images.yml
@@ -60,6 +68,8 @@ jobs:
       registry_password: ${{ secrets.DOCKER_PASSWORD }}
   
   combine_and_push_images:
+    permissions:
+      contents: read
     name: Combine multi-arch manifest and push to DockerHub
     runs-on: ubuntu-latest
     if: success()

--- a/.github/workflows/run_maven_tests.yml
+++ b/.github/workflows/run_maven_tests.yml
@@ -9,8 +9,12 @@ on:
   pull_request:
     branches: [ "**" ]
 
+permissions: {}
+
 jobs:
   run_tests:
+    permissions:
+      contents: read
     name: Run unit and integration tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sonarcube-scan.yml
+++ b/.github/workflows/sonarcube-scan.yml
@@ -4,6 +4,9 @@ on:
     workflows: [ 'Java CI with Maven' ]
     types:
       - completed
+
+permissions: {}
+
 jobs:
   sonar:
     name: 'SonarCube Analysis'


### PR DESCRIPTION
The workflows declared no top-level `permissions:`, so every job in them ran with whatever the repository default grants rather than with what it needs. All get `contents: read`. Jobs that need more were already declaring their own permissions and are unaffected, since a job-level block replaces the top-level set rather than adding to it

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
