### PR TITLE
ci: lint the built images with dockle, report-only

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,9 @@
+# Checkpoints dockle should not report for any openrouteservice image stage.
+# Stage-specific suppressions belong in the workflow matrix (--ignore), not here.
+
+# CIS-DI-0005: "Enable Content trust for Docker".
+# Content Trust (Notary v1) is not the mechanism we use, and enabling it is a
+# property of the machine doing the pull, not of the image being inspected --
+# dockle raises it unconditionally on every image, ours included. Provenance for
+# these images is established with cosign signatures and attestations instead.
+CIS-DI-0005

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -154,6 +154,7 @@ jobs:
             image_stage: slim
     env:
       ARTIFACT_PATTERN: 'image-${{ matrix.platform_name }}-${{ matrix.image_stage }}-*.tar'
+      DOCKLE_IMAGE: goodwithtech/dockle:v0.4.15@sha256:eade932f793742de0aa8755406c7677cd7696f8675b6180926f7eeffa7abe6b9
     steps:
       - name: Skip condition
         id: skip-condition
@@ -242,3 +243,61 @@ jobs:
       - name: Fail on critical or high vulnerabilities
         if: ${{ steps.skip-condition.outputs.skip != 'true' && matrix.image_stage == 'slim' }}
         run: trivy convert --scanners vuln --severity CRITICAL,HIGH --exit-code 1 --format table results.json
+
+      - name: Run dockle image lint
+        if: ${{ steps.skip-condition.outputs.skip != 'true' }}
+        run: |
+          # Scanned from the image tarball, not from the Docker daemon. This is more efficient and secure.
+          artifact_rel="${ARTIFACT_FILE#"${RUNNER_TEMP}"/}"
+          if [[ "${artifact_rel}" == /* ]]; then
+            echo "::error::${ARTIFACT_FILE} is not under RUNNER_TEMP (${RUNNER_TEMP})"
+            exit 1
+          fi
+          echo "DOCKLE_INPUT=/artifacts/${artifact_rel}" >> "$GITHUB_ENV"
+
+          # `list` is dockle's own console format, so the log gets the report as
+          # dockle writes it.
+          echo "dockle — ${SCAN_IMAGE_NAME}"
+          docker run --rm \
+            -v "${RUNNER_TEMP}:/artifacts:ro" \
+            "${DOCKLE_IMAGE}" \
+            --exit-code 0 --no-color --format list \
+            --input "/artifacts/${artifact_rel}"
+
+      # dockle has no convert subcommand the way Trivy does.
+      # The cost is one container start.
+      - name: Generate dockle SARIF report
+        if: ${{ steps.skip-condition.outputs.skip != 'true' }}
+        run: |
+          docker run --rm \
+            -v "${RUNNER_TEMP}:/artifacts:ro" \
+            "${DOCKLE_IMAGE}" \
+            --exit-code 0 --no-color --format sarif \
+            --input "${DOCKLE_INPUT}" > dockle-results.sarif
+
+          #Code Scanning cannot process a file with an empty artifact location; dockle emits an empty artifactLocation.uri for SKIP-level results
+          # Therefore we fill in the image name for any empty artifact location, so that Code Scanning can process the SARIF file.
+          jq --arg image "${SCAN_IMAGE_NAME}" '
+            .runs[]?.results[]? |= (
+              if (.locations | length) == 0 then
+                .locations = [{physicalLocation: {artifactLocation: {uri: $image}}}]
+              else
+                .locations[].physicalLocation.artifactLocation.uri |=
+                  (if . == null or . == "" then $image else . end)
+              end
+            )' dockle-results.sarif > dockle-results.sarif.tmp
+          mv dockle-results.sarif.tmp dockle-results.sarif
+
+          empty_locations=$(jq '[.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri
+                                 | select(. == null or . == "")] | length' dockle-results.sarif)
+          if [ "${empty_locations}" -ne 0 ]; then
+            echo "::error::${empty_locations} dockle SARIF result(s) still have an empty artifact location; code scanning would reject the upload"
+            exit 1
+          fi
+
+      - name: Upload dockle report
+        if: ${{ steps.skip-condition.outputs.skip != 'true' }}
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          sarif_file: dockle-results.sarif
+          category: Dockle-Docker-Image-${{ matrix.image_stage }}-${{ matrix.platform }}

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,19 @@
     "org.heigit.ors:openrouteservice",
     "com.fasterxml.jackson.datatype:jackson-datatype-jts"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Regex manager for Dockle image pinned in GitHub Actions workflow",
+      "managerFilePatterns": ["/^\\.github/workflows/vulnerability-scanning\\.yml$/"],
+      "matchStrings": [
+        "DOCKLE_IMAGE: goodwithtech/dockle:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "depNameTemplate": "goodwithtech/dockle",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": "Every major waits for a human tick on the Dependency Dashboard",
@@ -73,8 +86,8 @@
       "labels": ["dependencies", "container :whale:", "security"]
     },
     {
-      "description": "Workflow YAML is a different review surface than the POMs",
-      "matchManagers": ["github-actions"],
+      "description": "Workflow YAML is a different review surface than the POMs. custom.regex is here too because its only dependency is a CI tool image pinned in a workflow env var.",
+      "matchManagers": ["github-actions", "custom.regex"],
       "groupName": "github actions",
       "labels": ["dependencies", "ci"]
     },


### PR DESCRIPTION
Trivy is not scanning everything it does scan, which known-vulnerable packages are installed (from the package database) and what the Dockerfile says (from the build instructions). It doesn't reach the filesystem the image actually ships. However, dockle does.

The single publish WARN is CIS-DI-0001, the missing USER instruction which we can ignore.

Assisted-by: Claude Code

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
