### PR TITLE
fix: propagate custom model to round-trip routing

### DIFF
--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingRequest.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingRequest.java
@@ -589,6 +589,10 @@ public class RoutingRequest extends ServiceRequest {
             if (props != null && !props.isEmpty())
                 req.getHints().putAll(props);
 
+            if (searchParams.getCustomModel() != null) {
+                req.setCustomModel(searchParams.getCustomModel());
+            }
+
             if (TemporaryUtilShelter.supportWeightingMethod(profileType))
                 ProfileTools.setWeightingMethod(req.getHints(), weightingMethod, profileType, false);
             else


### PR DESCRIPTION
## Description

Custom models are currently not propagated to the `GHRequest` when using round-trip routing.

I encountered this while developing a self-hosted bicycle round-trip router. A custom model that blocks ways based on `mtb_scale` worked correctly for normal A-to-B routing, but the same model was ignored when using `round_trip`.

The reason appears to be that the normal routing path calls:

```java
req.setCustomModel(searchParams.getCustomModel());
```

while `computeRoundTripRoute(...)` creates its own `GHRequest` without setting the custom model.

This PR propagates the custom model to the round-trip request in the same way as regular routing.

## Reproduction / verification

In my local ORS 9.10.0 setup using a `cycling-regular` based custom profile:

- A problematic OSM way has `mtb:scale=2`.
- A custom model with `mtb_scale >= 1 -> multiply_by 0` correctly avoids this way during normal A-to-B routing.
- With identical custom-model rules, a round-trip route still used the way before this fix.
- After applying this patch and rebuilding ORS, the same round-trip request with the same start point, distance, points and seed avoids the way.

The behavior was additionally verified visually against the local OSM data.

## Note

I am not a Java developer. The reproducible issue originated while developing my self-hosted bicycle router. The source analysis and this small patch were worked out together with ChatGPT.