### PR TITLE
docs: document csv extra info #1974

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Releasing is documented in RELEASE.md
 ## [unreleased]
 
 ### Added
+- documentation for CSV extra info from graph-build CSV files ([#1974](https://github.com/GIScience/openrouteservice/issues/1974))
 - add SBOM and provenance via docker buildx commands ([#2347](https://github.com/GIScience/openrouteservice/pull/2347))
 - add OCI title/description/documentation labels to base image ([#2364](https://github.com/GIScience/openrouteservice/pull/2364))
 - disable file logging in the slim image so it can run with a read-only root filesystem given a tmpfs at `/tmp` for GeoTools' EPSG cache ([#2367](https://github.com/GIScience/openrouteservice/pull/2367))

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -119,6 +119,10 @@ export default withMermaid(defineVersionedConfig({
                                                             link: '/api-reference/endpoints/directions/extra-info/waytype'
                                                         },
                                                         {
+                                                            text: 'CSV extra info',
+                                                            link: '/api-reference/endpoints/directions/extra-info/csv'
+                                                        },
+                                                        {
                                                             text: 'Difficulty IDs',
                                                             link: '/api-reference/endpoints/directions/extra-info/trail-difficulty'
                                                         },

--- a/docs/api-reference/endpoints/directions/extra-info/csv.md
+++ b/docs/api-reference/endpoints/directions/extra-info/csv.md
@@ -1,0 +1,67 @@
+# CSV extra info
+
+Generic extra information loaded from a CSV file at graph-build time.
+
+This feature is experimental and is **not** available on the public openrouteservice hosted by HeiGIT. You need a self-hosted instance with the `Csv` extended storage enabled.
+
+## Enable at graph build
+
+Add a `Csv` entry under `ors.engine.profiles.<PROFILE-NAME>.build.ext_storages` and point `filepath` at your CSV file:
+
+```yaml
+ors:
+  engine:
+    profiles:
+      foot-walking:
+        build:
+          ext_storages:
+            Csv:
+              filepath: /path/to/extra.csv
+```
+
+Graphs must be rebuilt after changing the file.
+
+See also [`ext_storages.Csv`](/run-instance/configuration/engine/profiles/build.md#csv).
+
+## CSV file format
+
+The first row is a header. The first column is the OSM way id. Every later column is a named value that can be requested independently.
+
+```csv
+osm_id,heat,greenness
+4084881,0.33,0.84
+4280150,0.43,0.93
+```
+
+- Values are floating-point numbers in `[-1.0, 1.0]`. They are stored as integers `value * 100` (so `-100` to `100`).
+- Ways that are not in the file get the default stored value `50` (that is `0.50`).
+- Column names come from the header (everything after the id column). They are case-sensitive.
+
+## Request extra info
+
+Ask for `csv` in `extra_info` and name the column with `options.profile_params.weightings.csv_column`:
+
+```json
+{
+  "coordinates": [[8.681495, 49.41461], [8.686507, 49.41943]],
+  "extra_info": ["csv"],
+  "options": {
+    "profile_params": {
+      "weightings": {
+        "csv_column": "heat",
+        "csv_factor": 0
+      }
+    }
+  }
+}
+```
+
+`csv_column` must match a header name. `csv_factor` is optional; set it to `0` if you only want the extra info and do not want the column to influence the route. Values between `0` and `1` use the column as a heat-stress-style weighting.
+
+The values appear in the directions response under
+
+```jsonpath
+$.routes[*].extras.csv
+```
+
+with the same `values` / `summary` structure as other extra info. The third number of each `values` triple is the stored integer (`original_float * 100`).

--- a/docs/api-reference/endpoints/directions/extra-info/index.md
+++ b/docs/api-reference/endpoints/directions/extra-info/index.md
@@ -29,7 +29,7 @@ The following table lists the possible values for the request as well as the key
 |             green             | How "green" the parts of the route are (influenced by things like number of trees, parks, rivers etc.)                                       | `green`                              | 0 (minimal green-space) - 10 (a lot of green-space)       |
 |             noise             | How noisy the parts of the route are (influenced by things like proximity to highways)                                                       | `noise`                              | 0 (quiet) - 10 (noisy)                                    |
 |            shadow²            | How sunny the parts of the route are are                                                                                                     | `shadow`                             | 0 (completely in the shadow) - 10 (completely in the sun) |
-|             csv²              | Experimental feature: Generic extra information from provided csv file(s)                                                                    | `csv`                                | custom values                                             |
+|             csv²              | Experimental feature: Generic extra information from provided csv file(s)                                                                    | `csv`                                | [CSV extra info](csv.md)                                  |
 
 *¹ Note the different keys in request and response!*
 

--- a/docs/run-instance/configuration/engine/profiles/build.md
+++ b/docs/run-instance/configuration/engine/profiles/build.md
@@ -93,8 +93,8 @@ This information is made available as `extra_info` in a routing response.
 
 To do so, add a key from the list below.
 Leave its value empty, unless you want to specify further options (currently only available for
-[RoadAccessRestrictions](#roadaccessrestrictions), [Borders](#borders), [Wheelchair](#wheelchair)
-and [HeavyVehicle](#heavyvehicle)).
+[RoadAccessRestrictions](#roadaccessrestrictions), [Borders](#borders), [Wheelchair](#wheelchair),
+[HeavyVehicle](#heavyvehicle) and [Csv](#csv)).
 
 ::: warning
 In addition to providing the information in query response, data from `WayCategory` and `Tollways` storages is being
@@ -127,6 +127,7 @@ Properties beneath `ors.engine.profiles.<PROFILE-NAME>.build.ext_storages`:
 | TrailDifficulty        | object | Returns the trail difficulty in the route response, compatible with walking and cycling profiles                                                 |                                                   |
 | Wheelchair             | object | Wheelchair-specific attributes compatible only with that profile                                                                                 | [Wheelchair](#wheelchair)                         |
 | OsmId                  | object | Returns the OsmId of the way, compatible with any profile type                                                                                   |                                                   |
+| Csv                    | object | Experimental: generic extra information from a CSV file of OSM way ids, compatible with any profile type                                         | [Csv](#csv)                                       |
 
 Check [this table](/api-reference/endpoints/directions/extra-info/index.md#extra-info-availability) for extra
 info availability.
@@ -171,3 +172,17 @@ country borders, compatible with any profile type.
 | key          | type    | description                                                                                                                                                                                                                                                    | example value |
 |--------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | restrictions | boolean | Encode certain size and weight limits such as ones contained in `maxheight`, `maxlength`, `maxwidth`, `maxweight` and `maxaxleload` OSM way tags. Includes also access restrictions for vehicles carrying hazardous materials as provided by the `hazmat` tag. | `true`        |
+
+### `Csv`
+
+Experimental storage that attaches custom numeric attributes to OSM ways from a CSV file.
+Not available on the public HeiGIT instance.
+
+Properties beneath `ors.engine.profiles.<PROFILE-NAME>.build.ext_storages.Csv`:
+
+| key      | type   | description                                                                                          | example value            |
+|----------|--------|------------------------------------------------------------------------------------------------------|--------------------------|
+| filepath | string | Path to a CSV file. First column is the OSM way id; later columns are named float values in [-1, 1]. | `/data/heat_stress.csv`  |
+
+After the graph is built, request the values with `extra_info: ["csv"]` and `options.profile_params.weightings.csv_column` set to a header name. See [CSV extra info](/api-reference/endpoints/directions/extra-info/csv.md).
+


### PR DESCRIPTION
Fixes #1974

### Pull Request Checklist
- [x] 1. Rebased onto main.
- [x] 2. CHANGELOG.md under Unreleased.
- [ ] 3. No new Java.
- [x] 4. No leftover debug.
- [ ] 5. Docs only, no new JUnit.
- [ ] 6. Docs only, no new API tests.
- [x] 7. Documented `ext_storages.Csv` / `filepath` in the config docs.
- [ ] 8. Docs only.
- [x] 9. References #1974.
- [ ] 10. Docs only.
- [ ] 11. Docs only.
- [x] 12. Change described below.
- [ ] 13. I did not run the API playground locally.

### Information about the changes
- Key functionality added: docs for loading a CSV of OSM way attributes at graph build, the file format, and how to request `extra_info: csv` with `csv_column`.
- Reason for change: that path was only mentioned as a one-line extra_info value.

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
- None. Docs only.

### Required changes to ors config (if applicable)
- None. Documents the existing `Csv` storage.
