### PR TITLE
ci: move build layout resolution into the build-docker-image action

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -33,13 +33,12 @@ inputs:
     required: false
     type: string
     default: 'gha'
-  artifact_full_path:
-    description: Full path to save the artifact (for non-push builds)
-    required: false
-    type: string
-    default: ''
   output_type:
-    description: Docker output type (docker, or docker with dest).
+    description: >-
+      Docker output type. Leave empty on a non-push build to have the action
+      pick the tarball location itself and report it back through the
+      artifact_name / artifact_full_path outputs. 
+      Set it to pin the exporter explicitly.
     required: false
     type: string
     default: 'type=docker'
@@ -70,10 +69,44 @@ outputs:
   metadata:
     description: Metadata of the built image
     value: ${{ steps.build-image.outputs.metadata }}
+  artifact_name:
+    description: File name of the exported image tarball. Empty when the action didn't pick the location.
+    value: ${{ steps.layout.outputs.name }}
+  artifact_full_path:
+    description: Full path of the exported image tarball. Empty when the action didn't pick the location.
+    value: ${{ steps.layout.outputs.full_path }}
 
 runs:
   using: composite
   steps:
+    - name: Resolve build layout
+      id: layout
+      shell: bash
+      env:
+        IMAGE_STAGE: ${{ inputs.image_stage }}
+        PLATFORM: ${{ inputs.platform }}
+        DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+        OUTPUT_TYPE: ${{ inputs.output_type }}
+        ARTIFACT_DIR: ${{ runner.temp }}
+      run: |
+        PLATFORM_NAME="${PLATFORM//\//_}"
+        HASH=$(sha256sum "$DOCKERFILE_PATH" | cut -d' ' -f1 | cut -c1-8)
+        NAME="image-${PLATFORM_NAME}-${IMAGE_STAGE}-${HASH}.tar"
+        FULL="${ARTIFACT_DIR}/${NAME}"
+
+        echo "cache_scope=${IMAGE_STAGE}-${PLATFORM_NAME}" >> "$GITHUB_OUTPUT"
+
+        # The tarball is the caller's artifact only when the caller left the
+        # exporter to us. With output_type pinned (the push path) there is no
+        # tarball, and these stay empty so nothing downstream tries to ship it.
+        if [ -z "$OUTPUT_TYPE" ]; then
+          {
+            echo "name=$NAME"
+            echo "full_path=$FULL"
+            echo "output_spec=type=docker,dest=$FULL"
+          } >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Build Docker image
       id: build-image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -85,8 +118,9 @@ runs:
         load: false
         tags: ${{ inputs.docker_tag }}
         platforms: ${{ inputs.platform }}
-        cache-from: type=${{ inputs.cache_from_type }}
-        cache-to: type=${{ inputs.cache_to_type }}
-        outputs: ${{ inputs.push_image && '' || inputs.output_type }}
+        cache-from: type=${{ inputs.cache_from_type }},scope=${{ steps.layout.outputs.cache_scope }}
+        cache-to: type=${{ inputs.cache_to_type }},scope=${{ steps.layout.outputs.cache_scope }}
+        # output_spec is empty whenever the caller pinned output_type.
+        outputs: ${{ steps.layout.outputs.output_spec || inputs.output_type }}
         sbom: ${{ inputs.push_image == 'true' && inputs.sbom == 'true' }}
         provenance: ${{ inputs.push_image == 'true' && inputs.provenance || 'false' }}

--- a/.github/workflows/_reusable_build_docker_images.yml
+++ b/.github/workflows/_reusable_build_docker_images.yml
@@ -1,5 +1,4 @@
 name: Build Docker Images (Reusable)
-description: Reusable workflow to build Docker images for multiple platforms and stages
 
 on:
   workflow_call:
@@ -73,39 +72,33 @@ on:
 
 jobs:
 
-  validate_input_parameters:
-    name: Validate input parameters
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate docker_login and push_by_digest
-        run: |
-          if [ "${{ inputs.push_by_digest }}" = "true" ] && [ "${{ inputs.docker_login }}" != "true" ]; then
-            echo "Error: docker_login must be true when push_by_digest is true."
-            exit 1
-          fi
-
   build_docker_image:
-    needs: validate_input_parameters
     strategy:
       matrix:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
-            build: ${{ fromJSON(inputs.build_amd64) }}
+            build: ${{ inputs.build_amd64 }}
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
-            build: ${{ fromJSON(inputs.build_arm64) }}
+            build: ${{ inputs.build_arm64 }}
     
     name: Build ${{ inputs.image_stage }} for ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     outputs:
-      image_hash_amd64: ${{ matrix.platform == 'linux/amd64' && steps.final-artifact.outputs.image_hash || '' }}
-      image_hash_arm64: ${{ matrix.platform == 'linux/arm64' && steps.final-artifact.outputs.image_hash || '' }}
-      artifact_name_amd64: ${{ matrix.platform == 'linux/amd64' && steps.final-artifact.outputs.artifact_name || '' }}
-      artifact_name_arm64: ${{ matrix.platform == 'linux/arm64' && steps.final-artifact.outputs.artifact_name || '' }}
+      image_hash_amd64: ${{ matrix.platform == 'linux/amd64' && steps.build-image.outputs.imageid || '' }}
+      image_hash_arm64: ${{ matrix.platform == 'linux/arm64' && steps.build-image.outputs.imageid || '' }}
+      artifact_name_amd64: ${{ matrix.platform == 'linux/amd64' && steps.build-image.outputs.artifact_name || '' }}
+      artifact_name_arm64: ${{ matrix.platform == 'linux/arm64' && steps.build-image.outputs.artifact_name || '' }}
       image_digest_amd64: ${{ matrix.platform == 'linux/amd64' && steps.build-image.outputs.digest || '' }}
       image_digest_arm64: ${{ matrix.platform == 'linux/arm64' && steps.build-image.outputs.digest || '' }}
     steps:
+      - name: Validate docker_login and push_by_digest
+        if: ${{ inputs.push_by_digest && !inputs.docker_login }}
+        run: |
+          echo "Error: docker_login must be true when push_by_digest is true."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with: # make sure we check out the configured branch on manual trigger
@@ -121,48 +114,6 @@ jobs:
           docker_username: ${{ secrets.registry_username }}
           docker_password: ${{ secrets.registry_password }}
 
-      - name: Generate Dockerfile hash
-        if: matrix.build == true
-        id: dockerfile-hash
-        env:
-          DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
-        run: |
-          HASH=$(sha256sum "$DOCKERFILE_PATH" | cut -d' ' -f1 | cut -c1-8)
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
-
-      - name: Set artifact names and output type
-        if: matrix.build == true
-        id: artifact
-        env:
-          IMAGE_STAGE: ${{ inputs.image_stage }}
-          PLATFORM: ${{ matrix.platform }}
-          HASH: ${{ steps.dockerfile-hash.outputs.hash }}
-          RUNNER_TEMP: ${{ runner.temp }}
-          PUSH_BY_DIGEST: ${{ inputs.push_by_digest }}
-          DOCKER_TAG: ${{ inputs.docker_tag }}
-        run: |
-          PLATFORM_NAME=$(echo "$PLATFORM" | sed 's/\//_/g')
-          ARTIFACT_NAME="image-${PLATFORM_NAME}-${IMAGE_STAGE}-${HASH}.tar"
-          echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
-          ARTIFACT_PATH="$RUNNER_TEMP"
-          echo "artifact_path=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
-          ARTIFACT_FULL_PATH="${ARTIFACT_PATH}/${ARTIFACT_NAME}"
-          echo "artifact_full_path=$ARTIFACT_FULL_PATH" >> $GITHUB_OUTPUT
-          
-          if [ "$PUSH_BY_DIGEST" = "true" ]; then
-            # Use push-by-digest for multi-arch manifest combining
-            OUTPUT_TYPE="push-by-digest=true,type=image"
-            CACHE_TO_TYPE='' # no cache-to needed when pushing
-            PUSH_IMAGE="true"
-          else
-            # Use docker output for artifact
-            OUTPUT_TYPE="type=docker,dest=${ARTIFACT_FULL_PATH}"
-            PUSH_IMAGE="false"
-          fi
-          echo "output_type=$OUTPUT_TYPE" >> $GITHUB_OUTPUT
-          echo "cache_to_type=$CACHE_TO_TYPE" >> $GITHUB_OUTPUT
-          echo "push_image=$PUSH_IMAGE" >> $GITHUB_OUTPUT
-
       - name: Build Docker image
         if: matrix.build == true
         id: build-image
@@ -172,37 +123,18 @@ jobs:
           image_stage: ${{ inputs.image_stage }}
           docker_tag: ${{ inputs.docker_tag }}
           platform: ${{ matrix.platform }}
-          push_image: ${{ steps.artifact.outputs.push_image == 'true' }}
-          output_type: ${{ steps.artifact.outputs.output_type }}
-          cache_to_type: ${{ steps.artifact.outputs.cache_to_type || 'gha' }}
+          push_image: ${{ inputs.push_by_digest }}
+          # Empty means "action picks the tarball location and reports it back".
+          output_type: ${{ inputs.push_by_digest && 'push-by-digest=true,type=image' || '' }}
 
       - name: Upload image artifact
-        id: upload-artifact
-        if: |
-          matrix.build == true && 
-          fromJSON(inputs.upload_image_as_artifact) &&
-          !fromJSON(inputs.push_by_digest)
+        if: ${{ matrix.build && inputs.upload_image_as_artifact && !inputs.push_by_digest }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ steps.artifact.outputs.artifact_name }}
-          path: ${{ steps.artifact.outputs.artifact_path }}
+          name: ${{ steps.build-image.outputs.artifact_name }}
+          # The tarball itself, not the directory it sits in.
+          path: ${{ steps.build-image.outputs.artifact_full_path }}
           retention-days: 1
           if-no-files-found: error
           compression-level: 0
           overwrite: true
-
-      - name: Set final artifact info
-        if: matrix.build == true
-        id: final-artifact
-        env:
-          ARTIFACT_FULL_PATH: ${{ steps.artifact.outputs.artifact_full_path }}
-          ARTIFACT_NAME: ${{ steps.artifact.outputs.artifact_name }}
-          IMAGE_ID: ${{ steps.build-image.outputs.imageid }}
-        run: |
-          if [ -f "$ARTIFACT_FULL_PATH" ]; then
-            echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
-            echo "image_hash=$IMAGE_ID" >> $GITHUB_OUTPUT
-          else
-            echo "Artifact not created, skipping upload."
-            echo "artifact_name=" >> $GITHUB_OUTPUT
-          fi

--- a/.github/workflows/_test_action_build_docker_image.yml
+++ b/.github/workflows/_test_action_build_docker_image.yml
@@ -126,7 +126,7 @@ jobs:
             exit 1
           fi
       
-      - name: Test 4 - Empty output_type returns no image and digest IDs
+      - name: Test 4 - Empty output_type makes the action choose the tarball location
         id: test4
         uses: ./.github/actions/build-docker-image
         with:
@@ -138,15 +138,21 @@ jobs:
       - name: Verify Test 4 outputs
         run: |
           echo "Image ID: ${{ steps.test4.outputs.imageid }}"
-          echo "Digest: ${{ steps.test4.outputs.digest }}"
-          
-          if [ -n '${{ steps.test4.outputs.imageid }}' ]; then
-            echo "Test 4 FAILED: Expected no imageid output with empty output_type"
+          echo "Artifact name: ${{ steps.test4.outputs.artifact_name }}"
+          echo "Artifact path: ${{ steps.test4.outputs.artifact_full_path }}"
+
+          if [ -z '${{ steps.test4.outputs.imageid }}' ]; then
+            echo "Test 4 FAILED: Expected an imageid when the action picks the exporter"
             exit 1
           fi
 
-          if [ -n '${{ steps.test4.outputs.digest }}' ]; then
-            echo "Test 4 FAILED: Expected no digest output with empty output_type"
+          if [ -z '${{ steps.test4.outputs.artifact_name }}' ]; then
+            echo "Test 4 FAILED: Expected artifact_name to be reported back"
+            exit 1
+          fi
+
+          if [ ! -f '${{ steps.test4.outputs.artifact_full_path }}' ]; then
+            echo "Test 4 FAILED: Expected the image tarball to exist at artifact_full_path"
             exit 1
           fi
       - name: Summary


### PR DESCRIPTION
This is the first PR to prepare the github workflows for a release only CVE hard fail gate.

Consolidate the `.github/workflows/_reusable_build_docker_images.yml`. This also fixes the bug where the whole temp folder was accidentally uploaded instead of just the tarball.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
