### PR TITLE
ci: add a shared trivy-scan action and audit the published images

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -1,0 +1,164 @@
+name: Trivy Scan
+description: >-
+  Scan a target with Trivy and report the result: table to the log and the job
+  summary, SARIF to the code scanning tab, and an optional hard failure.
+  Report-only unless one of the fail_on_* inputs is set.
+
+  Trivy names its target differently per scan type (input= for an image
+  tarball, image-ref= for an image in a registry or the local daemon, scan-ref=
+  for a path). scan_type selects which, so callers pass one `target` and don't
+  have to know the mapping.
+
+inputs:
+  scan_type:
+    description: >-
+      What `target` is: 'image-tar' (a docker-archive on disk), 'image-ref' (an
+      image reference resolved from a registry or the local daemon) or 'config'
+      (a Dockerfile or other IaC file).
+    required: true
+  target:
+    description: The tarball, image reference or file to scan
+    required: true
+  scanners:
+    description: Comma-separated Trivy scanners to run (vuln, secret, misconfig)
+    required: false
+    default: 'vuln'
+  summary_title:
+    description: Heading for the job summary section
+    required: true
+  sarif_category:
+    description: Code scanning category for vulnerability and misconfiguration results
+    required: false
+    default: ''
+  sarif_category_secrets:
+    description: >-
+      Code scanning category for secret findings, kept distinct from
+      vulnerabilities. Defaults to "<sarif_category>-Secrets"; pass it
+      explicitly where an existing category has to be preserved so its alerts
+      aren't orphaned.
+    required: false
+    default: ''
+  upload_sarif:
+    description: Upload SARIF to the code scanning (Security) tab. Requires security-events:write.
+    required: false
+    default: 'false'
+  fail_on_severity:
+    description: Comma-separated severities that fail the job (e.g. 'CRITICAL,HIGH'). Empty means report-only.
+    required: false
+    default: ''
+  fail_on_secrets:
+    description: Fail the job if the secret scanner found anything
+    required: false
+    default: 'false'
+  fail_on_misconfig:
+    description: Fail the job if the misconfiguration scanner found anything (no severity filter)
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Run Trivy scan
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: ${{ startsWith(inputs.scan_type, 'image') && 'image' || inputs.scan_type }}
+        input: ${{ inputs.scan_type == 'image-tar' && inputs.target || '' }}
+        image-ref: ${{ inputs.scan_type == 'image-ref' && inputs.target || '' }}
+        scan-ref: ${{ inputs.scan_type == 'config' && inputs.target || '' }}
+        scanners: ${{ inputs.scanners }}
+        format: json
+        output: results.json
+        # Reporting happens below; gating is a separate, explicit decision.
+        exit-code: '0'
+
+    # Converted once, then reused for both the log and the summary.
+    - name: Report results
+      shell: bash
+      env:
+        SCANNERS: ${{ inputs.scanners }}
+        SUMMARY_TITLE: ${{ inputs.summary_title }}
+      run: |
+        trivy convert --scanners "$SCANNERS" --format table results.json > trivy-table.txt
+        cat trivy-table.txt
+        {
+          echo "### ${SUMMARY_TITLE}"
+          echo '```'
+          cat trivy-table.txt
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Convert vulnerability results to SARIF
+      if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'vuln') }}
+      shell: bash
+      run: trivy convert --scanners vuln --format sarif --output vuln-results.sarif results.json
+
+    - name: Upload vulnerability report
+      if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'vuln') }}
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+      with:
+        sarif_file: vuln-results.sarif
+        category: ${{ inputs.sarif_category }}
+
+    - name: Convert misconfiguration results to SARIF
+      if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'misconfig') }}
+      shell: bash
+      run: trivy convert --scanners misconfig --format sarif --output misconfig-results.sarif results.json
+
+    - name: Upload misconfiguration report
+      if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'misconfig') }}
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+      with:
+        sarif_file: misconfig-results.sarif
+        category: ${{ inputs.sarif_category }}
+
+    - name: Convert secret scan results to SARIF
+      if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'secret') }}
+      shell: bash
+      run: trivy convert --scanners secret --format sarif --output secret-results.sarif results.json
+
+    - name: Upload secret scan report
+      if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'secret') }}
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+      with:
+        sarif_file: secret-results.sarif
+        category: ${{ inputs.sarif_category_secrets || format('{0}-Secrets', inputs.sarif_category) }}
+
+    - name: Gate on findings
+      if: ${{ inputs.fail_on_severity != '' || inputs.fail_on_misconfig == 'true' || inputs.fail_on_secrets == 'true' }}
+      shell: bash
+      env:
+        SEVERITY: ${{ inputs.fail_on_severity }}
+        FAIL_ON_MISCONFIG: ${{ inputs.fail_on_misconfig }}
+        FAIL_ON_SECRETS: ${{ inputs.fail_on_secrets }}
+        TITLE: ${{ inputs.summary_title }}
+      run: |
+        failures=()
+
+        # Prints the findings only when a check trips; the full,
+        # unfiltered table is already in the log and the job summary.
+        gate() {
+          local scanner="$1" label="$2"
+          shift 2
+          if trivy convert --scanners "$scanner" "$@" --exit-code 1 --format table results.json > gate.txt; then
+            return
+          fi
+          cat gate.txt
+          echo "::error::${TITLE} - gate failed on ${label}"
+          echo "- Gate failed - ${TITLE}: ${label}" >> "$GITHUB_STEP_SUMMARY"
+          failures+=("$label")
+        }
+
+        if [ -n "$SEVERITY" ]; then
+          gate vuln "${SEVERITY} vulnerabilities" --severity "$SEVERITY"
+        fi
+        if [ "$FAIL_ON_MISCONFIG" = 'true' ]; then
+          gate misconfig misconfigurations
+        fi
+        if [ "$FAIL_ON_SECRETS" = 'true' ]; then
+          gate secret "detected secrets"
+        fi
+
+        if [ ${#failures[@]} -gt 0 ]; then
+          echo "Gates failed: ${failures[*]}"
+          exit 1
+        fi

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -40,6 +40,29 @@ jobs:
           echo "Test Slim Image Name: ${{ env.TEST_SLIM_IMAGE_NAME }}"
           echo " Is Draft: ${{ steps.check-draft.outputs.is_draft }}"
           echo " Build ARM64: ${{ steps.check-draft.outputs.build_arm64 }}"
+
+  trivy_dockerfile_scan:
+    name: Trivy scan Dockerfile
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    needs: prepare_environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Scan the Dockerfile
+        uses: ./.github/actions/trivy-scan
+        with:
+          scan_type: config
+          target: Dockerfile
+          scanners: misconfig
+          summary_title: Trivy scan — Dockerfile misconfig
+          sarif_category: Trivy-Dockerfile-Misconfig
+          upload_sarif: ${{ github.event_name != 'pull_request' }}
+
   build_docker_images:
     permissions:
       contents: read

--- a/.github/workflows/docker-nightly-image.yml
+++ b/.github/workflows/docker-nightly-image.yml
@@ -180,3 +180,33 @@ jobs:
             "$IMAGE_REPO"
 
           echo "Successfully pushed multi-arch image: $HEIGIT_IMAGE_REPO"
+
+  scan_published_images:
+    name: Trivy scan published ${{ matrix.tag }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_stage: publish
+            tag: latest
+          - image_stage: slim
+            tag: latest-slim
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Scan the published image
+        uses: ./.github/actions/trivy-scan
+        with:
+          scan_type: image-ref
+          target: docker.io/openrouteservice/openrouteservice:${{ matrix.tag }}
+          scanners: vuln,secret
+          summary_title: Trivy scan — published ${{ matrix.tag }} (report-only)
+          sarif_category: Trivy-Published-Image-${{ matrix.image_stage }}
+          sarif_category_secrets: Trivy-Published-Image-Secrets-${{ matrix.image_stage }}
+          upload_sarif: true

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -33,35 +33,6 @@ jobs:
             echo "is_draft=false" >> $GITHUB_OUTPUT
           fi
 
-  trivy_dockerfile_scan:
-    name: Trivy scan Dockerfile
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          scan-type: config
-          scan-ref: "Dockerfile"
-          format: json
-          output: results.json
-          exit-code: '0'
-      - name: Print Trivy results to console
-        run: trivy convert --scanners misconfig --format table results.json
-      - name: Convert Trivy results to SARIF
-        run: trivy convert --scanners misconfig --format sarif --output trivy-results.sarif results.json
-      - name: Upload misconfiguration report
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
-        with:
-          sarif_file: trivy-results.sarif
-          category: Trivy-Dockerfile-Misconfig
-
   build_docker_images:
     name: Build Docker images - ${{ matrix.image_stage }}
     strategy:


### PR DESCRIPTION
Next step after PR #2403 

Consolidate the trivy scans.
It is the preparation to remove the vunlerability-scanning.yml in the next PR


### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
