### PR TITLE
ci: Introduce trivy gates

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -74,6 +74,11 @@ inputs:
     required: false
     type: boolean
     default: false
+  vex_file:
+    description: Repo-relative path to an OpenVEX document used to suppress accepted-risk findings in the pre-push scan
+    required: false
+    type: string
+    default: ''
   upload_sarif:
     description: Upload the pre-push scan's SARIF results to the code scanning (Security) tab. Requires security-events:write.
     required: false
@@ -162,6 +167,7 @@ runs:
         sarif_category: Trivy-Docker-Image-${{ inputs.image_stage }}-${{ inputs.platform }}
         sarif_category_secrets: Trivy-Docker-Image-Secrets-${{ inputs.image_stage }}-${{ inputs.platform }}
         upload_sarif: ${{ inputs.upload_sarif }}
+        vex_file: ${{ inputs.vex_file }}
         fail_on_severity: ${{ inputs.fail_on_severity }}
         fail_on_secrets: ${{ inputs.fail_on_secrets }}
 

--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -73,7 +73,7 @@ inputs:
     description: Fail the pre-push scan if the secret scanner finds anything
     required: false
     type: boolean
-    default: false
+    default: true
   vex_file:
     description: Repo-relative path to an OpenVEX document used to suppress accepted-risk findings in the pre-push scan
     required: false

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -1,8 +1,9 @@
 name: Trivy Scan
 description: >-
   Scan a target with Trivy and report the result: table to the log and the job
-  summary, SARIF to the code scanning tab, and an optional hard failure.
-  Report-only unless one of the fail_on_* inputs is set.
+  summary, SARIF to the code scanning tab, and an optional hard failure. Secrets
+  and misconfigurations gate by default; only the vulnerability severity gate
+  (fail_on_severity) is opt-in and report-only until set.
 
   Trivy names its target differently per scan type (input= for an image
   tarball, image-ref= for an image in a registry or the local daemon, scan-ref=
@@ -54,13 +55,16 @@ inputs:
     required: false
     default: ''
   fail_on_secrets:
-    description: Fail the job if the secret scanner found anything
+    description: >-
+      Fail the job if the secret scanner found anything. Defaults to true.
     required: false
-    default: 'false'
+    default: 'true'
   fail_on_misconfig:
-    description: Fail the job if the misconfiguration scanner found anything (no severity filter)
+    description: >-
+      Fail the job if the misconfiguration scanner found anything (no severity
+      filter). Defaults to true, see fail_on_secrets.
     required: false
-    default: 'false'
+    default: 'true'
 
 runs:
   using: composite

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -42,6 +42,13 @@ inputs:
     description: Upload SARIF to the code scanning (Security) tab. Requires security-events:write.
     required: false
     default: 'false'
+  vex_file:
+    description: >-
+      Repo-relative path to an OpenVEX document suppressing accepted-risk
+      findings. Only consulted when this scan gates something - a report-only
+      scan shows everything.
+    required: false
+    default: ''
   fail_on_severity:
     description: Comma-separated severities that fail the job (e.g. 'CRITICAL,HIGH'). Empty means report-only.
     required: false
@@ -60,6 +67,9 @@ runs:
   steps:
     - name: Run Trivy scan
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      env:
+        TRIVY_VEX: ${{ inputs.vex_file }}
+        TRIVY_SHOW_SUPPRESSED: ${{ inputs.vex_file != '' }}
       with:
         scan-type: ${{ startsWith(inputs.scan_type, 'image') && 'image' || inputs.scan_type }}
         input: ${{ inputs.scan_type == 'image-tar' && inputs.target || '' }}

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -5,6 +5,9 @@ description: >-
   and misconfigurations gate by default; only the vulnerability severity gate
   (fail_on_severity) is opt-in and report-only until set.
 
+  Each requested scanner runs as its own Trivy invocation writing its own report
+  file. A shared report cannot be split afterwards.
+
   Trivy names its target differently per scan type (input= for an image
   tarball, image-ref= for an image in a registry or the local daemon, scan-ref=
   for a path). scan_type selects which, so callers pass one `target` and don't
@@ -46,8 +49,7 @@ inputs:
   vex_file:
     description: >-
       Repo-relative path to an OpenVEX document suppressing accepted-risk
-      findings. Only consulted when this scan gates something - a report-only
-      scan shows everything.
+      findings. Applies to the vulnerability scan only.
     required: false
     default: ''
   fail_on_severity:
@@ -69,7 +71,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Run Trivy scan
+    - name: Scan for vulnerabilities
+      if: ${{ contains(inputs.scanners, 'vuln') }}
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       env:
         TRIVY_VEX: ${{ inputs.vex_file }}
@@ -79,21 +82,47 @@ runs:
         input: ${{ inputs.scan_type == 'image-tar' && inputs.target || '' }}
         image-ref: ${{ inputs.scan_type == 'image-ref' && inputs.target || '' }}
         scan-ref: ${{ inputs.scan_type == 'config' && inputs.target || '' }}
-        scanners: ${{ inputs.scanners }}
+        scanners: vuln
         format: json
-        output: results.json
-        # Reporting happens below; gating is a separate, explicit decision.
+        output: vuln.json
         exit-code: '0'
 
-    # Converted once, then reused for both the log and the summary.
+    - name: Scan for secrets
+      if: ${{ contains(inputs.scanners, 'secret') }}
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: ${{ startsWith(inputs.scan_type, 'image') && 'image' || inputs.scan_type }}
+        input: ${{ inputs.scan_type == 'image-tar' && inputs.target || '' }}
+        image-ref: ${{ inputs.scan_type == 'image-ref' && inputs.target || '' }}
+        scan-ref: ${{ inputs.scan_type == 'config' && inputs.target || '' }}
+        scanners: secret
+        format: json
+        output: secret.json
+        exit-code: '0'
+
+    - name: Scan for misconfigurations
+      if: ${{ contains(inputs.scanners, 'misconfig') }}
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: ${{ startsWith(inputs.scan_type, 'image') && 'image' || inputs.scan_type }}
+        input: ${{ inputs.scan_type == 'image-tar' && inputs.target || '' }}
+        image-ref: ${{ inputs.scan_type == 'image-ref' && inputs.target || '' }}
+        scan-ref: ${{ inputs.scan_type == 'config' && inputs.target || '' }}
+        scanners: misconfig
+        format: json
+        output: misconfig.json
+        exit-code: '0'
+
     - name: Report results
       shell: bash
       env:
-        SCANNERS: ${{ inputs.scanners }}
         SUMMARY_TITLE: ${{ inputs.summary_title }}
       run: |
-        trivy convert --scanners "$SCANNERS" --format table results.json > trivy-table.txt
-        cat trivy-table.txt
+        : > trivy-table.txt
+        for report in vuln secret misconfig; do
+          [ -f "$report.json" ] || continue
+          trivy convert --format table "$report.json" | tee -a trivy-table.txt
+        done
         {
           echo "### ${SUMMARY_TITLE}"
           echo '```'
@@ -104,89 +133,65 @@ runs:
     - name: Convert vulnerability results to SARIF
       if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'vuln') }}
       shell: bash
-      run: trivy convert --scanners vuln --format sarif --output vuln-results.sarif results.json
+      run: trivy convert --format sarif --output vuln.sarif vuln.json
 
     - name: Upload vulnerability report
       if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'vuln') }}
       uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
-        sarif_file: vuln-results.sarif
+        sarif_file: vuln.sarif
         category: ${{ inputs.sarif_category }}
 
     - name: Convert misconfiguration results to SARIF
       if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'misconfig') }}
       shell: bash
-      run: trivy convert --scanners misconfig --format sarif --output misconfig-results.sarif results.json
+      run: trivy convert --format sarif --output misconfig.sarif misconfig.json
 
     - name: Upload misconfiguration report
       if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'misconfig') }}
       uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
-        sarif_file: misconfig-results.sarif
+        sarif_file: misconfig.sarif
         category: ${{ inputs.sarif_category }}
 
     - name: Convert secret scan results to SARIF
       if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'secret') }}
       shell: bash
-      run: trivy convert --scanners secret --format sarif --output secret-results.sarif results.json
+      run: trivy convert --format sarif --output secret.sarif secret.json
 
     - name: Upload secret scan report
       if: ${{ inputs.upload_sarif == 'true' && contains(inputs.scanners, 'secret') }}
       uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
-        sarif_file: secret-results.sarif
+        sarif_file: secret.sarif
         category: ${{ inputs.sarif_category_secrets || format('{0}-Secrets', inputs.sarif_category) }}
 
-    - name: Gate on findings
-      if: ${{ inputs.fail_on_severity != '' || inputs.fail_on_misconfig == 'true' || inputs.fail_on_secrets == 'true' }}
+    - name: Gate - vulnerabilities
+      id: gate-vuln
+      if: ${{ inputs.fail_on_severity != '' && contains(inputs.scanners, 'vuln') }}
       shell: bash
       env:
         SEVERITY: ${{ inputs.fail_on_severity }}
-        FAIL_ON_MISCONFIG: ${{ inputs.fail_on_misconfig }}
-        FAIL_ON_SECRETS: ${{ inputs.fail_on_secrets }}
+      run: trivy convert --severity "$SEVERITY" --exit-code 1 --format table vuln.json || echo "failed=true" >> "$GITHUB_OUTPUT"
+
+    - name: Gate - secrets
+      id: gate-secret
+      if: ${{ inputs.fail_on_secrets == 'true' && contains(inputs.scanners, 'secret') }}
+      shell: bash
+      run: trivy convert --exit-code 1 --format table secret.json || echo "failed=true" >> "$GITHUB_OUTPUT"
+
+    - name: Gate - misconfigurations
+      id: gate-misconfig
+      if: ${{ inputs.fail_on_misconfig == 'true' && contains(inputs.scanners, 'misconfig') }}
+      shell: bash
+      run: trivy convert --exit-code 1 --format table misconfig.json || echo "failed=true" >> "$GITHUB_OUTPUT"
+
+    - name: Fail if any gate tripped
+      if: ${{ steps.gate-vuln.outputs.failed == 'true' || steps.gate-secret.outputs.failed == 'true' || steps.gate-misconfig.outputs.failed == 'true' }}
+      shell: bash
+      env:
         TITLE: ${{ inputs.summary_title }}
       run: |
-        # `trivy convert --scanners X` does not filter which findings count
-        # toward --exit-code - per `trivy convert --help` it is "used only for
-        # rendering the summary table". A gate built on it trips on whatever the
-        # report contains overall, not on scanner X specifically: a vuln-only
-        # report exiting a misconfig/secret gate happened in production. Query
-        # results.json directly instead, so each gate only ever sees its own
-        # finding type.
-        failures=()
-
-        if [ -n "$SEVERITY" ]; then
-          sevs_json=$(printf '%s' "$SEVERITY" | tr ',' '\n' | jq -R . | jq -sc .)
-          count=$(jq --argjson sevs "$sevs_json" '[.Results[]?.Vulnerabilities[]? | select(.Severity as $s | $sevs | index($s))] | length' results.json)
-          if [ "$count" -gt 0 ]; then
-            jq --argjson sevs "$sevs_json" -r '.Results[]?.Vulnerabilities[]? | select(.Severity as $s | $sevs | index($s)) | "  \(.VulnerabilityID)\t\(.Severity)\t\(.PkgName)"' results.json
-            echo "::error::${TITLE} - gate failed on ${SEVERITY} vulnerabilities (${count})"
-            echo "- Gate failed - ${TITLE}: ${SEVERITY} vulnerabilities (${count})" >> "$GITHUB_STEP_SUMMARY"
-            failures+=("${SEVERITY} vulnerabilities")
-          fi
-        fi
-
-        if [ "$FAIL_ON_MISCONFIG" = 'true' ]; then
-          count=$(jq '[.Results[]?.Misconfigurations[]? | select(.Status=="FAIL")] | length' results.json)
-          if [ "$count" -gt 0 ]; then
-            jq -r '.Results[]?.Misconfigurations[]? | select(.Status=="FAIL") | "  \(.ID)\t\(.Severity)\t\(.Title)"' results.json
-            echo "::error::${TITLE} - gate failed on misconfigurations (${count})"
-            echo "- Gate failed - ${TITLE}: misconfigurations (${count})" >> "$GITHUB_STEP_SUMMARY"
-            failures+=("misconfigurations")
-          fi
-        fi
-
-        if [ "$FAIL_ON_SECRETS" = 'true' ]; then
-          count=$(jq '[.Results[]?.Secrets[]?] | length' results.json)
-          if [ "$count" -gt 0 ]; then
-            jq -r '.Results[]?.Secrets[]? | "  \(.RuleID)\t\(.Title)"' results.json
-            echo "::error::${TITLE} - gate failed on detected secrets (${count})"
-            echo "- Gate failed - ${TITLE}: detected secrets (${count})" >> "$GITHUB_STEP_SUMMARY"
-            failures+=("detected secrets")
-          fi
-        fi
-
-        if [ ${#failures[@]} -gt 0 ]; then
-          echo "Gates failed: ${failures[*]}"
-          exit 1
-        fi
+        echo "::error::${TITLE} - a Trivy gate failed; see the Gate steps above"
+        echo "- Gate failed - ${TITLE}" >> "$GITHUB_STEP_SUMMARY"
+        exit 1

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -146,30 +146,44 @@ runs:
         FAIL_ON_SECRETS: ${{ inputs.fail_on_secrets }}
         TITLE: ${{ inputs.summary_title }}
       run: |
+        # `trivy convert --scanners X` does not filter which findings count
+        # toward --exit-code - per `trivy convert --help` it is "used only for
+        # rendering the summary table". A gate built on it trips on whatever the
+        # report contains overall, not on scanner X specifically: a vuln-only
+        # report exiting a misconfig/secret gate happened in production. Query
+        # results.json directly instead, so each gate only ever sees its own
+        # finding type.
         failures=()
 
-        # Prints the findings only when a check trips; the full,
-        # unfiltered table is already in the log and the job summary.
-        gate() {
-          local scanner="$1" label="$2"
-          shift 2
-          if trivy convert --scanners "$scanner" "$@" --exit-code 1 --format table results.json > gate.txt; then
-            return
-          fi
-          cat gate.txt
-          echo "::error::${TITLE} - gate failed on ${label}"
-          echo "- Gate failed - ${TITLE}: ${label}" >> "$GITHUB_STEP_SUMMARY"
-          failures+=("$label")
-        }
-
         if [ -n "$SEVERITY" ]; then
-          gate vuln "${SEVERITY} vulnerabilities" --severity "$SEVERITY"
+          sevs_json=$(printf '%s' "$SEVERITY" | tr ',' '\n' | jq -R . | jq -sc .)
+          count=$(jq --argjson sevs "$sevs_json" '[.Results[]?.Vulnerabilities[]? | select(.Severity as $s | $sevs | index($s))] | length' results.json)
+          if [ "$count" -gt 0 ]; then
+            jq --argjson sevs "$sevs_json" -r '.Results[]?.Vulnerabilities[]? | select(.Severity as $s | $sevs | index($s)) | "  \(.VulnerabilityID)\t\(.Severity)\t\(.PkgName)"' results.json
+            echo "::error::${TITLE} - gate failed on ${SEVERITY} vulnerabilities (${count})"
+            echo "- Gate failed - ${TITLE}: ${SEVERITY} vulnerabilities (${count})" >> "$GITHUB_STEP_SUMMARY"
+            failures+=("${SEVERITY} vulnerabilities")
+          fi
         fi
+
         if [ "$FAIL_ON_MISCONFIG" = 'true' ]; then
-          gate misconfig misconfigurations
+          count=$(jq '[.Results[]?.Misconfigurations[]? | select(.Status=="FAIL")] | length' results.json)
+          if [ "$count" -gt 0 ]; then
+            jq -r '.Results[]?.Misconfigurations[]? | select(.Status=="FAIL") | "  \(.ID)\t\(.Severity)\t\(.Title)"' results.json
+            echo "::error::${TITLE} - gate failed on misconfigurations (${count})"
+            echo "- Gate failed - ${TITLE}: misconfigurations (${count})" >> "$GITHUB_STEP_SUMMARY"
+            failures+=("misconfigurations")
+          fi
         fi
+
         if [ "$FAIL_ON_SECRETS" = 'true' ]; then
-          gate secret "detected secrets"
+          count=$(jq '[.Results[]?.Secrets[]?] | length' results.json)
+          if [ "$count" -gt 0 ]; then
+            jq -r '.Results[]?.Secrets[]? | "  \(.RuleID)\t\(.Title)"' results.json
+            echo "::error::${TITLE} - gate failed on detected secrets (${count})"
+            echo "- Gate failed - ${TITLE}: detected secrets (${count})" >> "$GITHUB_STEP_SUMMARY"
+            failures+=("detected secrets")
+          fi
         fi
 
         if [ ${#failures[@]} -gt 0 ]; then

--- a/.github/workflows/_reusable_build_docker_images.yml
+++ b/.github/workflows/_reusable_build_docker_images.yml
@@ -53,10 +53,6 @@ on:
         description: Comma-separated severities that fail the pre-push scan (e.g. 'CRITICAL,HIGH'). Empty means report-only.
         type: string
         default: ''
-      fail_on_secrets:
-        description: Fail the pre-push scan if the secret scanner finds anything
-        type: boolean
-        default: false
       vex_file:
         description: Repo-relative path to an OpenVEX document used to suppress accepted-risk findings in the pre-push scan
         type: string
@@ -150,7 +146,6 @@ jobs:
           output_type: ${{ inputs.push_by_digest && 'push-by-digest=true,type=image' || '' }}
           scan_before_push: ${{ inputs.scan_before_push }}
           fail_on_severity: ${{ inputs.fail_on_severity }}
-          fail_on_secrets: ${{ inputs.fail_on_secrets }}
           vex_file: ${{ inputs.vex_file }}
           upload_sarif: ${{ inputs.upload_sarif }}
 

--- a/.github/workflows/_reusable_build_docker_images.yml
+++ b/.github/workflows/_reusable_build_docker_images.yml
@@ -57,6 +57,10 @@ on:
         description: Fail the pre-push scan if the secret scanner finds anything
         type: boolean
         default: false
+      vex_file:
+        description: Repo-relative path to an OpenVEX document used to suppress accepted-risk findings in the pre-push scan
+        type: string
+        default: ''
       upload_sarif:
         description: Upload the pre-push scan's SARIF results to the code scanning (Security) tab. Requires the caller job to grant security-events:write.
         type: boolean
@@ -147,6 +151,7 @@ jobs:
           scan_before_push: ${{ inputs.scan_before_push }}
           fail_on_severity: ${{ inputs.fail_on_severity }}
           fail_on_secrets: ${{ inputs.fail_on_secrets }}
+          vex_file: ${{ inputs.vex_file }}
           upload_sarif: ${{ inputs.upload_sarif }}
 
       - name: Upload image artifact

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -38,7 +38,9 @@ jobs:
             echo "is_draft=false" >> $GITHUB_OUTPUT
             BUILD_ARM64=true
           fi
-          # Release-prep branches (releases/vX.Y.Z) hard-gate on CVEs/secrets, arm64 included.
+          # Release-prep branches (releases/vX.Y.Z) hard-gate on vulnerability
+          # severity, arm64 included. Secrets and Dockerfile misconfigurations
+          # always gate, regardless of this flag.
           if [[ "$HEAD_REF" == releases/* || "$REF_NAME" == releases/* ]]; then
             echo "gate=true" >> $GITHUB_OUTPUT
             BUILD_ARM64=true
@@ -52,7 +54,7 @@ jobs:
           echo "Test Slim Image Name: ${{ env.TEST_SLIM_IMAGE_NAME }}"
           echo " Is Draft: ${{ steps.check-draft.outputs.is_draft }}"
           echo " Build ARM64: ${{ steps.check-draft.outputs.build_arm64 }}"
-          echo " Gate (hard-fail on CVEs/secrets): ${{ steps.check-draft.outputs.gate }}"
+          echo " Gate (hard-fail on vulnerability severity): ${{ steps.check-draft.outputs.gate }}"
 
   trivy_dockerfile_scan:
     name: Trivy scan Dockerfile
@@ -75,7 +77,6 @@ jobs:
           summary_title: Trivy scan — Dockerfile misconfig
           sarif_category: Trivy-Dockerfile-Misconfig
           upload_sarif: ${{ github.event_name != 'pull_request' }}
-          fail_on_misconfig: ${{ needs.prepare_environment.outputs.gate == 'true' }}
 
   build_docker_images:
     permissions:
@@ -94,7 +95,6 @@ jobs:
       # Scans the tarball this build already writes for the test jobs.
       scan_before_push: true
       fail_on_severity: ''
-      fail_on_secrets: ${{ needs.prepare_environment.outputs.gate == 'true' }}
       upload_sarif: ${{ github.event_name != 'pull_request' }}
       vex_file: openvex.json
 
@@ -114,7 +114,6 @@ jobs:
       upload_image_as_artifact: true
       scan_before_push: true
       fail_on_severity: ${{ needs.prepare_environment.outputs.gate == 'true' && 'CRITICAL,HIGH' || '' }}
-      fail_on_secrets: ${{ needs.prepare_environment.outputs.gate == 'true' }}
       upload_sarif: ${{ github.event_name != 'pull_request' }}
       vex_file: openvex.json
 

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [ opened, synchronize, ready_for_review ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "releases/**" ]
   workflow_dispatch:
 
 env:
@@ -23,23 +23,36 @@ jobs:
       test_slim_image_name: ${{ env.TEST_SLIM_IMAGE_NAME }}
       is_draft: ${{ steps.check-draft.outputs.is_draft }}
       build_arm64: ${{ steps.check-draft.outputs.build_arm64 }}
+      gate: ${{ steps.check-draft.outputs.gate }}
     steps:
-      - name: Check if draft PR
+      - name: Check if draft PR / release-prep branch
         id: check-draft
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${{ github.event_name }}" = "pull_request" && "${{ github.event.pull_request.draft }}" = "true" ]]; then
             echo "is_draft=true" >> $GITHUB_OUTPUT
-            echo "build_arm64=false" >> $GITHUB_OUTPUT
+            BUILD_ARM64=false
           else
             echo "is_draft=false" >> $GITHUB_OUTPUT
-            echo "build_arm64=true" >> $GITHUB_OUTPUT
+            BUILD_ARM64=true
           fi
+          # Release-prep branches (releases/vX.Y.Z) hard-gate on CVEs/secrets, arm64 included.
+          if [[ "$HEAD_REF" == releases/* || "$REF_NAME" == releases/* ]]; then
+            echo "gate=true" >> $GITHUB_OUTPUT
+            BUILD_ARM64=true
+          else
+            echo "gate=false" >> $GITHUB_OUTPUT
+          fi
+          echo "build_arm64=$BUILD_ARM64" >> $GITHUB_OUTPUT
       - run: |
           echo "Publish environment variables"
           echo "Test Image Name: ${{ env.TEST_IMAGE_NAME }}"
           echo "Test Slim Image Name: ${{ env.TEST_SLIM_IMAGE_NAME }}"
           echo " Is Draft: ${{ steps.check-draft.outputs.is_draft }}"
           echo " Build ARM64: ${{ steps.check-draft.outputs.build_arm64 }}"
+          echo " Gate (hard-fail on CVEs/secrets): ${{ steps.check-draft.outputs.gate }}"
 
   trivy_dockerfile_scan:
     name: Trivy scan Dockerfile
@@ -62,6 +75,7 @@ jobs:
           summary_title: Trivy scan — Dockerfile misconfig
           sarif_category: Trivy-Dockerfile-Misconfig
           upload_sarif: ${{ github.event_name != 'pull_request' }}
+          fail_on_misconfig: ${{ needs.prepare_environment.outputs.gate == 'true' }}
 
   build_docker_images:
     permissions:
@@ -80,8 +94,9 @@ jobs:
       # Scans the tarball this build already writes for the test jobs.
       scan_before_push: true
       fail_on_severity: ''
-      fail_on_secrets: false
+      fail_on_secrets: ${{ needs.prepare_environment.outputs.gate == 'true' }}
       upload_sarif: ${{ github.event_name != 'pull_request' }}
+      vex_file: openvex.json
 
   build_slim_images:
     permissions:
@@ -98,9 +113,10 @@ jobs:
       build_arm64: ${{ fromJSON(needs.prepare_environment.outputs.build_arm64) }}
       upload_image_as_artifact: true
       scan_before_push: true
-      fail_on_severity: ''
-      fail_on_secrets: false
+      fail_on_severity: ${{ needs.prepare_environment.outputs.gate == 'true' && 'CRITICAL,HIGH' || '' }}
+      fail_on_secrets: ${{ needs.prepare_environment.outputs.gate == 'true' }}
       upload_sarif: ${{ github.event_name != 'pull_request' }}
+      vex_file: openvex.json
 
   docker_image_tests:
     permissions:

--- a/.github/workflows/docker-nightly-image.yml
+++ b/.github/workflows/docker-nightly-image.yml
@@ -89,6 +89,7 @@ jobs:
       scan_before_push: true
       fail_on_severity: '' # nightly is report-only, never gates
       fail_on_secrets: false
+      vex_file: openvex.json
       upload_sarif: true
     secrets:
       registry_username: ${{ secrets.DOCKER_USERNAME }}
@@ -115,6 +116,7 @@ jobs:
       scan_before_push: true
       fail_on_severity: '' # nightly is report-only, never gates
       fail_on_secrets: false
+      vex_file: openvex.json
       upload_sarif: true
     secrets:
       registry_username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-nightly-image.yml
+++ b/.github/workflows/docker-nightly-image.yml
@@ -87,8 +87,7 @@ jobs:
       docker_tag: openrouteservice/openrouteservice # push by digest needs no tag suffix
       branch: ${{ inputs.branch }}
       scan_before_push: true
-      fail_on_severity: '' # nightly is report-only, never gates
-      fail_on_secrets: false
+      fail_on_severity: '' # nightly is report-only on vulnerability severity, never gates
       vex_file: openvex.json
       upload_sarif: true
     secrets:
@@ -114,8 +113,7 @@ jobs:
       docker_tag: openrouteservice/openrouteservice # push by digest needs no tag suffix
       branch: ${{ inputs.branch }}
       scan_before_push: true
-      fail_on_severity: '' # nightly is report-only, never gates
-      fail_on_secrets: false
+      fail_on_severity: '' # nightly is report-only on vulnerability severity, never gates
       vex_file: openvex.json
       upload_sarif: true
     secrets:

--- a/.github/workflows/publish-tagged-release.yml
+++ b/.github/workflows/publish-tagged-release.yml
@@ -1,12 +1,66 @@
 name: Build and publish the newest version and latest Docker image
 on:
   release:
-    types: [published]
+    types: [created, published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to dry-run the release scan against (never publishes anything)'
+        required: true
 
 permissions: {}
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Dry run: fires as soon as a draft release is saved (release: created), or
+  # manually. Builds both stages/arches, hard-gates on the same Trivy checks as
+  # the real release, and pushes nothing anywhere.
+  # ---------------------------------------------------------------------------
+  dry_run_scan_publish_images:
+    if: github.event.action == 'created' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    name: "[Dry run] Build and scan publish images"
+    uses: ./.github/workflows/_reusable_build_docker_images.yml
+    with:
+      upload_image_as_artifact: false
+      build_amd64: true
+      build_arm64: true
+      image_stage: 'publish'
+      docker_tag: local/openrouteservice:release-dry-run
+      dockerfile_path: 'Dockerfile'
+      branch: ${{ github.event.release.tag_name || inputs.tag }}
+      scan_before_push: true
+      fail_on_severity: ''
+      fail_on_secrets: true
+      vex_file: openvex.json
+
+  dry_run_scan_slim_images:
+    if: github.event.action == 'created' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    name: "[Dry run] Build and scan slim images"
+    uses: ./.github/workflows/_reusable_build_docker_images.yml
+    with:
+      upload_image_as_artifact: false
+      build_amd64: true
+      build_arm64: true
+      image_stage: 'slim'
+      docker_tag: local/openrouteservice:release-dry-run-slim
+      dockerfile_path: 'Dockerfile'
+      branch: ${{ github.event.release.tag_name || inputs.tag }}
+      scan_before_push: true
+      fail_on_severity: 'CRITICAL,HIGH'
+      fail_on_secrets: true
+      vex_file: openvex.json
+
+  # ---------------------------------------------------------------------------
+  # Real release: fires when the release is actually published. Every job below
+  # scans before it pushes anywhere external - a failure means no per-arch
+  # digest reaches Docker Hub, so combine_and_push_images has nothing to tag.
+  # ---------------------------------------------------------------------------
   check_version:
+    if: github.event.action == 'published'
     permissions:
       contents: read
     name: Check if this is the latest semantic version
@@ -28,9 +82,10 @@ jobs:
           current-tag: ${{ github.event.release.tag_name }}
 
   build_and_push_publish_images:
+    if: github.event.action == 'published'
     permissions:
       contents: read
-    name: Build and cache the Docker images with native runners
+    name: Build, scan and push the Docker images with native runners
     needs: check_version
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     with:
@@ -43,14 +98,19 @@ jobs:
       docker_tag: 'openrouteservice/openrouteservice' # push_by_digest doesn't need a tag suffix
       dockerfile_path: 'Dockerfile'
       branch: ${{ github.event.release.tag_name }}
+      scan_before_push: true
+      fail_on_severity: ''
+      fail_on_secrets: true
+      vex_file: openvex.json
     secrets:
       registry_username: ${{ secrets.DOCKER_USERNAME }}
       registry_password: ${{ secrets.DOCKER_PASSWORD }}
-  
+
   build_and_push_slim_images:
+    if: github.event.action == 'published'
     permissions:
       contents: read
-    name: Build and cache the slim Docker images with native runners
+    name: Build, scan and push the slim Docker images with native runners
     needs: check_version
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     with:
@@ -63,16 +123,20 @@ jobs:
       docker_tag: 'openrouteservice/openrouteservice' # push_by_digest doesn't need a tag suffix
       dockerfile_path: 'Dockerfile'
       branch: ${{ github.event.release.tag_name }}
+      scan_before_push: true
+      fail_on_severity: 'CRITICAL,HIGH'
+      fail_on_secrets: true
+      vex_file: openvex.json
     secrets:
       registry_username: ${{ secrets.DOCKER_USERNAME }}
       registry_password: ${{ secrets.DOCKER_PASSWORD }}
-  
+
   combine_and_push_images:
     permissions:
       contents: read
     name: Combine multi-arch manifest and push to DockerHub
     runs-on: ubuntu-latest
-    if: success()
+    if: github.event.action == 'published' && success()
     needs:
       - check_version
       - build_and_push_publish_images
@@ -140,7 +204,7 @@ jobs:
             echo "ARM64: $DIGEST_ARM64"
             exit 1
           fi
-          
+
           echo "Create and push manifest list for ${{ matrix.image_stage }} - ${{ matrix.image_tag }}"
           docker buildx imagetools create \
             -t "$IMAGE_REPO" \
@@ -164,7 +228,7 @@ jobs:
       - combine_and_push_images
     permissions:
       contents: write
-    if: fromJSON(needs.check_version.outputs.is-latest)
+    if: github.event.action == 'published' && fromJSON(needs.check_version.outputs.is-latest)
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -178,8 +242,9 @@ jobs:
 
   build_and_publish_release_artifacts:
     runs-on: ubuntu-latest
+    if: github.event.action == 'published'
     needs: [check_version, combine_and_push_images]
-    permissions: 
+    permissions:
       contents: write
     steps:
       - name: Checkout

--- a/.github/workflows/publish-tagged-release.yml
+++ b/.github/workflows/publish-tagged-release.yml
@@ -32,7 +32,6 @@ jobs:
       branch: ${{ github.event.release.tag_name || inputs.tag }}
       scan_before_push: true
       fail_on_severity: ''
-      fail_on_secrets: true
       vex_file: openvex.json
 
   dry_run_scan_slim_images:
@@ -51,7 +50,6 @@ jobs:
       branch: ${{ github.event.release.tag_name || inputs.tag }}
       scan_before_push: true
       fail_on_severity: 'CRITICAL,HIGH'
-      fail_on_secrets: true
       vex_file: openvex.json
 
   # ---------------------------------------------------------------------------
@@ -100,7 +98,6 @@ jobs:
       branch: ${{ github.event.release.tag_name }}
       scan_before_push: true
       fail_on_severity: ''
-      fail_on_secrets: true
       vex_file: openvex.json
     secrets:
       registry_username: ${{ secrets.DOCKER_USERNAME }}
@@ -125,7 +122,6 @@ jobs:
       branch: ${{ github.event.release.tag_name }}
       scan_before_push: true
       fail_on_severity: 'CRITICAL,HIGH'
-      fail_on_secrets: true
       vex_file: openvex.json
     secrets:
       registry_username: ${{ secrets.DOCKER_USERNAME }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,3 +57,27 @@
 7. Update version in POMs to X.Y.Z-SNAPSHOT using
    ./mvnw versions:set -DnewVersion=X.Y.Z-SNAPSHOT
 8. Check whether outreach, announcement, … is necessary and do so.
+
+## If a release fails its vulnerability gate
+
+If a finding has no upstream fix yet (or is a false positive / not reachable in our build), record
+it as an accepted risk in `openvex.json` at the repo root instead of ignoring the
+whole gate:
+
+1. Generate a CycloneDX SBOM of the image and copy the exact `purl` for the affected component -
+   a near-miss purl silently suppresses nothing:
+   ```
+   trivy image --format cyclonedx local/openrouteservice:test-slim | jq '.components[] | select(.name=="<lib>")'
+   ```
+2. Add one statement per `(CVE, subcomponent)` pair.
+3. `status: "not_affected"` requires a `justification` from Trivy's/OpenVEX's fixed enum (e.g.
+   `vulnerable_code_not_in_execute_path`, `vulnerable_code_not_present`). Add an `impact_statement`
+   explaining why.
+4. Set `timestamp` to the review date. VEX has no expiry of its own, so nothing forces a suppression to lapse.
+
+Verify a statement actually suppresses the finding before relying on it, with `--show-suppressed`:
+```
+trivy image --scanners vuln,secret --vex openvex.json --show-suppressed \
+  local/openrouteservice:test-slim
+```
+The finding should appear under "Suppressed Vulnerabilities" with your statement's justification.

--- a/openvex.json
+++ b/openvex.json
@@ -1,0 +1,8 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/GIScience/openrouteservice/blob/main/openvex.json",
+  "author": "HeiGIT openrouteservice maintainers",
+  "timestamp": "2026-09-01T00:00:00Z",
+  "version": 1,
+  "statements": []
+}


### PR DESCRIPTION
CVEs only gated at releases.
Dockerfile misconfiguration and secrets scan always gated.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
