### PR TITLE
ci: checkov iac scanning

### DIFF
--- a/.github/workflows/_reusable_build_docker_images.yml
+++ b/.github/workflows/_reusable_build_docker_images.yml
@@ -88,6 +88,10 @@ on:
         description: Digest of the pushed image for linux/arm64 (when push_by_digest is true)
         value: ${{ jobs.build_docker_image.outputs.image_digest_arm64 || '' }}
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
 
   build_docker_image:

--- a/.github/workflows/docker-nightly-image.yml
+++ b/.github/workflows/docker-nightly-image.yml
@@ -4,6 +4,7 @@ run-name: Build ${{ inputs.branch }} - ${{ inputs.user }}
 on:
   schedule:
     - cron: '15 1 * * *'
+  # checkov:skip=CKV_GHA_7: not relevant for this workflow, which only builds and publishes images. The inputs are only used to determine whether the workflow runs and what tag to build.
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/iac-scanning.yml
+++ b/.github/workflows/iac-scanning.yml
@@ -1,0 +1,77 @@
+name: IaC scanning
+
+# Checkov over the whole repository. Checkov scans infrastructure as code (IaC) files for misconfigurations.
+#
+# The gate is hard on every trigger, pull requests included: any finding fails
+# the job. Findings that are accepted rather than fixed are documented in the
+# source with `# checkov:skip=<ID>:<reason>` comments.
+
+on:
+  pull_request:
+    types: [ opened, synchronize, ready_for_review ]
+  push:
+    branches: [ "main", "releases/**" ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  checkov_scan:
+    name: Checkov IaC scan
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Run Checkov
+        uses: bridgecrewio/checkov-action@f967808197a8d784d3e72919f38c3ff0cda7884e # v12.3122.0
+        with:
+          directory: .
+          quiet: true
+          compact: true
+          soft_fail: true
+          skip_path: node_modules,target
+          output_format: cli,sarif,json
+          output_file_path: console,results.sarif,results.json
+
+      - name: Report results
+        if: ${{ always() && hashFiles('results.json') != '' }}
+        run: |
+          {
+            echo "### Checkov IaC scan"
+            echo
+            echo "| Framework | Passed | Failed | Skipped |"
+            echo "|---|---:|---:|---:|"
+            jq -r 'if type == "array" then .[] else . end
+                   | "| \(.check_type) | \(.summary.passed) | \(.summary.failed) | \(.summary.skipped) |"' results.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Checkov report
+        # Pull requests from forks cannot write to the Security tab.
+        if: ${{ github.event_name != 'pull_request' && hashFiles('results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          sarif_file: results.sarif
+          category: Checkov-IaC
+
+      - name: Gate - misconfigurations
+        run: |
+          if [ ! -f results.json ]; then
+            echo "::error::Checkov produced no report; treating that as a failure rather than a pass"
+            exit 1
+          fi
+          failed=$(jq -r '[ (if type == "array" then .[] else . end) | .summary.failed ] | add' results.json)
+          if [ "$failed" -eq 0 ]; then
+            echo "Checkov found no unhandled misconfigurations."
+            exit 0
+          fi
+          jq -r '(if type == "array" then .[] else . end)
+                 | .results.failed_checks[]
+                 | "- \(.check_id) \(.file_path):\(.file_line_range[0]) - \(.check_name)"' results.json \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "::error::Checkov found ${failed} unhandled misconfiguration(s); fix them, or add a documented '# checkov:skip=<ID>:<reason>' comment if the risk is accepted"
+          exit 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,6 +38,7 @@ jobs:
   build_test_scenario_base_image:
     permissions:
       contents: read
+      security-events: write
     name: Build test scenario builder images
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     with:
@@ -52,6 +53,7 @@ jobs:
   build_test_scenario_jar_builder_image:
     permissions:
       contents: read
+      security-events: write
     name: Build test scenario jar builder image
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     needs:

--- a/.github/workflows/publish-tagged-release.yml
+++ b/.github/workflows/publish-tagged-release.yml
@@ -2,6 +2,7 @@ name: Build and publish the newest version and latest Docker image
 on:
   release:
     types: [created, published]
+  # checkov:skip=CKV_GHA_7: not important for this workflow, which only builds and publishes images. The inputs are only used to determine whether the workflow runs and what tag to build.
   workflow_dispatch:
     inputs:
       tag:
@@ -20,6 +21,7 @@ jobs:
     if: github.event.action == 'created' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
+      security-events: write
     name: "[Dry run] Build and scan publish images"
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     with:
@@ -38,6 +40,7 @@ jobs:
     if: github.event.action == 'created' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
+      security-events: write
     name: "[Dry run] Build and scan slim images"
     uses: ./.github/workflows/_reusable_build_docker_images.yml
     with:
@@ -83,6 +86,7 @@ jobs:
     if: github.event.action == 'published'
     permissions:
       contents: read
+      security-events: write
     name: Build, scan and push the Docker images with native runners
     needs: check_version
     uses: ./.github/workflows/_reusable_build_docker_images.yml
@@ -107,6 +111,7 @@ jobs:
     if: github.event.action == 'published'
     permissions:
       contents: read
+      security-events: write
     name: Build, scan and push the slim Docker images with native runners
     needs: check_version
     uses: ./.github/workflows/_reusable_build_docker_images.yml

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,3 +81,18 @@ trivy image --scanners vuln,secret --vex openvex.json --show-suppressed \
   local/openrouteservice:test-slim
 ```
 The finding should appear under "Suppressed Vulnerabilities" with your statement's justification.
+
+## If the IaC scan fails
+
+The `IaC scanning` workflow runs Checkov over the whole repository.
+
+Reproduce a CI finding locally:
+```
+uvx --from checkov checkov -d . --compact --quiet --skip-path node_modules --skip-path target
+```
+
+Fix it if it is fixable. If the risk is accepted, record it in the source rather than loosening the
+gate, by putting a comment next to the flagged resource:
+```
+# checkov:skip=CKV_DOCKER_3: the Maven build needs root inside the builder; the image is never run as a service
+```

--- a/ors-test-scenarios/src/test/resources/Builder.Dockerfile
+++ b/ors-test-scenarios/src/test/resources/Builder.Dockerfile
@@ -4,6 +4,12 @@
 # Keeping them separate makes it impossible for testcontainers to change the build context for the builder images.
 # Look into the documentation under docs/technical-details/integration-tests.md for more information.
 
+# These are throwaway build images for the integration-test suite. They are built
+# on the runner, consumed by testcontainers and never pushed anywhere, so the
+# runtime-hardening checks that apply to the published image do not apply here.
+# checkov:skip=CKV_DOCKER_3: the Maven build needs root inside the builder; the image is never run as a service
+# checkov:skip=CKV_DOCKER_2: a builder has no service to health-check
+
 ARG CONTAINER_BUILD_DIR=/build
 ARG CONTAINER_WORK_DIR=/home/ors/openrouteservice
 

--- a/ors-test-scenarios/src/test/resources/jar.Dockerfile
+++ b/ors-test-scenarios/src/test/resources/jar.Dockerfile
@@ -1,4 +1,9 @@
 # Look into the documentation under docs/technical-details/integration-tests.md for more information.
+
+# Throwaway integration-test image, built on the runner and never pushed.
+# checkov:skip=CKV_DOCKER_7: the base is ors-test-scenarios-jar-builder, built locally by Builder.Dockerfile - there is no registry digest to pin
+# checkov:skip=CKV_DOCKER_3: runs the ORS test instance as root inside a disposable container
+
 ARG CONTAINER_BUILD_DIR=/build
 ARG CONTAINER_WORK_DIR=/home/ors/openrouteservice
 

--- a/ors-test-scenarios/src/test/resources/maven.Dockerfile
+++ b/ors-test-scenarios/src/test/resources/maven.Dockerfile
@@ -1,4 +1,9 @@
 # Look into the documentation under docs/technical-details/integration-tests.md for more information.
+
+# Throwaway integration-test image, built on the runner and never pushed.
+# checkov:skip=CKV_DOCKER_7: the base is ors-test-scenarios-maven-builder, built locally by Builder.Dockerfile - there is no registry digest to pin
+# checkov:skip=CKV_DOCKER_3: runs the ORS test instance as root inside a disposable container
+
 ARG CONTAINER_BUILD_DIR=/build
 ARG CONTAINER_WORK_DIR=/home/ors/openrouteservice
 


### PR DESCRIPTION
Add checkov infrastructure as code (IaC) scan to our CI. It mainly scans the github workflows and Dockerfiles for issues.
It is a hard fail. So if any PR introduces regressions, it needs to be fixed directly.

### Pull Request Checklist
<!--- Please make sure you have completed the following items BEFORE submitting a pull request (put an x in each box
when you have checked you have done them): -->
- [ ] 1. I have [**rebased**][rebase] the latest version of the main branch into my feature branch and all conflicts
         have been resolved.
- [ ] 2. I have added information about the change/addition to functionality to the CHANGELOG.md file under the
         [Unreleased] heading.
- [ ] 3. I have documented my code using JDocs tags.
- [ ] 4. I have removed unnecessary commented out code, imports and System.out.println statements.
- [ ] 5. I have written JUnit tests for any new methods/classes and ensured that they pass.
- [ ] 6. I have created API tests for any new functionality exposed to the API.
- [ ] 7. If changes/additions are made to the ors-config.json file, I have added these to the [ors config documentation][config]
         along with a short description of what it is for, and documented this in the Pull Request (below).
- [ ] 8. I have built graphs with my code of the Heidelberg.osm.gz file and run the api-tests with all test passing
- [ ] 9. I have referenced the Issue Number in the Pull Request (if the changes were from an issue).
- [ ] 10. For new features or changes involving building of graphs, I have tested on a larger dataset
          (at least Germany), and the graphs build without problems (i.e. no out-of-memory errors).
- [ ] 11. For new features or changes involving the graphbuilding process (i.e. changing encoders, updating the
          importer etc.), I have generated longer distance routes for the affected profiles with different options
          (avoid features, max weight etc.) and compared these with the routes of the same parameters and start/end
          points generated from the current live ORS.
          If there are differences then the reasoning for these **MUST** be documented in the pull request.
- [ ] 12. I have written in the Pull Request information about the changes made including their intended usage
          and why the change was needed.
- [ ] 13. For changes touching the API documentation, I have tested that the API playground [renders correctly][api].

Fixes # .

### Information about the changes
- Key functionality added:
- Reason for change:

### Examples and reasons for differences between live ORS routes, and those generated from this pull request
-

### Required changes to ors config (if applicable)
-

[config]: https://GIScience.github.io/openrouteservice/run-instance/configuration/
[api]: https://gitlab.gistools.geog.uni-heidelberg.de/giscience/openrouteservice-infrastructure/ors-docs-api#test-new-ors-documentation
[rebase]: https://github.com/GIScience/openrouteservice/blob/main/CONTRIBUTE.md#pull-request-guidelines
